### PR TITLE
Add Sources with GitHub App authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,4 +79,21 @@ AWS_ENDPOINT=
 AWS_URL=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
+# Registers this registry with GitHub, which is what lets an admin connect an
+# organisation from the admin panel in a click. Both values come off the app's
+# settings page when it is created; see docs/github-app.md.
+# GITHUB_APP_PRIVATE_KEY takes either a path to the generated .pem or the key
+# itself with its newlines escaped as "\n".
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+
+# Read from GitHub automatically. Set only to skip that lookup, or if the app
+# is renamed. GITHUB_APP_API_URL only changes on GitHub Enterprise.
+# GITHUB_APP_SLUG=
+# GITHUB_APP_API_URL=https://api.github.com
+
+# Last-resort token, used only for packages with neither a connected source nor
+# a token of their own. Leave empty once sources are set up.
+GITHUB_TOKEN=
+
 VITE_APP_NAME="${APP_NAME}"

--- a/app/Console/Commands/SyncPackages.php
+++ b/app/Console/Commands/SyncPackages.php
@@ -11,13 +11,15 @@ use Throwable;
 class SyncPackages extends Command
 {
     protected $signature = 'packages:sync
-        {name? : Only sync the package with this composer name or "owner/repo" path}';
+        {name? : Only sync the package with this composer name or "owner/repo" path}
+        {--source= : Only sync packages connected through this source, by name or account}';
 
     protected $description = 'Sync package versions from their GitHub repositories';
 
     public function handle(PackageSynchronizer $synchronizer): int
     {
         $name = $this->argument('name');
+        $source = $this->option('source');
 
         // The stored name only becomes the composer name once a package has
         // synced, so an unsynced package is still addressable by its
@@ -28,6 +30,10 @@ class SyncPackages extends Command
                 fn ($query) => $query
                     ->where('name', $name)
                     ->orWhere('repository', 'like', '%'.$name.'%')
+            ))
+            ->when($source, fn ($query, string $source) => $query->whereHas(
+                'source',
+                fn ($query) => $query->where('name', $source)->orWhere('account', $source),
             ))
             ->get()
             ->filter(fn (Package $package): bool => $name === null

--- a/app/Enums/SourceProvider.php
+++ b/app/Enums/SourceProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * The version control providers a Source can connect to.
+ *
+ * Only GitHub is implemented; the enum exists so that the rest of the app is
+ * written against a provider rather than assuming GitHub everywhere.
+ */
+enum SourceProvider: string implements HasLabel
+{
+    case Github = 'github';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Github => 'GitHub',
+        };
+    }
+
+    /**
+     * The API root used when a source does not override it with a base_url,
+     * which self-hosted installations (GitHub Enterprise) need to do.
+     */
+    public function defaultApiUrl(): string
+    {
+        return match ($this) {
+            self::Github => 'https://api.github.com',
+        };
+    }
+
+    /**
+     * The host that owns a repository on this provider, used to match a
+     * package's repository URL back to a source.
+     */
+    public function host(): string
+    {
+        return match ($this) {
+            self::Github => 'github.com',
+        };
+    }
+}

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Resources\Packages\Schemas;
 
 use App\Models\Package;
+use App\Models\Source;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
@@ -26,6 +28,12 @@ class PackageForm
                     ->maxLength(255)
                     ->unique(ignoreRecord: true)
                     ->placeholder('https://github.com/vendor/package'),
+                Select::make('source_id')
+                    ->label('Source')
+                    ->options(fn (): array => Source::options())
+                    ->searchable()
+                    ->placeholder('Match automatically from the repository URL')
+                    ->helperText('The connected account this package authenticates through. Left empty, a source owning the repository URL is attached on save.'),
                 TextInput::make('token')
                     ->label('GitHub token')
                     ->password()
@@ -36,7 +44,7 @@ class PackageForm
                     ->afterStateHydrated(fn (TextInput $component) => $component->state(null))
                     ->dehydrated(fn (?string $state): bool => filled($state))
                     ->placeholder(fn (?Package $record): string => $record?->token ? 'Token saved — enter a new one to replace it' : 'ghp_...')
-                    ->helperText('Personal access token with read access to the repository. Falls back to GITHUB_TOKEN when empty.'),
+                    ->helperText('Only used for repositories no source covers — a connected source takes precedence over this. Falls back to GITHUB_TOKEN when both are empty.'),
                 TextInput::make('latest_version')
                     ->maxLength(255)
                     ->placeholder('v1.0.0')

--- a/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Packages\Schemas;
 
+use App\Filament\Resources\Sources\SourceResource;
 use App\Models\Package;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Schema;
@@ -25,13 +26,23 @@ class PackageInfolist
                 TextEntry::make('type')
                     ->badge()
                     ->placeholder('-'),
+                TextEntry::make('source.name')
+                    ->label('Source')
+                    ->badge()
+                    ->color(fn (Package $record): string => $record->source?->isConnected() ? 'success' : 'warning')
+                    ->url(fn (Package $record): ?string => $record->source
+                        ? SourceResource::getUrl('view', ['record' => $record->source])
+                        : null)
+                    ->placeholder('No source — using this package\'s own credentials'),
                 TextEntry::make('token')
                     ->label('GitHub token')
                     // Never render the secret itself.
                     ->formatStateUsing(fn (): string => 'Saved')
                     ->badge()
                     ->color('success')
-                    ->placeholder('Using GITHUB_TOKEN fallback'),
+                    ->placeholder(fn (Package $record): string => $record->source
+                        ? 'Not needed — authenticating through the source'
+                        : 'Using GITHUB_TOKEN fallback'),
                 TextEntry::make('last_synced_at')
                     ->label('Last synced')
                     ->since()

--- a/app/Filament/Resources/Packages/Tables/PackagesTable.php
+++ b/app/Filament/Resources/Packages/Tables/PackagesTable.php
@@ -31,6 +31,14 @@ class PackagesTable
                     ->openUrlInNewTab()
                     ->color('primary')
                     ->limit(50),
+                TextColumn::make('source.name')
+                    ->label('Source')
+                    ->badge()
+                    ->color(fn (Package $record): string => $record->source?->isConnected() ? 'success' : 'warning')
+                    ->searchable()
+                    ->sortable()
+                    ->placeholder('Unlinked')
+                    ->toggleable(),
                 TextColumn::make('latest_version')
                     ->label('Latest version')
                     ->badge()
@@ -68,6 +76,10 @@ class PackagesTable
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
+                SelectFilter::make('source')
+                    ->relationship('source', 'name')
+                    ->multiple()
+                    ->preload(),
                 SelectFilter::make('type')
                     ->options(fn (): array => Package::types())
                     ->multiple(),

--- a/app/Filament/Resources/Sources/Actions/ConnectGitHubAction.php
+++ b/app/Filament/Resources/Sources/Actions/ConnectGitHubAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Actions;
+
+use App\Services\GitHub\GitHubApp;
+use Filament\Actions\Action;
+use Filament\Support\Icons\Heroicon;
+
+class ConnectGitHubAction
+{
+    /**
+     * The primary way to add a source: no form, straight to GitHub's install
+     * screen. The account, its type and the repository list all come back from
+     * the installation, so the source is created without anything being typed.
+     */
+    public static function make(): Action
+    {
+        return Action::make('connectGithub')
+            ->label('Connect GitHub account')
+            ->icon(Heroicon::OutlinedLink)
+            ->color('primary')
+            ->url(fn (): ?string => static::isAvailable() ? route('sources.connect.new') : null)
+            ->disabled(fn (): bool => ! static::isAvailable())
+            ->tooltip(fn (): ?string => static::isAvailable()
+                ? null
+                : 'No GitHub App is registered for this instance. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY — see docs/github-app.md.');
+    }
+
+    public static function isAvailable(): bool
+    {
+        return app(GitHubApp::class)->isConfigured();
+    }
+}

--- a/app/Filament/Resources/Sources/Actions/ConnectSourceAction.php
+++ b/app/Filament/Resources/Sources/Actions/ConnectSourceAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Actions;
+
+use App\Models\Source;
+use Filament\Actions\Action;
+use Filament\Support\Icons\Heroicon;
+
+class ConnectSourceAction
+{
+    /**
+     * Sends the admin to GitHub to install the app onto an organisation. The
+     * handshake finishes in App\Http\Controllers\SourceConnectionController.
+     */
+    public static function make(): Action
+    {
+        return Action::make('connect')
+            ->label(fn (Source $record): string => $record->isConnected() ? 'Reconnect' : 'Connect')
+            ->icon(Heroicon::OutlinedLink)
+            ->color(fn (Source $record): string => $record->isConnected() ? 'gray' : 'primary')
+            ->url(fn (Source $record): ?string => ConnectGitHubAction::isAvailable()
+                ? route('sources.connect', $record)
+                : null)
+            ->disabled(fn (): bool => ! ConnectGitHubAction::isAvailable())
+            ->tooltip(fn (): ?string => ConnectGitHubAction::isAvailable()
+                ? null
+                : 'No GitHub App is registered for this instance — see docs/github-app.md.')
+            // Only meaningful for app-based connections; a source holding its
+            // own token has nothing to install.
+            ->visible(fn (Source $record): bool => blank($record->token));
+    }
+}

--- a/app/Filament/Resources/Sources/Actions/DisconnectSourceAction.php
+++ b/app/Filament/Resources/Sources/Actions/DisconnectSourceAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Actions;
+
+use App\Models\Source;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+
+class DisconnectSourceAction
+{
+    /**
+     * Drops the stored credentials without deleting the source, so its
+     * packages keep their link and start working again once it is reconnected.
+     */
+    public static function make(): Action
+    {
+        return Action::make('disconnect')
+            ->label('Disconnect')
+            ->icon(Heroicon::OutlinedLinkSlash)
+            ->color('danger')
+            ->requiresConfirmation()
+            ->modalHeading('Disconnect this source?')
+            ->modalDescription(fn (Source $record): string => "Syncing {$record->packages()->count()} package(s) will fail until the source is connected again. Uninstall the app on GitHub separately if you want to revoke access there too.")
+            ->action(function (Source $record): void {
+                $record->disconnect();
+
+                Notification::make()
+                    ->success()
+                    ->title("Disconnected {$record->name}")
+                    ->send();
+            })
+            ->visible(fn (Source $record): bool => $record->isConnected());
+    }
+}

--- a/app/Filament/Resources/Sources/Actions/TestSourceAction.php
+++ b/app/Filament/Resources/Sources/Actions/TestSourceAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Actions;
+
+use App\Models\Source;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use Throwable;
+
+class TestSourceAction
+{
+    /**
+     * Confirms the source's credentials still work, refreshing the account
+     * details and reachable repository count from the provider.
+     */
+    public static function make(): Action
+    {
+        return Action::make('test')
+            ->label('Test connection')
+            ->icon(Heroicon::OutlinedBolt)
+            ->color('gray')
+            ->action(function (Source $record): void {
+                try {
+                    $count = $record->verify();
+
+                    Notification::make()
+                        ->success()
+                        ->title("{$record->refresh()->account} is reachable")
+                        ->body("{$count} repositories are available to this source.")
+                        ->send();
+                } catch (Throwable $exception) {
+                    Notification::make()
+                        ->danger()
+                        ->title('Connection failed')
+                        ->body($exception->getMessage())
+                        ->send();
+                }
+            })
+            ->visible(fn (Source $record): bool => $record->usesInstallation() || filled($record->token));
+    }
+}

--- a/app/Filament/Resources/Sources/Pages/CreateSource.php
+++ b/app/Filament/Resources/Sources/Pages/CreateSource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Pages;
+
+use App\Filament\Resources\Sources\Actions\ConnectGitHubAction;
+use App\Filament\Resources\Sources\SourceResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateSource extends CreateRecord
+{
+    protected static string $resource = SourceResource::class;
+
+    protected static ?string $title = 'Add a source manually';
+
+    /**
+     * This form is the fallback, so it says what the normal route is — or, on
+     * an instance with no app registered, why it is the only one.
+     */
+    public function getSubheading(): ?string
+    {
+        return ConnectGitHubAction::isAvailable()
+            ? 'Most accounts are added with "Connect GitHub account", which fills all of this in from GitHub. Use this form for a GitHub Enterprise instance, or an account you authenticate with an access token.'
+            : 'No GitHub App is registered for this instance, so sources authenticate with an access token. Register one (see docs/github-app.md) to connect accounts in a click instead.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ConnectGitHubAction::make(),
+        ];
+    }
+
+    /**
+     * A new source has no credentials yet, so land on its page where the
+     * "Connect" action is rather than back in the list.
+     */
+    protected function getRedirectUrl(): string
+    {
+        return static::getResource()::getUrl('view', ['record' => $this->getRecord()]);
+    }
+}

--- a/app/Filament/Resources/Sources/Pages/EditSource.php
+++ b/app/Filament/Resources/Sources/Pages/EditSource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Pages;
+
+use App\Filament\Resources\Sources\Actions\ConnectSourceAction;
+use App\Filament\Resources\Sources\Actions\TestSourceAction;
+use App\Filament\Resources\Sources\SourceResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditSource extends EditRecord
+{
+    protected static string $resource = SourceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ConnectSourceAction::make(),
+            TestSourceAction::make(),
+            ViewAction::make(),
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Sources/Pages/ListSources.php
+++ b/app/Filament/Resources/Sources/Pages/ListSources.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Pages;
+
+use App\Filament\Resources\Sources\Actions\ConnectGitHubAction;
+use App\Filament\Resources\Sources\SourceResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSources extends ListRecords
+{
+    protected static string $resource = SourceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            // Connecting is the normal way in; the form behind "Add manually"
+            // only exists for GitHub Enterprise and access-token sources.
+            ConnectGitHubAction::make(),
+            CreateAction::make()
+                ->label('Add manually')
+                ->color('gray')
+                ->outlined(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Sources/Pages/ViewSource.php
+++ b/app/Filament/Resources/Sources/Pages/ViewSource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Pages;
+
+use App\Filament\Resources\Sources\Actions\ConnectSourceAction;
+use App\Filament\Resources\Sources\Actions\DisconnectSourceAction;
+use App\Filament\Resources\Sources\Actions\TestSourceAction;
+use App\Filament\Resources\Sources\SourceResource;
+use Filament\Actions\EditAction;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewSource extends ViewRecord
+{
+    protected static string $resource = SourceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ConnectSourceAction::make(),
+            TestSourceAction::make(),
+            EditAction::make(),
+            DisconnectSourceAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Sources/RelationManagers/PackagesRelationManager.php
+++ b/app/Filament/Resources/Sources/RelationManagers/PackagesRelationManager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Resources\Sources\RelationManagers;
+
+use App\Filament\Resources\Packages\PackageResource;
+use App\Models\Package;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+/**
+ * The packages authenticating through this source — the other half of the
+ * bridge, so it is obvious what breaks if the source is disconnected.
+ */
+class PackagesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'packages';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('name')
+            ->defaultSort('name')
+            ->recordUrl(fn (Package $record): string => PackageResource::getUrl('view', ['record' => $record]))
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('repository')
+                    ->label('Repository')
+                    ->searchable()
+                    ->limit(50),
+                TextColumn::make('latest_version')
+                    ->label('Latest version')
+                    ->badge()
+                    ->placeholder('Unreleased'),
+                TextColumn::make('last_synced_at')
+                    ->label('Last synced')
+                    ->since()
+                    ->sortable()
+                    ->placeholder('Never')
+                    ->color(fn (Package $record): ?string => $record->sync_error ? 'danger' : null)
+                    ->tooltip(fn (Package $record): ?string => $record->sync_error),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Sources/Schemas/SourceForm.php
+++ b/app/Filament/Resources/Sources/Schemas/SourceForm.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Schemas;
+
+use App\Enums\SourceProvider;
+use App\Models\Source;
+use App\Services\GitHub\GitHubApp;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class SourceForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->placeholder('Acme engineering')
+                    ->helperText('A label for this connection; only shown in the admin.'),
+                Select::make('provider')
+                    ->options(SourceProvider::class)
+                    ->default(SourceProvider::Github)
+                    ->required()
+                    ->selectablePlaceholder(false),
+                TextInput::make('account')
+                    ->label('Organisation or user')
+                    ->maxLength(255)
+                    ->placeholder('acme')
+                    // Required for a token-based source, since there is no
+                    // installation to read the account off. Connecting fills
+                    // it in instead.
+                    ->required(fn (?Source $record): bool => ! $record?->usesInstallation())
+                    ->helperText('Packages whose repository sits under this owner authenticate through this source.'),
+                TextInput::make('base_url')
+                    ->label('API base URL')
+                    ->url()
+                    ->maxLength(255)
+                    ->placeholder('https://api.github.com')
+                    ->helperText('Only needed for GitHub Enterprise; leave empty for github.com.'),
+                TextInput::make('token')
+                    ->label('Access token')
+                    ->password()
+                    ->revealable()
+                    ->maxLength(255)
+                    // The stored token is never echoed back to the browser;
+                    // a blank input keeps it, a new value replaces it.
+                    ->afterStateHydrated(fn (TextInput $component) => $component->state(null))
+                    ->dehydrated(fn (?string $state): bool => filled($state))
+                    ->placeholder(fn (?Source $record): string => $record?->token ? 'Token saved — enter a new one to replace it' : 'github_pat_...')
+                    ->helperText(fn (): string => app(GitHubApp::class)->isConfigured()
+                        ? 'Optional. Leave empty and use "Connect" instead — an installed GitHub App issues short-lived tokens scoped to the repositories you pick.'
+                        : 'No GitHub App is configured on this instance, so a source needs a token here. See docs/github-app.md to set the app up instead.')
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Sources/Schemas/SourceForm.php
+++ b/app/Filament/Resources/Sources/Schemas/SourceForm.php
@@ -5,8 +5,10 @@ namespace App\Filament\Resources\Sources\Schemas;
 use App\Enums\SourceProvider;
 use App\Models\Source;
 use App\Services\GitHub\GitHubApp;
+use Closure;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 
 class SourceForm
@@ -34,6 +36,20 @@ class SourceForm
                     // installation to read the account off. Connecting fills
                     // it in instead.
                     ->required(fn (?Source $record): bool => ! $record?->usesInstallation())
+                    // Packages are matched to a source by owner, so a provider
+                    // may only hold each account once — a database constraint
+                    // that has to surface here rather than as a query error.
+                    ->rule(static fn (?Source $record, Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($record, $get): void {
+                        if (blank($value)) {
+                            return;
+                        }
+
+                        $holder = Source::accountHolder((string) $value, $get('provider'), $record);
+
+                        if ($holder instanceof Source) {
+                            $fail("This account is already connected as \"{$holder->name}\".");
+                        }
+                    })
                     ->helperText('Packages whose repository sits under this owner authenticate through this source.'),
                 TextInput::make('base_url')
                     ->label('API base URL')

--- a/app/Filament/Resources/Sources/Schemas/SourceInfolist.php
+++ b/app/Filament/Resources/Sources/Schemas/SourceInfolist.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Schemas;
+
+use App\Models\Source;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Schema;
+
+class SourceInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextEntry::make('name'),
+                TextEntry::make('provider')
+                    ->badge(),
+                TextEntry::make('account')
+                    ->label('Organisation or user')
+                    ->url(fn (Source $record): ?string => $record->account
+                        ? "https://{$record->provider->host()}/{$record->account}"
+                        : null)
+                    ->openUrlInNewTab()
+                    ->color('primary')
+                    ->placeholder('Not connected yet'),
+                TextEntry::make('account_type')
+                    ->label('Account type')
+                    ->placeholder('-'),
+                TextEntry::make('connected_at')
+                    ->label('Connected')
+                    ->since()
+                    ->placeholder('Never'),
+                TextEntry::make('installation_id')
+                    ->label('Authentication')
+                    ->badge()
+                    ->color(fn (Source $record): string => $record->usesInstallation() ? 'success' : 'warning')
+                    // Token-based sources have no installation id, so the
+                    // state is filled in from the record rather than the
+                    // column to keep the entry from falling back to a dash.
+                    ->state(fn (Source $record): string => match (true) {
+                        $record->usesInstallation() => "GitHub App installation #{$record->installation_id}",
+                        filled($record->token) => 'Access token',
+                        default => 'None',
+                    }),
+                TextEntry::make('metadata.repository_selection')
+                    ->label('Repository access')
+                    ->formatStateUsing(fn (string $state): string => $state === 'all'
+                        ? 'All repositories in the account'
+                        : 'Only the selected repositories')
+                    ->placeholder('-'),
+                TextEntry::make('metadata.repository_count')
+                    ->label('Repositories reachable')
+                    ->placeholder('Unknown — run "Test connection"'),
+                TextEntry::make('base_url')
+                    ->label('API base URL')
+                    ->placeholder('https://api.github.com'),
+                TextEntry::make('connection_error')
+                    ->label('Connection error')
+                    ->color('danger')
+                    ->placeholder('None')
+                    ->columnSpanFull(),
+                TextEntry::make('created_at')
+                    ->dateTime()
+                    ->placeholder('-'),
+                TextEntry::make('updated_at')
+                    ->dateTime()
+                    ->placeholder('-'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Sources/SourceResource.php
+++ b/app/Filament/Resources/Sources/SourceResource.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Filament\Resources\Sources;
+
+use App\Filament\Resources\Sources\Pages\CreateSource;
+use App\Filament\Resources\Sources\Pages\EditSource;
+use App\Filament\Resources\Sources\Pages\ListSources;
+use App\Filament\Resources\Sources\Pages\ViewSource;
+use App\Filament\Resources\Sources\Schemas\SourceForm;
+use App\Filament\Resources\Sources\Schemas\SourceInfolist;
+use App\Filament\Resources\Sources\Tables\SourcesTable;
+use App\Models\Source;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class SourceResource extends Resource
+{
+    protected static ?string $model = Source::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCloud;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    // Sources are what packages are pulled from, so they read first.
+    protected static ?int $navigationSort = -1;
+
+    public static function form(Schema $schema): Schema
+    {
+        return SourceForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return SourceInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return SourcesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\PackagesRelationManager::class,
+        ];
+    }
+
+    /**
+     * Surfaces a source that has stopped authenticating without the admin
+     * having to open the list.
+     */
+    public static function getNavigationBadge(): ?string
+    {
+        $failing = static::getModel()::query()->whereNull('connected_at')->count();
+
+        return $failing === 0 ? null : (string) $failing;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'danger';
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListSources::route('/'),
+            'create' => CreateSource::route('/create'),
+            'view' => ViewSource::route('/{record}'),
+            'edit' => EditSource::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Sources/Tables/SourcesTable.php
+++ b/app/Filament/Resources/Sources/Tables/SourcesTable.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Tables;
+
+use App\Enums\SourceProvider;
+use App\Filament\Resources\Sources\Actions\ConnectGitHubAction;
+use App\Filament\Resources\Sources\Actions\ConnectSourceAction;
+use App\Filament\Resources\Sources\Actions\TestSourceAction;
+use App\Models\Source;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class SourcesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('name')
+            ->emptyStateIcon(Heroicon::OutlinedCloud)
+            ->emptyStateHeading('No sources connected')
+            ->emptyStateDescription('Connect a GitHub account and every package under it authenticates through this source — no token per repository.')
+            ->emptyStateActions([
+                ConnectGitHubAction::make(),
+            ])
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('provider')
+                    ->badge()
+                    ->sortable(),
+                TextColumn::make('account')
+                    ->label('Organisation or user')
+                    ->searchable()
+                    ->sortable()
+                    ->url(fn (Source $record): ?string => $record->account
+                        ? "https://{$record->provider->host()}/{$record->account}"
+                        : null)
+                    ->openUrlInNewTab()
+                    ->color('primary')
+                    ->placeholder('-'),
+                TextColumn::make('status')
+                    ->badge()
+                    ->state(fn (Source $record): string => match (true) {
+                        $record->connection_error !== null => 'Failing',
+                        $record->isConnected() => 'Connected',
+                        $record->usesInstallation() || filled($record->token) => 'Untested',
+                        default => 'Not connected',
+                    })
+                    ->color(fn (Source $record): string => match (true) {
+                        $record->connection_error !== null => 'danger',
+                        $record->isConnected() => 'success',
+                        default => 'gray',
+                    })
+                    ->tooltip(fn (Source $record): ?string => $record->connection_error),
+                TextColumn::make('packages_count')
+                    ->label('Packages')
+                    ->counts('packages')
+                    ->sortable(),
+                TextColumn::make('connected_at')
+                    ->label('Connected')
+                    ->since()
+                    ->sortable()
+                    ->placeholder('Never')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('base_url')
+                    ->label('API base URL')
+                    ->placeholder('github.com')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('provider')
+                    ->options(SourceProvider::class),
+                Filter::make('disconnected')
+                    ->label('Needs attention')
+                    ->query(fn (Builder $query): Builder => $query->whereNull('connected_at')),
+            ])
+            ->recordActions([
+                ConnectSourceAction::make(),
+                TestSourceAction::make(),
+                ViewAction::make(),
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Http/Controllers/SourceConnectionController.php
+++ b/app/Http/Controllers/SourceConnectionController.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Filament\Resources\Sources\SourceResource;
+use App\Models\Package;
+use App\Models\Source;
+use App\Services\GitHub\GitHubApp;
+use Filament\Notifications\Notification;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * Drives the GitHub App install handshake that connects a source.
+ *
+ * The admin is sent to GitHub to choose an organisation and the repositories
+ * to share; GitHub returns them here with an installation id, which is all the
+ * app needs to mint tokens from then on.
+ */
+class SourceConnectionController extends Controller
+{
+    /**
+     * The session key holding the pending handshake. It carries the source
+     * being connected as well as the CSRF-style state, so a callback can only
+     * ever complete the connection the same browser started.
+     */
+    private const SESSION_KEY = 'sources.github.pending';
+
+    /**
+     * Connect a GitHub account that has no source yet. The source is created
+     * from whatever GitHub reports back, so nothing has to be typed first.
+     */
+    public function connectNew(Request $request): RedirectResponse
+    {
+        return $this->start($request, null);
+    }
+
+    /**
+     * Reconnect an existing source, or connect one that was added by hand.
+     */
+    public function connect(Request $request, Source $source): RedirectResponse
+    {
+        return $this->start($request, $source);
+    }
+
+    private function start(Request $request, ?Source $source): RedirectResponse
+    {
+        $app = app(GitHubApp::class);
+
+        if (! $app->isConfigured()) {
+            return $this->back($source, 'danger', 'No GitHub App configured', 'Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY to connect accounts from here. See docs/github-app.md.');
+        }
+
+        $state = Str::random(40);
+
+        $request->session()->put(self::SESSION_KEY, [
+            'state' => $state,
+            'source_id' => $source?->id,
+        ]);
+
+        return redirect()->away($app->installationUrl($state));
+    }
+
+    public function callback(Request $request): RedirectResponse
+    {
+        $pending = $request->session()->pull(self::SESSION_KEY);
+
+        $state = $request->query('state');
+
+        // Without a matching state this callback did not originate from a
+        // "Connect" click in this session, so there is nothing safe to attach
+        // the installation to.
+        if (! is_array($pending) || ! is_string($state) || ! hash_equals($pending['state'], $state)) {
+            return $this->back(null, 'danger', 'Connection could not be verified', 'The install did not match a pending connection. Start again from the source you want to connect.');
+        }
+
+        // A null source_id is the "connect an account we have no source for
+        // yet" flow; the source is built from the installation below.
+        $source = $pending['source_id'] === null ? null : Source::find($pending['source_id']);
+
+        if ($pending['source_id'] !== null && ! $source instanceof Source) {
+            return $this->back(null, 'danger', 'Source no longer exists', 'It was deleted while the install was in progress.');
+        }
+
+        $installationId = (int) $request->query('installation_id');
+
+        if ($installationId <= 0) {
+            // GitHub sends the admin here without an installation id when they
+            // cancel, or when a request to install needs owner approval.
+            return $this->back($source, 'warning', 'Nothing was installed', 'GitHub did not return an installation. If your organisation requires owner approval, connect again once the request is approved.');
+        }
+
+        try {
+            $installation = app(GitHubApp::class)->installation($installationId);
+        } catch (Throwable $exception) {
+            return $this->back($source, 'danger', 'Connection failed', $exception->getMessage());
+        }
+
+        $login = $installation['account']['login'] ?? null;
+
+        // Installing onto an account another source already holds would break
+        // the unique indexes; say so rather than surfacing a database error.
+        if ($source && $conflict = Source::conflicting($source, $installationId, $login)) {
+            return $this->back($source, 'danger', 'Already connected', "{$login} is connected as \"{$conflict->name}\". Reconnect from that source, or disconnect it first.");
+        }
+
+        $source ??= Source::forInstallation($installationId, $installation);
+
+        try {
+            $source->completeInstallation($installationId, $installation);
+            $count = $source->verify();
+        } catch (Throwable $exception) {
+            return $this->back($source->exists ? $source : null, 'danger', 'Connection failed', $exception->getMessage());
+        }
+
+        $this->adoptMatchingPackages($source);
+
+        return $this->back($source, 'success', "Connected {$source->account}", "{$count} repositories are reachable from this source.");
+    }
+
+    /**
+     * Claim the packages that were added before this owner was connected.
+     *
+     * Auto-linking on save cannot see a source that does not exist yet, so
+     * connecting one sweeps up the repositories already pointing at it.
+     */
+    private function adoptMatchingPackages(Source $source): void
+    {
+        $unlinked = Package::query()->whereNull('source_id')->get();
+
+        foreach ($unlinked as $package) {
+            try {
+                $owner = strtok($package->repositoryPath(), '/');
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+
+            if (strcasecmp($owner, (string) $source->account) === 0) {
+                $package->forceFill(['source_id' => $source->id])->save();
+            }
+        }
+    }
+
+    private function back(?Source $source, string $status, string $title, string $body): RedirectResponse
+    {
+        Notification::make()->{$status}()->title($title)->body($body)->send();
+
+        return redirect($source
+            ? SourceResource::getUrl('view', ['record' => $source])
+            : SourceResource::getUrl('index'));
+    }
+}

--- a/app/Http/Controllers/SourceConnectionController.php
+++ b/app/Http/Controllers/SourceConnectionController.php
@@ -101,6 +101,13 @@ class SourceConnectionController extends Controller
 
         $login = $installation['account']['login'] ?? null;
 
+        // A reconnect has to land on the owner the source already points at.
+        // Installing onto a different account would re-credential this source
+        // and silently move it away from the packages matched to its owner.
+        if ($source?->account && $login && strcasecmp($source->account, $login) !== 0) {
+            return $this->back($source, 'danger', 'Wrong account installed', "This source is for \"{$source->account}\", but the app was installed on \"{$login}\". Install it on {$source->account} instead, or connect {$login} from the sources list as its own source.");
+        }
+
         // Installing onto an account another source already holds would break
         // the unique indexes; say so rather than surfacing a database error.
         if ($source && $conflict = Source::conflicting($source, $installationId, $login)) {

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -2,14 +2,16 @@
 
 namespace App\Models;
 
+use App\Enums\SourceProvider;
 use Database\Factories\PackageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use InvalidArgumentException;
 
-#[Fillable(['repository', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error'])]
+#[Fillable(['source_id', 'repository', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error'])]
 class Package extends Model
 {
     /** @use HasFactory<PackageFactory> */
@@ -26,12 +28,73 @@ class Package extends Model
         ];
     }
 
+    protected static function booted(): void
+    {
+        static::saving(fn (self $package) => $package->linkSource());
+    }
+
     /**
      * @return HasMany<PackageVersion, $this>
      */
     public function versions(): HasMany
     {
         return $this->hasMany(PackageVersion::class);
+    }
+
+    /**
+     * @return BelongsTo<Source, $this>
+     */
+    public function source(): BelongsTo
+    {
+        return $this->belongsTo(Source::class);
+    }
+
+    /**
+     * Attach the connected source that owns this package's repository.
+     *
+     * Runs on every save, but only fills a source in when the package has none
+     * *and* the repository URL is new — so a source chosen (or cleared) by
+     * hand is never overwritten, and repointing a package at another
+     * organisation is a deliberate act rather than a silent re-credentialing.
+     */
+    public function linkSource(): void
+    {
+        if ($this->source_id !== null || ! $this->isDirty('repository')) {
+            return;
+        }
+
+        try {
+            $path = $this->repositoryPath();
+        } catch (InvalidArgumentException) {
+            // An unparseable repository belongs to no source.
+            return;
+        }
+
+        $this->source_id = Source::forRepositoryPath($path)?->id;
+    }
+
+    /**
+     * The credential to use when talking to this package's provider.
+     *
+     * The connected source wins, because it is the credential an admin
+     * deliberately attached to the whole organisation. A per-package token
+     * remains as an override for repositories no source covers, and
+     * GITHUB_TOKEN is the last resort.
+     */
+    public function accessToken(): ?string
+    {
+        return $this->source?->accessToken()
+            ?? $this->token
+            ?? config('services.github.token');
+    }
+
+    /**
+     * The API root to reach this package's repository through, which a
+     * self-hosted source overrides.
+     */
+    public function apiUrl(): string
+    {
+        return $this->source?->apiUrl() ?? SourceProvider::Github->defaultApiUrl();
     }
 
     /**

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -63,8 +63,24 @@ class Source extends Model
 
         return static::query()
             ->where('provider', SourceProvider::Github)
-            // GitHub logins are case insensitive, so the match must be too.
-            ->whereRaw('lower(account) = ?', [mb_strtolower($owner)])
+            ->forAccount($owner)
+            ->first();
+    }
+
+    /**
+     * The source already holding an account for a provider, ignoring the given
+     * one so that editing a source does not collide with itself.
+     *
+     * A provider may only reach an owner through a single source — the unique
+     * index says so — and both the form and the install callback ask this
+     * before writing, so a duplicate reads as an error rather than a crash.
+     */
+    public static function accountHolder(string $account, SourceProvider|string|null $provider, ?self $except = null): ?self
+    {
+        return static::query()
+            ->where('provider', $provider)
+            ->when($except?->exists, fn (Builder $query): Builder => $query->whereKeyNot($except->getKey()))
+            ->forAccount($account)
             ->first();
     }
 
@@ -85,9 +101,8 @@ class Source extends Model
             ->where('provider', SourceProvider::Github)
             ->where(fn (Builder $query): Builder => $query
                 ->where('installation_id', $installationId)
-                ->when($login, fn (Builder $query): Builder => $query->orWhereRaw(
-                    'lower(account) = ?',
-                    [mb_strtolower($login)],
+                ->when($login, fn (Builder $query): Builder => $query->orWhere(
+                    fn (Builder $query): Builder => $query->forAccount($login),
                 )))
             ->first();
 
@@ -110,11 +125,24 @@ class Source extends Model
             ->whereKeyNot($except->getKey())
             ->where(fn (Builder $query): Builder => $query
                 ->where('installation_id', $installationId)
-                ->when($login, fn (Builder $query): Builder => $query->orWhereRaw(
-                    'lower(account) = ?',
-                    [mb_strtolower($login)],
+                ->when($login, fn (Builder $query): Builder => $query->orWhere(
+                    fn (Builder $query): Builder => $query->forAccount($login),
                 )))
             ->first();
+    }
+
+    /**
+     * Narrow to the sources owned by an account.
+     *
+     * GitHub logins are case insensitive, so the match must be too — otherwise
+     * "Acme" and "acme" would look like two different owners.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeForAccount(Builder $query, string $account): Builder
+    {
+        return $query->whereRaw('lower(account) = ?', [mb_strtolower($account)]);
     }
 
     /**

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SourceProvider;
+use App\Services\GitHub\GitHubApp;
+use Database\Factories\SourceFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Throwable;
+
+/**
+ * A connected version control account that packages are sourced from.
+ *
+ * A source holds the credentials for one owner — a GitHub organisation or user
+ * — so that every package under that owner authenticates through it instead of
+ * carrying its own token.
+ */
+#[Fillable(['name', 'provider', 'base_url', 'account', 'account_type', 'installation_id', 'token', 'metadata'])]
+class Source extends Model
+{
+    /** @use HasFactory<SourceFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'provider' => SourceProvider::class,
+            'token' => 'encrypted',
+            'metadata' => 'array',
+            'installation_id' => 'integer',
+            'connected_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return HasMany<Package, $this>
+     */
+    public function packages(): HasMany
+    {
+        return $this->hasMany(Package::class);
+    }
+
+    /**
+     * The source that owns a given "owner/repo" path, or null when that owner
+     * has not been connected.
+     */
+    public static function forRepositoryPath(string $repositoryPath): ?self
+    {
+        $owner = strtok($repositoryPath, '/');
+
+        if ($owner === false || $owner === '') {
+            return null;
+        }
+
+        return static::query()
+            ->where('provider', SourceProvider::Github)
+            // GitHub logins are case insensitive, so the match must be too.
+            ->whereRaw('lower(account) = ?', [mb_strtolower($owner)])
+            ->first();
+    }
+
+    /**
+     * The source a finished installation belongs to.
+     *
+     * Reconnecting an account, or connecting one that was first added by hand,
+     * lands on the existing row; anything else returns a new unsaved source
+     * named after the account, so connecting is all it takes to add one.
+     *
+     * @param  array<string, mixed>  $installation
+     */
+    public static function forInstallation(int $installationId, array $installation): self
+    {
+        $login = $installation['account']['login'] ?? null;
+
+        $existing = static::query()
+            ->where('provider', SourceProvider::Github)
+            ->where(fn (Builder $query): Builder => $query
+                ->where('installation_id', $installationId)
+                ->when($login, fn (Builder $query): Builder => $query->orWhereRaw(
+                    'lower(account) = ?',
+                    [mb_strtolower($login)],
+                )))
+            ->first();
+
+        return $existing ?? new self([
+            'name' => static::availableName($login ?? "GitHub installation {$installationId}"),
+            'provider' => SourceProvider::Github,
+            'account' => $login,
+        ]);
+    }
+
+    /**
+     * A source other than the given one that already holds this installation
+     * or account — which the unique indexes would otherwise reject with a
+     * database error rather than something an admin can act on.
+     */
+    public static function conflicting(self $except, int $installationId, ?string $login): ?self
+    {
+        return static::query()
+            ->where('provider', SourceProvider::Github)
+            ->whereKeyNot($except->getKey())
+            ->where(fn (Builder $query): Builder => $query
+                ->where('installation_id', $installationId)
+                ->when($login, fn (Builder $query): Builder => $query->orWhereRaw(
+                    'lower(account) = ?',
+                    [mb_strtolower($login)],
+                )))
+            ->first();
+    }
+
+    /**
+     * The preferred name, suffixed until it no longer collides. Names are
+     * unique and this one is chosen for the admin rather than by them.
+     */
+    private static function availableName(string $preferred): string
+    {
+        $name = $preferred;
+
+        for ($suffix = 2; static::query()->where('name', $name)->exists(); $suffix++) {
+            $name = "{$preferred} ({$suffix})";
+        }
+
+        return $name;
+    }
+
+    /**
+     * Every source keyed by id, for the package form's picker.
+     *
+     * Sources that cannot authenticate yet are listed too, flagged rather than
+     * hidden: a package may be assigned to a source before it is connected,
+     * and leaving one out would blank the picker for packages already linked
+     * to it.
+     *
+     * @return array<int, string>
+     */
+    public static function options(): array
+    {
+        return static::query()
+            ->orderBy('name')
+            ->get()
+            ->mapWithKeys(fn (self $source): array => [
+                $source->id => "{$source->name} ({$source->provider->getLabel()})"
+                    .($source->isConnected() ? '' : ' — not connected'),
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeConnected(Builder $query): Builder
+    {
+        return $query->whereNotNull('connected_at');
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->connected_at !== null;
+    }
+
+    /**
+     * Whether this source authenticates through the GitHub App rather than a
+     * token typed in by hand.
+     */
+    public function usesInstallation(): bool
+    {
+        return $this->installation_id !== null;
+    }
+
+    /**
+     * The API root for this source, which self-hosted instances override.
+     */
+    public function apiUrl(): string
+    {
+        return rtrim($this->base_url ?: $this->provider->defaultApiUrl(), '/');
+    }
+
+    /**
+     * A token authorised for this source's repositories.
+     *
+     * An installed app mints a fresh short-lived token; otherwise the manually
+     * stored token is used. Null means the source cannot authenticate, and the
+     * caller should fall back to whatever else it has.
+     */
+    public function accessToken(): ?string
+    {
+        if ($this->usesInstallation()) {
+            return app(GitHubApp::class)->installationToken($this->installation_id);
+        }
+
+        return $this->token;
+    }
+
+    /**
+     * Record a completed GitHub App installation against this source.
+     *
+     * @param  array<string, mixed>  $installation
+     */
+    public function completeInstallation(int $installationId, array $installation): void
+    {
+        $this->forceFill([
+            'installation_id' => $installationId,
+            'account' => $installation['account']['login'] ?? $this->account,
+            'account_type' => $installation['account']['type'] ?? null,
+            'metadata' => [
+                'app_slug' => $installation['app_slug'] ?? null,
+                'repository_selection' => $installation['repository_selection'] ?? null,
+                'permissions' => $installation['permissions'] ?? [],
+            ],
+            'connected_at' => now(),
+            'connection_error' => null,
+        ])->save();
+    }
+
+    /**
+     * Forget the installation, leaving the source in place but unable to
+     * authenticate until it is connected again.
+     */
+    public function disconnect(): void
+    {
+        if ($this->usesInstallation()) {
+            app(GitHubApp::class)->forgetInstallationToken($this->installation_id);
+        }
+
+        $this->forceFill([
+            'installation_id' => null,
+            'token' => null,
+            'connected_at' => null,
+            'connection_error' => null,
+        ])->save();
+    }
+
+    /**
+     * Call the provider to confirm the stored credentials still work, and
+     * refresh the account details and repository count from the response.
+     *
+     * The failure reason is recorded on the source before it bubbles up.
+     *
+     * @return int the number of repositories this source can reach
+     */
+    public function verify(): int
+    {
+        try {
+            $count = $this->usesInstallation()
+                ? $this->verifyInstallation()
+                : $this->verifyToken();
+        } catch (Throwable $exception) {
+            $this->forceFill([
+                'connected_at' => null,
+                'connection_error' => $exception->getMessage(),
+            ])->save();
+
+            throw $exception;
+        }
+
+        $this->forceFill([
+            'metadata' => [...$this->metadata ?? [], 'repository_count' => $count],
+            'connected_at' => now(),
+            'connection_error' => null,
+        ])->save();
+
+        return $count;
+    }
+
+    /**
+     * Re-read the installation and count the repositories it reaches.
+     */
+    private function verifyInstallation(): int
+    {
+        $app = app(GitHubApp::class);
+
+        // A token minted before the app's permissions or repository selection
+        // changed would still pass, so this check always starts clean.
+        $app->forgetInstallationToken($this->installation_id);
+
+        $installation = $app->installation($this->installation_id);
+
+        $this->fill([
+            'account' => $installation['account']['login'] ?? $this->account,
+            'account_type' => $installation['account']['type'] ?? $this->account_type,
+        ]);
+
+        return (int) ($this->get('/installation/repositories', ['per_page' => 1])['total_count'] ?? 0);
+    }
+
+    /**
+     * Confirm a manually stored token works and reaches this source's account.
+     */
+    private function verifyToken(): int
+    {
+        throw_unless($this->token, new RuntimeException(
+            'This source has neither a GitHub App installation nor an access token.'
+        ));
+
+        throw_unless($this->account, new RuntimeException(
+            'Set the account (the GitHub organisation or user) before testing a token-based source.'
+        ));
+
+        // Org repositories first; a source pointed at a personal account is
+        // not an org, and GitHub answers 404 there.
+        $repositories = $this->get("/orgs/{$this->account}/repos", ['per_page' => 100], allowMissing: true)
+            ?? $this->get("/users/{$this->account}/repos", ['per_page' => 100]);
+
+        return count($repositories);
+    }
+
+    /**
+     * A GET against this source's API, authenticated as the source.
+     *
+     * @param  array<string, mixed>  $query
+     * @return array<mixed>|null
+     */
+    private function get(string $path, array $query = [], bool $allowMissing = false): ?array
+    {
+        $response = Http::baseUrl($this->apiUrl())
+            ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
+            ->withToken($this->accessToken())
+            ->acceptJson()
+            ->get($path, $query);
+
+        if ($allowMissing && $response->status() === 404) {
+            return null;
+        }
+
+        return $response->throw()->json();
+    }
+}

--- a/app/Services/GitHub/GitHubApp.php
+++ b/app/Services/GitHub/GitHubApp.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace App\Services\GitHub;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * The registered GitHub App, which is how this registry authenticates against
+ * repositories without anyone pasting a long-lived token.
+ *
+ * An admin installs the app onto an organisation; GitHub hands back an
+ * installation id, and from there every API call uses an installation token
+ * minted on demand. Those tokens expire after an hour and are scoped to the
+ * repositories chosen at install time, so nothing durable and over-broad is
+ * ever stored.
+ */
+class GitHubApp
+{
+    /**
+     * GitHub rejects app JWTs valid for more than ten minutes. Nine leaves
+     * room for the backdated `iat` below without crossing that line.
+     */
+    private const JWT_LIFETIME = 540;
+
+    /**
+     * Clock skew allowance. GitHub rejects a JWT whose `iat` is in the future
+     * relative to its own clock, so it is issued a minute in the past.
+     */
+    private const JWT_BACKDATE = 60;
+
+    /**
+     * Margin subtracted from an installation token's expiry before caching, so
+     * a token is never handed out with only seconds of life left.
+     */
+    private const TOKEN_EXPIRY_MARGIN = 300;
+
+    /**
+     * Whether an app has been registered and configured on this instance.
+     * Sources fall back to their stored token when it has not.
+     */
+    public function isConfigured(): bool
+    {
+        return filled(config('services.github.app.id'))
+            && filled(config('services.github.app.private_key'));
+    }
+
+    /**
+     * Where to send an admin to install the app. GitHub returns them to the
+     * app's configured setup URL with `installation_id` and this `state`.
+     */
+    public function installationUrl(string $state): string
+    {
+        $this->ensureConfigured();
+
+        return "https://github.com/apps/{$this->slug()}/installations/new?"
+            .http_build_query(['state' => $state]);
+    }
+
+    /**
+     * The app's public name, which is the only part of the install URL that
+     * is not fixed.
+     *
+     * GitHub reports it against the app's own credentials, so it does not need
+     * configuring; it is cached because it only changes if the app is renamed,
+     * and an override exists for that case and for saving the round trip.
+     */
+    private function slug(): string
+    {
+        if (filled($configured = config('services.github.app.slug'))) {
+            return $configured;
+        }
+
+        return Cache::remember(
+            'github-app.slug.'.config('services.github.app.id'),
+            now()->addDay(),
+            function (): string {
+                $slug = $this->request()->withToken($this->jwt())->get('/app')->throw()->json('slug');
+
+                throw_unless(is_string($slug), new RuntimeException(
+                    'GitHub did not report a slug for this app; check GITHUB_APP_ID matches the private key.'
+                ));
+
+                return $slug;
+            },
+        );
+    }
+
+    /**
+     * The installation record, which tells us which account the app was
+     * installed onto.
+     *
+     * @return array<string, mixed>
+     */
+    public function installation(int $installationId): array
+    {
+        return $this->request()
+            ->withToken($this->jwt())
+            ->get("/app/installations/{$installationId}")
+            ->throw()
+            ->json();
+    }
+
+    /**
+     * A token for acting on the installation's repositories.
+     *
+     * Tokens are cached until shortly before GitHub expires them, so a sync
+     * touching many repositories mints one rather than one per call. The cache
+     * holds them encrypted because it is a shared store that outlives the
+     * request.
+     */
+    public function installationToken(int $installationId): string
+    {
+        $key = "github-app.installation-token.{$installationId}";
+
+        if (is_string($cached = Cache::get($key))) {
+            return Crypt::decryptString($cached);
+        }
+
+        $response = $this->request()
+            ->withToken($this->jwt())
+            ->post("/app/installations/{$installationId}/access_tokens")
+            ->throw()
+            ->json();
+
+        $token = $response['token'] ?? null;
+
+        throw_unless(
+            is_string($token),
+            new RuntimeException("GitHub did not return an access token for installation {$installationId}."),
+        );
+
+        $expiresAt = strtotime($response['expires_at'] ?? '') ?: time() + 3600;
+        $ttl = $expiresAt - time() - self::TOKEN_EXPIRY_MARGIN;
+
+        if ($ttl > 0) {
+            Cache::put($key, Crypt::encryptString($token), $ttl);
+        }
+
+        return $token;
+    }
+
+    /**
+     * Drop any cached token, so the next call mints a fresh one. Used when an
+     * installation is reconnected or removed.
+     */
+    public function forgetInstallationToken(int $installationId): void
+    {
+        Cache::forget("github-app.installation-token.{$installationId}");
+    }
+
+    /**
+     * A short-lived JWT identifying the app itself, which is what GitHub
+     * accepts on the `/app/*` endpoints.
+     */
+    private function jwt(): string
+    {
+        $this->ensureConfigured();
+
+        $issuedAt = time() - self::JWT_BACKDATE;
+
+        $segments = [
+            $this->base64UrlEncode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'])),
+            $this->base64UrlEncode(json_encode([
+                'iat' => $issuedAt,
+                'exp' => $issuedAt + self::JWT_LIFETIME,
+                'iss' => (string) config('services.github.app.id'),
+            ])),
+        ];
+
+        $payload = implode('.', $segments);
+
+        throw_unless(
+            openssl_sign($payload, $signature, $this->privateKey(), OPENSSL_ALGO_SHA256),
+            new RuntimeException('Unable to sign the GitHub App JWT; check GITHUB_APP_PRIVATE_KEY is a valid RSA private key.'),
+        );
+
+        return $payload.'.'.$this->base64UrlEncode($signature);
+    }
+
+    /**
+     * The app's RSA private key, accepted either as a path to the .pem file
+     * GitHub generates or as the key itself (whose newlines survive an
+     * environment file only when escaped, so "\n" is restored here).
+     */
+    private function privateKey(): string
+    {
+        $key = (string) config('services.github.app.private_key');
+
+        if (! str_contains($key, 'PRIVATE KEY')) {
+            throw_unless(
+                File::exists($key),
+                new RuntimeException("GITHUB_APP_PRIVATE_KEY is neither a PEM key nor a readable file path [{$key}]."),
+            );
+
+            return File::get($key);
+        }
+
+        return str_replace('\n', "\n", $key);
+    }
+
+    private function ensureConfigured(): void
+    {
+        throw_unless($this->isConfigured(), new RuntimeException(
+            'No GitHub App is configured. Set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY, '
+            .'or give the source its own access token.'
+        ));
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl(config('services.github.app.api_url'))
+            ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
+            ->acceptJson();
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/app/Services/GitHub/GitHubClient.php
+++ b/app/Services/GitHub/GitHubClient.php
@@ -22,13 +22,19 @@ class GitHubClient
     public function __construct(
         private readonly string $repositoryPath,
         private readonly ?string $token,
+        private readonly string $apiUrl = 'https://api.github.com',
     ) {}
 
+    /**
+     * A client for one package, authenticated with whatever credential the
+     * package resolves to — its connected source first of all.
+     */
     public static function for(Package $package): self
     {
         return new self(
             $package->repositoryPath(),
-            $package->token ?? config('services.github.token'),
+            $package->accessToken(),
+            $package->apiUrl(),
         );
     }
 
@@ -137,7 +143,7 @@ class GitHubClient
 
     private function request(): PendingRequest
     {
-        return Http::baseUrl('https://api.github.com')
+        return Http::baseUrl($this->apiUrl)
             ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
             ->when($this->token, fn (PendingRequest $request) => $request->withToken($this->token))
             ->acceptJson();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        // The admin-only routes outside the Filament panel (the GitHub App
+        // connect handshake) use the plain "auth" middleware, which has no
+        // login route of its own to fall back on. Keep this in sync with the
+        // panel's path() in App\Providers\Filament\AdminPanelProvider.
+        $middleware->redirectGuestsTo('/admin/login');
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(

--- a/config/services.php
+++ b/config/services.php
@@ -15,9 +15,23 @@ return [
     */
 
     'github' => [
-        // Fallback token for packages that don't carry their own; used when
-        // syncing and when proxying zipballs from private repositories.
+        // Last-resort token, used only for packages with neither a connected
+        // source nor a token of their own.
         'token' => env('GITHUB_TOKEN'),
+
+        // The registered GitHub App that sources install onto an organisation
+        // to authenticate without a long-lived token. See docs/github-app.md.
+        'app' => [
+            'id' => env('GITHUB_APP_ID'),
+            // The generated .pem, given either as a file path or as the key
+            // itself with its newlines escaped as "\n".
+            'private_key' => env('GITHUB_APP_PRIVATE_KEY'),
+            // Read from GitHub when empty; only worth setting to skip that
+            // lookup, or if the app is renamed before the cache expires.
+            'slug' => env('GITHUB_APP_SLUG'),
+            // Overridden only on GitHub Enterprise.
+            'api_url' => env('GITHUB_APP_API_URL', 'https://api.github.com'),
+        ],
     ],
 
     'postmark' => [

--- a/database/factories/SourceFactory.php
+++ b/database/factories/SourceFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SourceProvider;
+use App\Models\Source;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Source>
+ */
+class SourceFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $account = fake()->unique()->domainWord();
+
+        return [
+            'name' => ucfirst($account),
+            'provider' => SourceProvider::Github,
+            'account' => $account,
+            'account_type' => 'Organization',
+            'installation_id' => fake()->unique()->numberBetween(1_000_000, 9_999_999),
+            'metadata' => ['repository_selection' => 'selected', 'repository_count' => 3],
+            'connected_at' => now(),
+        ];
+    }
+
+    /**
+     * A source that has been created but never connected to the provider.
+     */
+    public function disconnected(): static
+    {
+        return $this->state(fn (): array => [
+            'installation_id' => null,
+            'token' => null,
+            'metadata' => null,
+            'connected_at' => null,
+        ]);
+    }
+
+    /**
+     * A source authenticating with a token typed in by hand rather than a
+     * GitHub App installation.
+     */
+    public function withToken(string $token = 'github_pat_source'): static
+    {
+        return $this->state(fn (): array => [
+            'installation_id' => null,
+            'token' => $token,
+        ]);
+    }
+}

--- a/database/migrations/2026_08_07_000000_create_sources_table.php
+++ b/database/migrations/2026_08_07_000000_create_sources_table.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sources', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('provider')->index();
+
+            // Only set for self-hosted instances (GitHub Enterprise); null
+            // means the provider's public API.
+            $table->string('base_url')->nullable();
+
+            // The owner whose repositories this source reaches — a GitHub org
+            // or user login. Packages are matched to a source by this value,
+            // so one source per owner.
+            $table->string('account')->nullable();
+            $table->string('account_type')->nullable();
+
+            // Set by the GitHub App install callback. With it we can mint
+            // short-lived installation tokens on demand and never store a
+            // long-lived credential.
+            $table->unsignedBigInteger('installation_id')->nullable();
+
+            // Manual fallback for instances with no GitHub App registered.
+            $table->text('token')->nullable();
+
+            $table->json('metadata')->nullable();
+            $table->timestamp('connected_at')->nullable();
+            $table->text('connection_error')->nullable();
+            $table->timestamps();
+
+            // A given installation may only be claimed by one source, so a
+            // second "Connect" onto the same installation is rejected by the
+            // database rather than silently splitting packages across rows.
+            $table->unique(['provider', 'installation_id']);
+            $table->unique(['provider', 'account']);
+        });
+
+        Schema::table('packages', function (Blueprint $table) {
+            $table->foreignId('source_id')
+                ->nullable()
+                ->after('id')
+                // Deleting a source leaves its packages in place; they fall
+                // back to their own token or GITHUB_TOKEN until relinked.
+                ->constrained()
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('packages', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('source_id');
+        });
+
+        Schema::dropIfExists('sources');
+    }
+};

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -1,0 +1,91 @@
+# Connecting GitHub sources
+
+A **source** is a connected GitHub account — an organisation or user — that
+packages are pulled from. Packages under that account authenticate through the
+source, so no repository needs a token of its own.
+
+Sources authenticate with a **GitHub App** rather than a personal access token.
+An installed app issues tokens that expire after an hour and only reach the
+repositories chosen at install time, and it belongs to the organisation rather
+than to a person, so access does not disappear when someone leaves.
+
+## 1. Register the app
+
+Once per deployment, at **Settings → Developer settings → GitHub Apps → New
+GitHub App** (on the organisation that will own it):
+
+| Field | Value |
+| --- | --- |
+| GitHub App name | e.g. `Acme Package Pipeline` |
+| Homepage URL | your `APP_URL` |
+| Setup URL | `<APP_URL>/sources/github/callback` |
+| Redirect on update | ✅ checked |
+| Webhook | uncheck **Active** (not used yet) |
+
+Repository permissions — read-only is enough for syncing and serving dists:
+
+- **Contents**: Read-only
+- **Metadata**: Read-only (mandatory)
+
+Then **Generate a private key** and download the `.pem`.
+
+## 2. Configure this app
+
+Two values, both on the app's settings page:
+
+```dotenv
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY=/secure/path/acme-package-pipeline.private-key.pem
+```
+
+These identify *this registry* to GitHub — the equivalent of an OAuth
+`client_id` and `client_secret`. They are set once by whoever runs the app, and
+are what make the one-click **Connect** flow possible; connecting an account
+after that needs nothing typed.
+
+`GITHUB_APP_PRIVATE_KEY` also accepts the key inline, with its newlines escaped
+as `\n`, which is what platforms that only take single-line secrets need:
+
+```dotenv
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\n-----END RSA PRIVATE KEY-----\n"
+```
+
+The app's slug (the `github.com/apps/<slug>` part) is read from GitHub and
+cached, so it needs no configuration. Set `GITHUB_APP_SLUG` only to skip that
+lookup, or if you rename the app and do not want to wait out the cache.
+
+## 3. Connect a source
+
+In the admin: **Sources → Connect GitHub account**. There is no form — GitHub
+asks which account to install onto and which repositories to share, and the
+source is created from what it hands back: the account, its type, and the
+repository count. Connecting an account that already has a source updates that
+one instead of adding a second.
+
+Until the app is registered the button is disabled and says why; **Add
+manually** is the token-based fallback described at the end of this page.
+
+Connecting also claims any package already pointing at that account, so sources
+can be added after the packages they cover.
+
+**Test connection** re-checks the credentials and refreshes the reachable
+repository count. **Disconnect** drops the stored credentials but keeps the
+source and its package links intact — revoking access on GitHub's side is a
+separate uninstall from the organisation's settings.
+
+## Without a GitHub App
+
+Use **Sources → Add manually**. A source can instead hold a fine-grained
+personal access token with read access to Contents and Metadata: fill in
+**Organisation or user** and **Access token**, then run **Test connection**.
+This is the fallback for GitHub Enterprise instances or where registering an app
+is not possible; the token has to be rotated by hand before it expires.
+
+## How a package picks its credential
+
+1. Its connected source, if it has one.
+2. Its own `token`, for repositories no source covers.
+3. `GITHUB_TOKEN`, as a last resort.
+
+A package with no source gets one attached on save when a connected source owns
+its repository URL. A source picked (or cleared) by hand is never overwritten.

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -33,6 +33,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 11 | Provider webhooks (auto-sync on push/tag/delete) | ❌ | — |
 | 12 | Queued batch imports with progress | 🟡 | — |
 | 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | 🟡 | — |
+| 13a | Sources with GitHub App auth + package bridging | ✅ | — |
 | 14 | Source project browser + one-click package onboarding | ❌ | 13 |
 | 15 | Download statistics + dashboard | ❌ | 2 |
 | 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ❌ | 9 |
@@ -342,6 +343,15 @@ In this Laravel app, move package syncing onto queued job batches:
 5. Ensure queue + batches tables exist (php artisan queue:batches-table if needed). Tests with
    Bus::fake and a small fake ref set exercising fan-out and failure isolation. Run tests.
 ```
+
+## 13a. Sources with GitHub App auth — implemented
+
+The `Source` model, its Filament resource, and the GitHub App install handshake are built; see
+[github-app.md](github-app.md). A source holds one GitHub owner and mints short-lived installation
+tokens, packages under that owner are linked to it on save, and `GitHubClient::for()` resolves
+source → package token → `GITHUB_TOKEN`. The provider is an enum (`App\Enums\SourceProvider`) but
+only GitHub is implemented — item 13 below is the remaining work: extracting a `SourceClient`
+contract and adding GitLab/Gitea/Bitbucket behind it.
 
 ## 13. Multi-provider source abstraction
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ComposerRepositoryController;
+use App\Http\Controllers\SourceConnectionController;
 use Illuminate\Support\Facades\Route;
 
 // The app is administered entirely through Filament, so the root URL lands on
@@ -18,3 +19,18 @@ Route::get('/p2/{vendor}/{package}.json', [ComposerRepositoryController::class, 
     ->name('composer.metadata');
 Route::get('/dist/{vendor}/{package}/{reference}.zip', [ComposerRepositoryController::class, 'dist'])
     ->name('composer.dist');
+
+// The GitHub App install handshake for connecting a source. Both legs are
+// admin-only: the callback attaches an installation to a source, so it must
+// never be reachable by an anonymous request. Register the app's "Setup URL"
+// as <this-app's-url>/sources/github/callback.
+Route::middleware('auth')->group(function () {
+    Route::get('/sources/github/callback', [SourceConnectionController::class, 'callback'])
+        ->name('sources.github.callback');
+    // Connecting an account that has no source yet; the source is created from
+    // the installation GitHub hands back.
+    Route::get('/sources/connect', [SourceConnectionController::class, 'connectNew'])
+        ->name('sources.connect.new');
+    Route::get('/sources/{source}/connect', [SourceConnectionController::class, 'connect'])
+        ->name('sources.connect');
+});

--- a/tests/Feature/SourceConnectionTest.php
+++ b/tests/Feature/SourceConnectionTest.php
@@ -170,6 +170,54 @@ class SourceConnectionTest extends TestCase
         $this->assertSame(99, $held->fresh()->installation_id);
     }
 
+    public function test_reconnecting_onto_a_different_account_than_the_source_holds_is_refused(): void
+    {
+        // The admin picked the wrong organisation on the GitHub install screen.
+        $this->fakeInstallation('someone-else');
+
+        $source = Source::factory()->disconnected()->create(['name' => 'Acme', 'account' => 'acme']);
+        $package = Package::factory()->create([
+            'source_id' => $source->id,
+            'repository' => 'https://github.com/acme/widgets',
+        ]);
+
+        $this->get(route('sources.connect', $source));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $source->refresh();
+
+        // Nothing was re-credentialled, so the linked packages still resolve.
+        $this->assertNull($source->installation_id);
+        $this->assertSame('acme', $source->account);
+        $this->assertFalse($source->isConnected());
+        $this->assertSame($source->id, $package->fresh()->source_id);
+        $this->assertDatabaseCount('sources', 1);
+    }
+
+    public function test_reconnecting_the_same_account_in_a_different_case_is_allowed(): void
+    {
+        $this->fakeInstallation('ACME');
+
+        $source = Source::factory()->disconnected()->create(['account' => 'acme']);
+
+        $this->get(route('sources.connect', $source));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $source->refresh();
+
+        $this->assertSame(42, $source->installation_id);
+        $this->assertSame('ACME', $source->account);
+        $this->assertTrue($source->isConnected());
+    }
+
     public function test_both_legs_of_the_handshake_require_authentication(): void
     {
         $this->fakeInstallation();

--- a/tests/Feature/SourceConnectionTest.php
+++ b/tests/Feature/SourceConnectionTest.php
@@ -1,0 +1,317 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\SourceProvider;
+use App\Models\Package;
+use App\Models\Source;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SourceConnectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($key, $pem);
+
+        config()->set('services.github.app', [
+            'id' => '123456',
+            'slug' => 'acme-pipeline',
+            'private_key' => $pem,
+            'api_url' => 'https://api.github.com',
+        ]);
+
+        // A request this suite forgot to fake must fail, not reach GitHub.
+        Http::preventStrayRequests();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    private function fakeInstallation(string $account = 'acme'): void
+    {
+        Http::fake([
+            'api.github.com/app/installations/42/access_tokens' => Http::response([
+                'token' => 'ghs_installation',
+                'expires_at' => now()->addHour()->toIso8601String(),
+            ]),
+            'api.github.com/app/installations/42' => Http::response([
+                'account' => ['login' => $account, 'type' => 'Organization'],
+                'app_slug' => 'acme-pipeline',
+                'repository_selection' => 'selected',
+            ]),
+            'api.github.com/installation/repositories*' => Http::response(['total_count' => 4]),
+        ]);
+    }
+
+    public function test_connect_redirects_to_the_github_install_screen(): void
+    {
+        $source = Source::factory()->disconnected()->create();
+
+        $response = $this->get(route('sources.connect', $source));
+
+        $response->assertRedirectContains('https://github.com/apps/acme-pipeline/installations/new');
+        $response->assertSessionHas('sources.github.pending');
+    }
+
+    public function test_the_app_slug_is_read_from_github_when_it_is_not_configured(): void
+    {
+        // Only the id and key are set; the slug is what builds the install URL.
+        config()->set('services.github.app.slug', null);
+
+        Http::fake(['api.github.com/app' => Http::response(['id' => 123456, 'slug' => 'derived-slug'])]);
+
+        $source = Source::factory()->disconnected()->create();
+
+        $this->get(route('sources.connect', $source))
+            ->assertRedirectContains('https://github.com/apps/derived-slug/installations/new');
+    }
+
+    public function test_the_derived_slug_is_only_looked_up_once(): void
+    {
+        config()->set('services.github.app.slug', null);
+
+        Http::fake(['api.github.com/app' => Http::response(['slug' => 'derived-slug'])]);
+
+        $source = Source::factory()->disconnected()->create();
+
+        $this->get(route('sources.connect', $source));
+        $this->get(route('sources.connect', $source));
+
+        Http::assertSentCount(1);
+    }
+
+    public function test_connecting_with_no_source_creates_one_from_the_installation(): void
+    {
+        $this->fakeInstallation('acme');
+
+        // Nothing exists and nothing was typed — just the button.
+        $this->assertDatabaseCount('sources', 0);
+
+        $this->get(route('sources.connect.new'))
+            ->assertRedirectContains('https://github.com/apps/acme-pipeline/installations/new');
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'setup_action' => 'install',
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $source = Source::sole();
+
+        $this->assertSame('acme', $source->name);
+        $this->assertSame('acme', $source->account);
+        $this->assertSame('Organization', $source->account_type);
+        $this->assertSame(42, $source->installation_id);
+        $this->assertSame(SourceProvider::Github, $source->provider);
+        $this->assertTrue($source->isConnected());
+    }
+
+    public function test_connecting_an_account_that_already_has_a_source_reuses_it(): void
+    {
+        $this->fakeInstallation('acme');
+
+        // Added by hand before the app existed.
+        $existing = Source::factory()->disconnected()->create(['name' => 'Acme', 'account' => 'ACME']);
+
+        $this->get(route('sources.connect.new'));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $this->assertDatabaseCount('sources', 1);
+        $this->assertSame($existing->id, Source::sole()->id);
+        $this->assertSame(42, $existing->fresh()->installation_id);
+        // The name the admin chose is kept.
+        $this->assertSame('Acme', $existing->fresh()->name);
+    }
+
+    public function test_a_created_source_name_does_not_collide_with_an_existing_one(): void
+    {
+        $this->fakeInstallation('acme');
+
+        // Same name, different account — so it is not the same source.
+        Source::factory()->create(['name' => 'acme', 'account' => 'someone-else']);
+
+        $this->get(route('sources.connect.new'));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $this->assertSame('acme (2)', Source::query()->where('account', 'acme')->sole()->name);
+    }
+
+    public function test_reconnecting_onto_an_account_another_source_holds_is_refused(): void
+    {
+        $this->fakeInstallation('acme');
+
+        $held = Source::factory()->create(['name' => 'Acme', 'account' => 'acme', 'installation_id' => 99]);
+        $other = Source::factory()->disconnected()->create(['name' => 'Spare', 'account' => null]);
+
+        $this->get(route('sources.connect', $other));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $this->assertNull($other->fresh()->installation_id);
+        $this->assertSame(99, $held->fresh()->installation_id);
+    }
+
+    public function test_both_legs_of_the_handshake_require_authentication(): void
+    {
+        $this->fakeInstallation();
+
+        $source = Source::factory()->disconnected()->create();
+
+        Auth::logout();
+        $this->flushSession();
+
+        $this->assertGuest();
+
+        $this->get(route('sources.connect', $source))->assertRedirect('/admin/login');
+        $this->get(route('sources.github.callback', ['installation_id' => 42]))->assertRedirect('/admin/login');
+
+        // An anonymous callback must never be able to attach an installation.
+        $this->assertNull($source->fresh()->installation_id);
+        Http::assertNothingSent();
+    }
+
+    public function test_the_callback_records_the_installation_and_verifies_it(): void
+    {
+        $this->fakeInstallation();
+
+        $source = Source::factory()->disconnected()->create(['account' => null]);
+
+        $this->get(route('sources.connect', $source));
+
+        $state = session('sources.github.pending')['state'];
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'setup_action' => 'install',
+            'state' => $state,
+        ]))->assertRedirect();
+
+        $source->refresh();
+
+        $this->assertSame(42, $source->installation_id);
+        $this->assertSame('acme', $source->account);
+        $this->assertSame('Organization', $source->account_type);
+        $this->assertSame('selected', $source->metadata['repository_selection']);
+        $this->assertSame(4, $source->metadata['repository_count']);
+        $this->assertTrue($source->isConnected());
+    }
+
+    public function test_connecting_claims_packages_already_pointing_at_the_account(): void
+    {
+        $this->fakeInstallation();
+
+        // Added before the source existed, so auto-linking on save found
+        // nothing to attach.
+        $mine = Package::factory()->create(['repository' => 'https://github.com/ACME/widgets']);
+        $theirs = Package::factory()->create(['repository' => 'https://github.com/other/widgets']);
+        $broken = Package::factory()->create(['repository' => 'not-a-repository-url']);
+
+        $source = Source::factory()->disconnected()->create(['account' => null]);
+
+        $this->get(route('sources.connect', $source));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $this->assertSame($source->id, $mine->fresh()->source_id);
+        $this->assertNull($theirs->fresh()->source_id);
+        $this->assertNull($broken->fresh()->source_id);
+    }
+
+    public function test_a_callback_with_a_mismatched_state_is_rejected(): void
+    {
+        $this->fakeInstallation();
+
+        $source = Source::factory()->disconnected()->create();
+
+        $this->get(route('sources.connect', $source));
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => 'forged-state',
+        ]))->assertRedirect();
+
+        $this->assertNull($source->fresh()->installation_id);
+        Http::assertNothingSent();
+    }
+
+    public function test_a_callback_with_no_pending_connection_is_rejected(): void
+    {
+        $this->fakeInstallation();
+
+        $this->get(route('sources.github.callback', [
+            'installation_id' => 42,
+            'state' => 'anything',
+        ]))->assertRedirect();
+
+        Http::assertNothingSent();
+        $this->assertDatabaseCount('sources', 0);
+    }
+
+    public function test_the_state_cannot_be_replayed(): void
+    {
+        $this->fakeInstallation();
+
+        $source = Source::factory()->disconnected()->create(['account' => null]);
+
+        $this->get(route('sources.connect', $source));
+        $state = session('sources.github.pending')['state'];
+
+        $this->get(route('sources.github.callback', ['installation_id' => 42, 'state' => $state]));
+
+        $other = Source::factory()->disconnected()->create();
+
+        // A second callback carrying the same state finds nothing pending, so
+        // it cannot attach the installation anywhere.
+        $this->get(route('sources.github.callback', ['installation_id' => 99, 'state' => $state]));
+
+        $this->assertNull($other->fresh()->installation_id);
+    }
+
+    public function test_a_cancelled_install_leaves_the_source_untouched(): void
+    {
+        $source = Source::factory()->disconnected()->create();
+
+        $this->get(route('sources.connect', $source));
+
+        $this->get(route('sources.github.callback', [
+            'state' => session('sources.github.pending')['state'],
+        ]))->assertRedirect();
+
+        $this->assertNull($source->fresh()->installation_id);
+        $this->assertFalse($source->fresh()->isConnected());
+    }
+
+    public function test_connect_reports_a_missing_app_configuration(): void
+    {
+        // The key is what makes an app usable; the slug is derived from it.
+        config()->set('services.github.app.private_key', null);
+
+        $source = Source::factory()->disconnected()->create();
+
+        $this->get(route('sources.connect', $source))
+            ->assertRedirect()
+            ->assertSessionMissing('sources.github.pending');
+    }
+}

--- a/tests/Feature/SourceResourceTest.php
+++ b/tests/Feature/SourceResourceTest.php
@@ -99,7 +99,49 @@ class SourceResourceTest extends TestCase
                 'account' => 'acme',
             ])
             ->call('create')
-            ->assertHasFormErrors(['name']);
+            ->assertHasFormErrors(['name', 'account']);
+    }
+
+    public function test_an_account_already_held_by_another_source_is_refused(): void
+    {
+        Source::factory()->create(['name' => 'Acme', 'account' => 'acme']);
+
+        Livewire::test(CreateSource::class)
+            ->fillForm([
+                'name' => 'Acme spare',
+                'provider' => SourceProvider::Github->value,
+                // GitHub logins are case insensitive, so this is the same owner.
+                'account' => 'ACME',
+            ])
+            ->call('create')
+            ->assertHasFormErrors(['account']);
+
+        $this->assertDatabaseCount('sources', 1);
+    }
+
+    public function test_a_source_can_be_saved_without_colliding_with_its_own_account(): void
+    {
+        $source = Source::factory()->create(['name' => 'Acme', 'account' => 'acme']);
+
+        Livewire::test(EditSource::class, ['record' => $source->getKey()])
+            ->fillForm(['name' => 'Acme engineering'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertSame('Acme engineering', $source->fresh()->name);
+    }
+
+    public function test_editing_a_source_onto_another_sources_account_is_refused(): void
+    {
+        Source::factory()->create(['name' => 'Acme', 'account' => 'acme']);
+        $other = Source::factory()->create(['name' => 'Spare', 'account' => 'spare']);
+
+        Livewire::test(EditSource::class, ['record' => $other->getKey()])
+            ->fillForm(['account' => 'acme'])
+            ->call('save')
+            ->assertHasFormErrors(['account']);
+
+        $this->assertSame('spare', $other->fresh()->account);
     }
 
     public function test_the_stored_token_is_never_sent_to_the_browser(): void

--- a/tests/Feature/SourceResourceTest.php
+++ b/tests/Feature/SourceResourceTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\SourceProvider;
+use App\Filament\Resources\Packages\Pages\EditPackage;
+use App\Filament\Resources\Sources\Pages\CreateSource;
+use App\Filament\Resources\Sources\Pages\EditSource;
+use App\Filament\Resources\Sources\Pages\ListSources;
+use App\Filament\Resources\Sources\Pages\ViewSource;
+use App\Filament\Resources\Sources\RelationManagers\PackagesRelationManager;
+use App\Models\Package;
+use App\Models\Source;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class SourceResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->create());
+    }
+
+    private function configureGitHubApp(): void
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($key, $pem);
+
+        config()->set('services.github.app', [
+            'id' => '123456',
+            'slug' => 'acme-pipeline',
+            'private_key' => $pem,
+            'api_url' => 'https://api.github.com',
+        ]);
+    }
+
+    public function test_the_index_offers_connecting_without_creating_a_record_first(): void
+    {
+        $this->configureGitHubApp();
+
+        Livewire::test(ListSources::class)
+            ->assertActionExists('connectGithub')
+            ->assertActionEnabled('connectGithub')
+            ->assertSee(route('sources.connect.new'));
+    }
+
+    public function test_connecting_is_disabled_when_no_github_app_is_registered(): void
+    {
+        config()->set('services.github.app', ['id' => null, 'slug' => null, 'private_key' => null]);
+
+        Livewire::test(ListSources::class)
+            ->assertActionExists('connectGithub')
+            ->assertActionDisabled('connectGithub');
+    }
+
+    public function test_the_source_index_lists_records(): void
+    {
+        $sources = Source::factory()->count(3)->create();
+
+        Livewire::test(ListSources::class)
+            ->assertCanSeeTableRecords($sources);
+    }
+
+    public function test_a_source_can_be_created(): void
+    {
+        Livewire::test(CreateSource::class)
+            ->fillForm([
+                'name' => 'Acme engineering',
+                'provider' => SourceProvider::Github->value,
+                'account' => 'acme',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('sources', [
+            'name' => 'Acme engineering',
+            'provider' => 'github',
+            'account' => 'acme',
+            'installation_id' => null,
+            'connected_at' => null,
+        ]);
+    }
+
+    public function test_the_source_name_and_account_must_be_unique(): void
+    {
+        Source::factory()->create(['name' => 'Acme', 'account' => 'acme']);
+
+        Livewire::test(CreateSource::class)
+            ->fillForm([
+                'name' => 'Acme',
+                'provider' => SourceProvider::Github->value,
+                'account' => 'acme',
+            ])
+            ->call('create')
+            ->assertHasFormErrors(['name']);
+    }
+
+    public function test_the_stored_token_is_never_sent_to_the_browser(): void
+    {
+        $source = Source::factory()->withToken('github_pat_secret')->create();
+
+        Livewire::test(EditSource::class, ['record' => $source->getKey()])
+            ->assertFormSet(['token' => null])
+            ->assertDontSee('github_pat_secret');
+    }
+
+    public function test_saving_without_a_new_token_keeps_the_existing_one(): void
+    {
+        $source = Source::factory()->withToken('github_pat_secret')->create();
+
+        Livewire::test(EditSource::class, ['record' => $source->getKey()])
+            ->fillForm(['name' => 'Renamed'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $source->refresh();
+
+        $this->assertSame('Renamed', $source->name);
+        $this->assertSame('github_pat_secret', $source->token);
+    }
+
+    public function test_the_view_page_shows_the_source(): void
+    {
+        $source = Source::factory()->create(['account' => 'acme']);
+
+        Livewire::test(ViewSource::class, ['record' => $source->getKey()])
+            ->assertOk()
+            ->assertSee($source->account)
+            ->assertSee('GitHub App installation #'.$source->installation_id);
+    }
+
+    public function test_the_view_page_lists_the_packages_bridged_through_the_source(): void
+    {
+        $source = Source::factory()->create(['account' => 'acme']);
+        $mine = Package::factory()->create(['repository' => 'https://github.com/acme/widgets']);
+        $theirs = Package::factory()->create(['repository' => 'https://github.com/other/widgets']);
+
+        Livewire::test(PackagesRelationManager::class, [
+            'ownerRecord' => $source,
+            'pageClass' => ViewSource::class,
+        ])
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$theirs]);
+    }
+
+    public function test_the_test_connection_action_records_the_result(): void
+    {
+        Http::fake([
+            'api.github.com/orgs/acme/repos*' => Http::response([
+                ['full_name' => 'acme/widgets'],
+            ]),
+        ]);
+
+        $source = Source::factory()->withToken()->create(['account' => 'acme']);
+        $source->forceFill(['connected_at' => null, 'connection_error' => 'stale failure'])->save();
+
+        Livewire::test(ViewSource::class, ['record' => $source->getKey()])
+            ->callAction('test');
+
+        $source->refresh();
+
+        $this->assertTrue($source->isConnected());
+        $this->assertNull($source->connection_error);
+        $this->assertSame(1, $source->metadata['repository_count']);
+    }
+
+    public function test_the_disconnect_action_clears_the_credentials(): void
+    {
+        $source = Source::factory()->withToken()->create();
+
+        Livewire::test(ViewSource::class, ['record' => $source->getKey()])
+            ->callAction('disconnect');
+
+        $source->refresh();
+
+        $this->assertNull($source->token);
+        $this->assertFalse($source->isConnected());
+    }
+
+    public function test_the_package_form_lists_every_source_and_flags_the_unconnected_ones(): void
+    {
+        $connected = Source::factory()->create(['name' => 'Acme']);
+        $pending = Source::factory()->disconnected()->create(['name' => 'Pending']);
+
+        $options = Source::options();
+
+        $this->assertSame('Acme (GitHub)', $options[$connected->id]);
+        $this->assertSame('Pending (GitHub) — not connected', $options[$pending->id]);
+    }
+
+    public function test_editing_a_package_keeps_a_link_to_a_disconnected_source(): void
+    {
+        $source = Source::factory()->disconnected()->create(['account' => 'acme']);
+        $package = Package::factory()->create([
+            'source_id' => $source->id,
+            'repository' => 'https://github.com/acme/widgets',
+        ]);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getKey()])
+            ->fillForm(['description' => 'Edited while the source is down.'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertSame($source->id, $package->fresh()->source_id);
+    }
+}

--- a/tests/Feature/SourceTest.php
+++ b/tests/Feature/SourceTest.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\Source;
+use App\Services\PackageSynchronizer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A throwaway RSA key, so the JWT signing path runs for real rather than
+     * being mocked around.
+     */
+    private static ?string $privateKey = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::$privateKey ??= $this->generatePrivateKey();
+
+        config()->set('services.github.app', [
+            'id' => '123456',
+            'slug' => 'acme-pipeline',
+            'private_key' => self::$privateKey,
+            'api_url' => 'https://api.github.com',
+        ]);
+
+        config()->set('services.github.token', null);
+
+        // A request this suite forgot to fake must fail, not reach GitHub.
+        Http::preventStrayRequests();
+    }
+
+    private function generatePrivateKey(): string
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+
+        openssl_pkey_export($key, $pem);
+
+        return $pem;
+    }
+
+    private function fakeInstallationToken(string $token = 'ghs_installation'): void
+    {
+        Http::fake([
+            'api.github.com/app/installations/*/access_tokens' => Http::response([
+                'token' => $token,
+                'expires_at' => now()->addHour()->toIso8601String(),
+            ]),
+        ]);
+    }
+
+    public function test_an_installed_source_mints_and_caches_an_installation_token(): void
+    {
+        $this->fakeInstallationToken();
+
+        $source = Source::factory()->create(['installation_id' => 42]);
+
+        $this->assertSame('ghs_installation', $source->accessToken());
+        $this->assertSame('ghs_installation', $source->accessToken());
+
+        // The second call came from the cache, so GitHub was only asked once.
+        Http::assertSentCount(1);
+    }
+
+    public function test_the_cached_installation_token_is_not_stored_in_the_clear(): void
+    {
+        $this->fakeInstallationToken();
+
+        $source = Source::factory()->create(['installation_id' => 42]);
+        $source->accessToken();
+
+        $cached = Cache::get('github-app.installation-token.42');
+
+        $this->assertNotNull($cached);
+        $this->assertStringNotContainsString('ghs_installation', $cached);
+    }
+
+    public function test_the_app_jwt_is_signed_with_the_configured_key(): void
+    {
+        $this->fakeInstallationToken();
+
+        Source::factory()->create(['installation_id' => 42])->accessToken();
+
+        Http::assertSent(function ($request): bool {
+            [$header, $payload, $signature] = explode('.', str_replace('Bearer ', '', $request->header('Authorization')[0]));
+
+            $claims = json_decode($this->base64UrlDecode($payload), true);
+
+            $this->assertSame('123456', $claims['iss']);
+            $this->assertLessThanOrEqual(600, $claims['exp'] - $claims['iat']);
+
+            $verified = openssl_verify(
+                "{$header}.{$payload}",
+                $this->base64UrlDecode($signature),
+                openssl_pkey_get_public(openssl_pkey_get_details(openssl_pkey_get_private(self::$privateKey))['key']),
+                OPENSSL_ALGO_SHA256,
+            );
+
+            return $verified === 1;
+        });
+    }
+
+    public function test_a_source_without_an_app_falls_back_to_its_own_token(): void
+    {
+        $source = Source::factory()->withToken('github_pat_abc')->create();
+
+        $this->assertSame('github_pat_abc', $source->accessToken());
+        $this->assertFalse($source->usesInstallation());
+    }
+
+    public function test_a_missing_app_configuration_is_reported_clearly(): void
+    {
+        config()->set('services.github.app.private_key', null);
+
+        $source = Source::factory()->create(['installation_id' => 42]);
+
+        $this->expectExceptionMessage('No GitHub App is configured');
+
+        $source->accessToken();
+    }
+
+    public function test_a_private_key_can_be_given_as_a_file_path(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'gh-key-');
+        file_put_contents($path, self::$privateKey);
+
+        config()->set('services.github.app.private_key', $path);
+
+        $this->fakeInstallationToken();
+
+        try {
+            $this->assertSame(
+                'ghs_installation',
+                Source::factory()->create(['installation_id' => 42])->accessToken(),
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function test_a_package_authenticates_through_its_source(): void
+    {
+        $this->fakeInstallationToken();
+
+        $source = Source::factory()->create(['account' => 'acme', 'installation_id' => 42]);
+        $package = Package::factory()->create([
+            'source_id' => $source->id,
+            'repository' => 'https://github.com/acme/widgets',
+            'token' => 'ghp_package_level',
+        ]);
+
+        // The source wins over the package's own token.
+        $this->assertSame('ghs_installation', $package->accessToken());
+    }
+
+    public function test_a_package_without_a_source_uses_its_own_token_then_the_env_fallback(): void
+    {
+        $package = Package::factory()->create([
+            'repository' => 'https://gitlab.com/acme/widgets',
+            'token' => 'ghp_package_level',
+        ]);
+
+        $this->assertNull($package->source_id);
+        $this->assertSame('ghp_package_level', $package->accessToken());
+
+        config()->set('services.github.token', 'ghp_env');
+        $package->forceFill(['token' => null])->save();
+
+        $this->assertSame('ghp_env', $package->fresh()->accessToken());
+    }
+
+    public function test_a_new_package_is_linked_to_the_source_owning_its_repository(): void
+    {
+        $source = Source::factory()->create(['account' => 'Acme']);
+
+        $package = Package::factory()->create(['repository' => 'https://github.com/acme/widgets']);
+
+        // Matched case insensitively, as GitHub logins are.
+        $this->assertSame($source->id, $package->source_id);
+    }
+
+    public function test_a_package_under_an_unconnected_owner_stays_unlinked(): void
+    {
+        Source::factory()->create(['account' => 'acme']);
+
+        $package = Package::factory()->create(['repository' => 'https://github.com/other/widgets']);
+
+        $this->assertNull($package->source_id);
+    }
+
+    public function test_a_source_chosen_by_hand_is_not_overwritten(): void
+    {
+        $owner = Source::factory()->create(['account' => 'acme']);
+        $chosen = Source::factory()->create(['account' => 'mirror']);
+
+        $package = Package::factory()->create([
+            'source_id' => $chosen->id,
+            'repository' => 'https://github.com/acme/widgets',
+        ]);
+
+        $this->assertSame($chosen->id, $package->source_id);
+        $this->assertNotSame($owner->id, $package->source_id);
+    }
+
+    public function test_clearing_a_source_by_hand_survives_a_later_save(): void
+    {
+        Source::factory()->create(['account' => 'acme']);
+
+        $package = Package::factory()->create(['repository' => 'https://github.com/acme/widgets']);
+        $this->assertNotNull($package->source_id);
+
+        $package->forceFill(['source_id' => null])->save();
+        $package->update(['description' => 'Still unlinked.']);
+
+        $this->assertNull($package->fresh()->source_id);
+    }
+
+    public function test_an_unparseable_repository_does_not_break_saving(): void
+    {
+        Source::factory()->create(['account' => 'acme']);
+
+        $package = Package::factory()->create(['repository' => 'not-a-repository-url']);
+
+        $this->assertNull($package->source_id);
+    }
+
+    public function test_deleting_a_source_leaves_its_packages_in_place(): void
+    {
+        $source = Source::factory()->create(['account' => 'acme']);
+        $package = Package::factory()->create(['repository' => 'https://github.com/acme/widgets']);
+
+        $source->delete();
+
+        $this->assertNull($package->fresh()->source_id);
+        $this->assertNotNull($package->fresh());
+    }
+
+    public function test_syncing_uses_the_source_credential_and_base_url(): void
+    {
+        Http::fake([
+            'api.github.com/app/installations/*/access_tokens' => Http::response([
+                'token' => 'ghs_installation',
+                'expires_at' => now()->addHour()->toIso8601String(),
+            ]),
+            'github.acme.test/api/v3/repos/acme/widgets/tags*' => Http::response([
+                ['name' => 'v1.0.0', 'commit' => ['sha' => str_repeat('a', 40)]],
+            ]),
+            'github.acme.test/api/v3/repos/acme/widgets/branches*' => Http::response([]),
+            'github.acme.test/api/v3/repos/acme/widgets/contents/composer.json*' => Http::response([
+                'name' => 'acme/widgets',
+                'type' => 'library',
+            ]),
+        ]);
+
+        $source = Source::factory()->create([
+            'account' => 'acme',
+            'installation_id' => 42,
+            'base_url' => 'https://github.acme.test/api/v3',
+        ]);
+
+        $package = Package::factory()->unreleased()->create([
+            'repository' => 'https://github.com/acme/widgets',
+        ]);
+
+        $this->assertSame($source->id, $package->source_id);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $this->assertSame('v1.0.0', $package->fresh()->latest_version);
+
+        // Every repository call went to the source's own host, carrying the
+        // installation token rather than any package-level credential.
+        Http::assertSent(fn ($request): bool => str_starts_with($request->url(), 'https://github.acme.test/api/v3/repos/')
+            && $request->header('Authorization') === ['Bearer ghs_installation']);
+    }
+
+    public function test_verify_records_the_reachable_repository_count(): void
+    {
+        Http::fake([
+            'api.github.com/app/installations/42/access_tokens' => Http::response([
+                'token' => 'ghs_installation',
+                'expires_at' => now()->addHour()->toIso8601String(),
+            ]),
+            'api.github.com/app/installations/42' => Http::response([
+                'account' => ['login' => 'acme', 'type' => 'Organization'],
+                'repository_selection' => 'selected',
+            ]),
+            'api.github.com/installation/repositories*' => Http::response(['total_count' => 7]),
+        ]);
+
+        $source = Source::factory()->disconnected()->create(['account' => null]);
+        $source->forceFill(['installation_id' => 42])->save();
+
+        $this->assertSame(7, $source->verify());
+
+        $source->refresh();
+
+        $this->assertSame('acme', $source->account);
+        $this->assertSame('Organization', $source->account_type);
+        $this->assertSame(7, $source->metadata['repository_count']);
+        $this->assertNotNull($source->connected_at);
+        $this->assertNull($source->connection_error);
+    }
+
+    public function test_a_failing_verify_records_the_reason_and_marks_the_source_disconnected(): void
+    {
+        Http::fake([
+            'api.github.com/app/installations/42/access_tokens' => Http::response(
+                ['message' => 'Bad credentials'],
+                401,
+            ),
+        ]);
+
+        $source = Source::factory()->create(['installation_id' => 42]);
+
+        try {
+            $source->verify();
+            $this->fail('verify() should have thrown.');
+        } catch (\Throwable) {
+            // Expected — the recorded state is what matters.
+        }
+
+        $source->refresh();
+
+        $this->assertNull($source->connected_at);
+        $this->assertNotNull($source->connection_error);
+        $this->assertFalse($source->isConnected());
+    }
+
+    public function test_verify_falls_back_to_the_user_endpoint_for_a_personal_account(): void
+    {
+        Http::fake([
+            'api.github.com/orgs/acme/repos*' => Http::response(['message' => 'Not Found'], 404),
+            'api.github.com/users/acme/repos*' => Http::response([
+                ['full_name' => 'acme/widgets'],
+                ['full_name' => 'acme/billing'],
+            ]),
+        ]);
+
+        $source = Source::factory()->withToken()->create(['account' => 'acme']);
+
+        $this->assertSame(2, $source->verify());
+    }
+
+    public function test_disconnecting_drops_the_credentials_but_keeps_the_packages(): void
+    {
+        $this->fakeInstallationToken();
+
+        $source = Source::factory()->create(['account' => 'acme', 'installation_id' => 42]);
+        $package = Package::factory()->create(['repository' => 'https://github.com/acme/widgets']);
+        $source->accessToken();
+
+        $source->disconnect();
+
+        $this->assertNull($source->installation_id);
+        $this->assertNull($source->connected_at);
+        $this->assertNull(Cache::get('github-app.installation-token.42'));
+        $this->assertSame($source->id, $package->fresh()->source_id);
+    }
+
+    public function test_the_sync_command_can_be_narrowed_to_one_source(): void
+    {
+        Source::factory()->create(['name' => 'Acme', 'account' => 'acme']);
+        Source::factory()->create(['name' => 'Other', 'account' => 'other']);
+
+        Package::factory()->create(['name' => 'acme/widgets', 'repository' => 'https://github.com/acme/widgets']);
+        Package::factory()->create(['name' => 'other/widgets', 'repository' => 'https://github.com/other/widgets']);
+
+        // Both syncs fail against the un-faked API; what is asserted here is
+        // which packages the filter selected, not the sync outcome.
+        Http::fake(['*' => Http::response([], 500)]);
+
+        $this->artisan('packages:sync', ['--source' => 'acme'])
+            ->expectsOutputToContain('acme/widgets')
+            ->doesntExpectOutputToContain('other/widgets')
+            ->assertFailed();
+    }
+
+    private function base64UrlDecode(string $value): string
+    {
+        return base64_decode(strtr($value, '-_', '+/'));
+    }
+}


### PR DESCRIPTION
Introduces a Source model representing a connected GitHub account (org or user). Packages under a source's owner authenticate through it via short-lived GitHub App installation tokens rather than long-lived per-package tokens.

Key changes:
- Source model, migration, factory, and Filament resource (list/view/create/edit)
- GitHubApp service minting and caching encrypted installation tokens via JWT
- GitHub App install handshake (connect/callback routes + SourceConnectionController)
- Packages auto-link to a matching source on save; manual overrides are preserved
- Package.accessToken() / apiUrl() resolve source → package token → GITHUB_TOKEN
- GitHubClient.for() uses the new resolution chain and supports a custom API base URL
- --source filter added to packages:sync command
- Feature tests covering the handshake, source CRUD, token resolution, and sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (GitHub App JWT, encrypted tokens, OAuth-style callback) and changes how all package sync/dist GitHub access is authorized.
> 
> **Overview**
> Adds **Sources** — connected GitHub org/user accounts — so packages under that owner sync and download through one credential instead of per-repo tokens.
> 
> Admins get a Filament **Sources** resource (connect via GitHub App install, manual token, test/disconnect) and package UI now shows/filters by source. **GitHub App** config (`GITHUB_APP_*`) drives JWT signing, encrypted cached installation tokens, and an auth-protected install callback with session `state` checks.
> 
> **Packages** gain optional `source_id`, auto-link to a source when the repository owner matches (only on new/changed repo URL; manual source choice is preserved), and resolve credentials as **source → package token → `GITHUB_TOKEN`**. `GitHubClient` and sync/dist flows use that chain plus per-source API base URLs (GHE). `packages:sync` adds `--source` to limit by source name/account.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e699338f4ede4c27e8716c1e5f4b916f7d28c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->