### PR TITLE
Implement Composer search/list endpoints and admin user management

### DIFF
--- a/app/Console/Commands/CreateAdmin.php
+++ b/app/Console/Commands/CreateAdmin.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password as PasswordRule;
+use Spatie\Permission\PermissionRegistrar;
 
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
@@ -98,6 +99,11 @@ class CreateAdmin extends Command
      */
     private function grantSuperAdmin(User $user): array
     {
+        // syncPermissions() resolves ids through Spatie's permission cache;
+        // if that cache predates the seeding of the permissions (easy to do
+        // in a hosted command runner), the sync throws rather than syncing.
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
         $role = Utils::createRole();
 
         // Scoped to the role's own guard: syncing a permission belonging to

--- a/app/Enums/WebhookCoverage.php
+++ b/app/Enums/WebhookCoverage.php
@@ -20,11 +20,11 @@ enum WebhookCoverage: string implements HasColor, HasLabel
     /** Covered by a hook created on the repository itself. */
     case Repository = 'repository';
 
-    /** The app would cover it, but no webhook secret is configured here. */
-    case Unconfigured = 'unconfigured';
-
     /** Creating the repository hook was attempted and failed. */
     case Failed = 'failed';
+
+    /** Switched off for this package: pushes are heard and ignored. */
+    case Disabled = 'disabled';
 
     /** No delivery path: pushes will not sync until one is set up. */
     case None = 'none';
@@ -34,8 +34,8 @@ enum WebhookCoverage: string implements HasColor, HasLabel
         return match ($this) {
             self::Application => 'GitHub App webhook',
             self::Repository => 'Repository webhook',
-            self::Unconfigured => 'Not configured',
             self::Failed => 'Not created',
+            self::Disabled => 'Off',
             self::None => 'None',
         };
     }
@@ -45,7 +45,8 @@ enum WebhookCoverage: string implements HasColor, HasLabel
         return match ($this) {
             self::Application, self::Repository => 'success',
             self::Failed => 'danger',
-            self::Unconfigured, self::None => 'warning',
+            self::Disabled => 'gray',
+            self::None => 'warning',
         };
     }
 

--- a/app/Enums/WebhookState.php
+++ b/app/Enums/WebhookState.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * What the GitHub App's own webhook is doing, as GitHub reports it.
+ *
+ * Distinct from `WebhookCoverage`, which is about one package. This is about
+ * the single webhook on the app, and it exists because "the secret is set in
+ * the environment" and "GitHub delivers here" are two different claims that
+ * used to be treated as one.
+ */
+enum WebhookState: string implements HasColor, HasLabel
+{
+    /** GitHub confirms the app posts to this registry. */
+    case Delivering = 'delivering';
+
+    /** The app has no webhook: it was registered with Active unchecked. */
+    case Absent = 'absent';
+
+    /** The app has a webhook, but it posts somewhere else — another environment. */
+    case Elsewhere = 'elsewhere';
+
+    /** No secret here, so a delivery could not be trusted even if it arrived. */
+    case NoSecret = 'no-secret';
+
+    /** Nothing to ask GitHub with, or GitHub could not be reached. */
+    case Unverifiable = 'unverifiable';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Delivering => 'Delivering here',
+            self::Absent => 'Not switched on',
+            self::Elsewhere => 'Pointing elsewhere',
+            self::NoSecret => 'No secret set',
+            self::Unverifiable => 'Configured, unverified',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Delivering => 'success',
+            self::Absent, self::NoSecret => 'warning',
+            self::Elsewhere => 'danger',
+            self::Unverifiable => 'gray',
+        };
+    }
+
+    /**
+     * What to do about it, or null when there is nothing to do.
+     */
+    public function remedy(string $url): ?string
+    {
+        return match ($this) {
+            self::Delivering => null,
+            self::Absent => 'The GitHub App has no webhook. On the app\'s settings page, tick Webhook → Active, set the payload URL below with content type application/json, paste the secret, '
+                .'and subscribe it to Push, Branch or tag creation, and Branch or tag deletion. Until then, packages get a webhook on their own repository instead.',
+            self::Elsewhere => "The app's webhook posts to {$url}, which is not this registry — another environment is using the same app. "
+                .'Register a separate app for this one, or accept that its packages each carry their own repository webhook.',
+            self::NoSecret => 'Set GITHUB_APP_WEBHOOK_SECRET to the secret on the app\'s webhook. Without it a delivery cannot be told from a forgery, so none are accepted.',
+            self::Unverifiable => 'A secret is set, but GitHub could not confirm the app\'s webhook just now. It is taken at its word until it can be checked again.',
+        };
+    }
+}

--- a/app/Filament/Resources/Packages/Pages/EditPackage.php
+++ b/app/Filament/Resources/Packages/Pages/EditPackage.php
@@ -2,10 +2,14 @@
 
 namespace App\Filament\Resources\Packages\Pages;
 
+use App\Enums\WebhookCoverage;
 use App\Filament\Resources\Packages\Actions\SyncPackageAction;
 use App\Filament\Resources\Packages\PackageResource;
+use App\Models\Package;
+use App\Services\GitHub\WebhookRegistrar;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 
 class EditPackage extends EditRecord
@@ -19,5 +23,41 @@ class EditPackage extends EditRecord
             ViewAction::make(),
             DeleteAction::make(),
         ];
+    }
+
+    /**
+     * Carry the auto-sync toggle through to GitHub.
+     *
+     * Only when it was the thing that changed: every other save — a renamed
+     * package, a corrected description — must not cost an API call, and must
+     * not retry a webhook that failed for a reason nobody has fixed yet.
+     */
+    protected function afterSave(): void
+    {
+        /** @var Package $package */
+        $package = $this->getRecord();
+
+        if (! $package->wasChanged('webhook_enabled')) {
+            return;
+        }
+
+        $coverage = app(WebhookRegistrar::class)->reconcile($package);
+
+        Notification::make()
+            ->status($coverage === WebhookCoverage::Failed ? 'warning' : 'success')
+            ->title(match ($coverage) {
+                WebhookCoverage::Disabled => 'Auto-sync switched off',
+                WebhookCoverage::Failed => 'Auto-sync is on, but the webhook could not be created',
+                default => 'Auto-sync switched on',
+            })
+            ->body(match ($coverage) {
+                WebhookCoverage::Disabled => "Pushes to {$package->repositoryPath()} will no longer sync this package, and its webhook has been removed from GitHub.",
+                WebhookCoverage::Application => 'Pushes are delivered through the GitHub App\'s webhook, so there was nothing to create.',
+                WebhookCoverage::Repository => "A webhook is set up on {$package->repositoryPath()}.",
+                WebhookCoverage::Failed => (string) app(WebhookRegistrar::class)->unmetRequirement($package),
+                WebhookCoverage::None => 'No webhook covers this repository yet.',
+            })
+            ->persistent($coverage === WebhookCoverage::Failed)
+            ->send();
     }
 }

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -2,11 +2,13 @@
 
 namespace App\Filament\Resources\Packages\Schemas;
 
+use App\Enums\WebhookCoverage;
 use App\Models\Package;
 use App\Models\Source;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Schema;
 
 /**
@@ -29,8 +31,32 @@ class PackageForm
                 self::token(),
                 self::latestVersion(),
                 self::type(),
+                self::webhookEnabled(),
                 self::description(),
             ]);
+    }
+
+    /**
+     * Whether pushes to the repository sync this package.
+     *
+     * Saving this on decides how the package is reached — a hook is created on
+     * the repository unless the GitHub App's webhook already covers it —
+     * and saving it off takes that hook back down. Deliveries that arrive
+     * anyway, through the app's account-wide webhook, are ignored for this
+     * package, so the switch means the same thing either way.
+     */
+    public static function webhookEnabled(): Toggle
+    {
+        return Toggle::make('webhook_enabled')
+            ->label('Sync automatically on push')
+            ->default(true)
+            ->helperText(fn (?Package $record): string => match (true) {
+                ! $record instanceof Package => 'A webhook is set up on the repository when the package is created, unless the GitHub App\'s webhook already covers it.',
+                $record->webhook_enabled => 'On. '.($record->webhookCoverage() === WebhookCoverage::Application
+                    ? 'Delivered through the GitHub App\'s webhook; turning this off stops this package syncing on push, and leaves the app\'s webhook alone.'
+                    : 'Turning this off removes the webhook from the repository.'),
+                default => 'Off — this package only syncs when asked. Turning it on sets the webhook up again.',
+            });
     }
 
     public static function name(): TextInput

--- a/app/Filament/Resources/Sources/Actions/RecheckWebhookAction.php
+++ b/app/Filament/Resources/Sources/Actions/RecheckWebhookAction.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Resources\Sources\Actions;
+
+use App\Enums\WebhookState;
+use App\Services\GitHub\GitHubApp;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+
+class RecheckWebhookAction
+{
+    /**
+     * Ask GitHub again what the app's webhook is doing.
+     *
+     * The answer is cached for a few minutes, which is right for a page that
+     * reports it on every load and wrong for the moment straight after
+     * switching the webhook on — which is exactly when someone wants to know
+     * whether it worked.
+     */
+    public static function make(): Action
+    {
+        return Action::make('recheckWebhook')
+            ->label('Re-check')
+            ->icon(Heroicon::OutlinedArrowPath)
+            ->color('gray')
+            ->action(function (): void {
+                $app = app(GitHubApp::class);
+
+                $app->forgetWebhookConfiguration();
+
+                $state = $app->webhookState();
+
+                Notification::make()
+                    ->status($state === WebhookState::Delivering ? 'success' : 'warning')
+                    ->title($state->getLabel())
+                    ->body($state->remedy((string) ($app->deliveringTo() ?? ''))
+                        ?? 'GitHub confirms the app posts to this registry. Pushes to any repository in this installation will sync their packages.')
+                    ->persistent($state !== WebhookState::Delivering)
+                    ->send();
+            });
+    }
+}

--- a/app/Filament/Resources/Sources/Schemas/SourceInfolist.php
+++ b/app/Filament/Resources/Sources/Schemas/SourceInfolist.php
@@ -2,8 +2,12 @@
 
 namespace App\Filament\Resources\Sources\Schemas;
 
+use App\Enums\WebhookState;
+use App\Filament\Resources\Sources\Actions\RecheckWebhookAction;
 use App\Models\Source;
+use App\Services\GitHub\GitHubApp;
 use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 
 class SourceInfolist
@@ -65,6 +69,53 @@ class SourceInfolist
                 TextEntry::make('updated_at')
                     ->dateTime()
                     ->placeholder('-'),
+                self::webhook(),
+            ]);
+    }
+
+    /**
+     * How pushes to this source's repositories get back here.
+     *
+     * This belongs on the source rather than on each package: the app's
+     * webhook is set up once and covers every repository in the installation,
+     * so a source that has just been connected is exactly where an admin is
+     * standing when it is worth doing — and where nothing else would mention
+     * it until a package quietly failed to sync itself.
+     */
+    private static function webhook(): Section
+    {
+        return Section::make('Auto-sync')
+            ->key('webhook')
+            ->visible(fn (Source $record): bool => $record->usesInstallation())
+            ->description('One webhook on the GitHub App covers every repository in every installation. Without it, each package carries a webhook on its own repository instead, which needs the app to have "Webhooks: Read and write".')
+            ->headerActions([RecheckWebhookAction::make()])
+            ->columnSpanFull()
+            ->schema([
+                TextEntry::make('webhook_status')
+                    ->label('GitHub App webhook')
+                    ->badge()
+                    // Asked of GitHub rather than inferred from this app's own
+                    // configuration: a secret set here says nothing about
+                    // whether the app was ever given a webhook to sign with it.
+                    ->state(fn (): WebhookState => app(GitHubApp::class)->webhookState())
+                    ->helperText(fn (): ?string => app(GitHubApp::class)->webhookState()
+                        ->remedy((string) (app(GitHubApp::class)->deliveringTo() ?? ''))),
+                TextEntry::make('webhook_url')
+                    ->label('Payload URL')
+                    ->state(fn (): string => app(GitHubApp::class)->webhookUrl())
+                    ->copyable()
+                    ->helperText('Set this as the webhook URL on the GitHub App, with content type application/json, and subscribe it to Push, Branch or tag creation, and Branch or tag deletion.'),
+                TextEntry::make('webhook_secret')
+                    ->label('Webhook secret')
+                    ->visible(fn (): bool => app(GitHubApp::class)->webhookState() === WebhookState::NoSecret)
+                    // Only ever a suggestion for a secret that is not set yet;
+                    // a configured one lives in the environment and is not
+                    // read back out to a browser.
+                    ->state(fn (): string => app(GitHubApp::class)->suggestedWebhookSecret())
+                    ->copyable()
+                    ->columnSpanFull()
+                    ->helperText(fn (): string => 'Not set yet — here is one to use. Paste it into the app\'s webhook secret field, and add it to this app\'s environment as GITHUB_APP_WEBHOOK_SECRET='
+                        .app(GitHubApp::class)->suggestedWebhookSecret().' — then restart or clear the config cache.'),
             ]);
     }
 }

--- a/app/Filament/Resources/Users/Pages/CreateUser.php
+++ b/app/Filament/Resources/Users/Pages/CreateUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Filament\Resources\Users\UserResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUser extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Filament/Resources/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/Users/Pages/EditUser.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Filament\Resources\Users\UserResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make()
+                // Deleting yourself while signed in is only ever a mistake.
+                ->hidden(fn (): bool => $this->getRecord()->is(auth()->user())),
+        ];
+    }
+}

--- a/app/Filament/Resources/Users/Pages/ListUsers.php
+++ b/app/Filament/Resources/Users/Pages/ListUsers.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Users\Pages;
+
+use App\Filament\Resources\Users\UserResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Users\Schemas;
+
+use App\Models\User;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Builder;
+
+class UserForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('email')
+                    ->email()
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true),
+                TextInput::make('password')
+                    ->password()
+                    ->revealable()
+                    ->maxLength(255)
+                    // The model's `hashed` cast does the hashing; an empty
+                    // input on edit keeps the current password.
+                    ->required(fn (string $operation): bool => $operation === 'create')
+                    ->dehydrated(fn (?string $state): bool => filled($state))
+                    ->placeholder(fn (string $operation): ?string => $operation === 'edit'
+                        ? 'Leave empty to keep the current password'
+                        : null),
+                Select::make('roles')
+                    // Roles are guarded; syncing through the bare relation
+                    // skips Spatie's guard check, so offer only matching ones.
+                    ->relationship('roles', 'name', fn (Builder $query): Builder => $query->where('guard_name', 'web'))
+                    ->multiple()
+                    ->preload()
+                    // Removing your own super_admin role is a lockout with
+                    // `admin:create` as the only way back; a disabled select
+                    // also skips the relationship sync on save.
+                    ->disabled(fn (?User $record): bool => $record !== null && $record->is(auth()->user()))
+                    ->helperText(fn (?User $record): string => $record !== null && $record->is(auth()->user())
+                        ? 'You cannot change your own roles — ask another admin.'
+                        : 'Without a role the account cannot sign in to the panel. What a role may do is defined under Roles.'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Users/Tables/UsersTable.php
+++ b/app/Filament/Resources/Users/Tables/UsersTable.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Filament\Resources\Users\Tables;
+
+use App\Models\User;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class UsersTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('name')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('roles.name')
+                    ->label('Roles')
+                    ->badge()
+                    ->placeholder('No role — cannot sign in'),
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->since()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('roles')
+                    ->relationship('roles', 'name')
+                    ->preload(),
+            ])
+            // Keeps "select all + delete" from taking your own account along.
+            ->checkIfRecordIsSelectableUsing(fn (User $record): bool => ! $record->is(auth()->user()))
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    ->hidden(fn (User $record): bool => $record->is(auth()->user())),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Users/UserResource.php
+++ b/app/Filament/Resources/Users/UserResource.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Users;
+
+use App\Filament\Resources\Users\Pages\CreateUser;
+use App\Filament\Resources\Users\Pages\EditUser;
+use App\Filament\Resources\Users\Pages\ListUsers;
+use App\Filament\Resources\Users\Schemas\UserForm;
+use App\Filament\Resources\Users\Tables\UsersTable;
+use App\Models\User;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedUsers;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    // Shares a group with Shield's Roles resource, which defines what the
+    // roles assigned here may do.
+    protected static string|UnitEnum|null $navigationGroup = 'Access Management';
+
+    // Account administration sits after the day-to-day resources.
+    protected static ?int $navigationSort = 10;
+
+    public static function form(Schema $schema): Schema
+    {
+        return UserForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return UsersTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+            'create' => CreateUser::route('/create'),
+            'edit' => EditUser::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -6,7 +6,9 @@ use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Services\GitHub\GitHubClient;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -22,10 +24,69 @@ class ComposerRepositoryController extends Controller
      */
     public function root(): JsonResponse
     {
+        // `search` and `list` rather than `available-packages`: inlining every
+        // name defeats Composer's lazy metadata loading and hands the full
+        // package list to anyone who fetches the root.
         return response()->json([
             'metadata-url' => '/p2/%package%.json',
-            'available-packages' => Package::query()->has('versions')->orderBy('name')->pluck('name'),
+            'search' => url('/search.json').'?q=%query%&type=%type%',
+            'list' => url('/list.json'),
         ]);
+    }
+
+    /**
+     * Search served packages by name prefix and optional Composer type,
+     * mirroring packagist.org's search.json shape.
+     */
+    public function search(Request $request): JsonResponse
+    {
+        // `%` and `_` in the query are literals, not wildcards — a search for
+        // "acme/%" must not enumerate the registry.
+        $prefix = addcslashes($request->string('q')->toString(), '\\%_');
+
+        $results = $this->servedPackages()
+            ->whereLike('name', "{$prefix}%")
+            ->when(
+                $request->filled('type'),
+                fn (Builder $query) => $query->where('type', $request->string('type')->toString()),
+            )
+            ->orderBy('name')
+            ->get(['name', 'description'])
+            ->map(fn (Package $package): array => [
+                'name' => $package->name,
+                'description' => (string) $package->description,
+                // Downloads are not tracked yet; the key is part of the
+                // packagist.org response shape, so it is served as zero
+                // rather than omitted.
+                'downloads' => 0,
+            ]);
+
+        return response()->json([
+            'total' => $results->count(),
+            'results' => $results,
+        ]);
+    }
+
+    /**
+     * Every package name this repository serves.
+     */
+    public function list(): JsonResponse
+    {
+        return response()->json([
+            'packageNames' => $this->servedPackages()->orderBy('name')->pluck('name'),
+        ]);
+    }
+
+    /**
+     * Packages the repository actually serves. A package with no synced
+     * versions resolves to nothing, so advertising it in search or list
+     * results would only produce dead ends.
+     *
+     * @return Builder<Package>
+     */
+    private function servedPackages(): Builder
+    {
+        return Package::query()->has('versions');
     }
 
     /**

--- a/app/Http/Controllers/GitHubWebhookController.php
+++ b/app/Http/Controllers/GitHubWebhookController.php
@@ -123,6 +123,16 @@ class GitHubWebhookController extends Controller
             return $this->ignore("No package is published from {$repository}.");
         }
 
+        // A package with auto-sync switched off had its own hook removed when
+        // it was switched off, but the app's webhook cannot be told to skip
+        // one repository — so it is skipped here instead, which is what makes
+        // the toggle mean the same thing whichever path a delivery arrives by.
+        $packages = $packages->filter(fn (Package $target): bool => $target->webhook_enabled);
+
+        if ($packages->isEmpty()) {
+            return $this->ignore("Auto-sync is switched off for every package published from {$repository}.");
+        }
+
         foreach ($packages as $target) {
             $target->forceFill(['webhook_received_at' => now()])->save();
 

--- a/app/Http/Controllers/SourceConnectionController.php
+++ b/app/Http/Controllers/SourceConnectionController.php
@@ -152,7 +152,27 @@ class SourceConnectionController extends Controller
             return $this->back($source, 'warning', "Connected {$source->account}, but no repositories", $reason);
         }
 
-        return $this->back($source, 'success', "Connected {$source->account}", "{$count} repositories are reachable from this source.");
+        return $this->back(
+            $source,
+            'success',
+            "Connected {$source->account}",
+            "{$count} repositories are reachable from this source.{$this->webhookAdvice()}",
+        );
+    }
+
+    /**
+     * A nudge towards the app's webhook, said here because this is the moment
+     * an admin is configuring the source and has the app's settings page open.
+     *
+     * Without it packages still sync themselves — each one falls back to a
+     * webhook on its own repository — but that needs a permission the app may
+     * not have, and one webhook on the app covers every repository instead.
+     */
+    private function webhookAdvice(): string
+    {
+        return app(GitHubApp::class)->hasWebhook()
+            ? ''
+            : ' Auto-sync is not set up yet: see "Auto-sync" below for the payload URL and a secret to put on the app\'s webhook.';
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\SourceProvider;
 use App\Enums\WebhookCoverage;
+use App\Services\GitHub\GitHubApp;
 use App\Services\GitHub\WebhookRegistrar;
 use Database\Factories\PackageFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -15,11 +16,22 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
-#[Fillable(['source_id', 'repository', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error'])]
+#[Fillable(['source_id', 'repository', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error', 'webhook_enabled'])]
 class Package extends Model
 {
     /** @use HasFactory<PackageFactory> */
     use HasFactory;
+
+    /**
+     * The column default alone would leave a freshly created package holding
+     * null in memory until it is read back, and the webhook is set up in that
+     * window — so the default is stated here as well.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'webhook_enabled' => true,
+    ];
 
     /**
      * @return array<string, string>
@@ -29,6 +41,7 @@ class Package extends Model
         return [
             'token' => 'encrypted',
             'webhook_secret' => 'encrypted',
+            'webhook_enabled' => 'boolean',
             'last_synced_at' => 'datetime',
             'webhook_received_at' => 'datetime',
         ];
@@ -175,14 +188,26 @@ class Package extends Model
      */
     public function webhookCoverage(): WebhookCoverage
     {
-        if ($this->source?->usesInstallation()) {
-            return filled(config('services.github.app.webhook_secret'))
-                ? WebhookCoverage::Application
-                : WebhookCoverage::Unconfigured;
+        // Switched off deliberately, which is not the same as uncovered and
+        // must not read like something left undone.
+        if (! $this->webhook_enabled) {
+            return WebhookCoverage::Disabled;
         }
 
+        // A hook on the repository is the concrete thing. If one exists it is
+        // what delivers, whatever else may also be configured — so it is
+        // checked first, and a registry that later turns the app's webhook on
+        // does not start describing this package as covered by something else.
         if ($this->webhook_id !== null) {
             return WebhookCoverage::Repository;
+        }
+
+        // Confirmed with GitHub rather than assumed from a secret sitting in
+        // this app's environment: an app whose webhook was never switched on
+        // delivers nothing, and a package told it is covered by one would
+        // never get the repository hook that would have worked.
+        if ($this->source?->usesInstallation() && app(GitHubApp::class)->hasWebhook()) {
+            return WebhookCoverage::Application;
         }
 
         return filled($this->webhook_error) ? WebhookCoverage::Failed : WebhookCoverage::None;

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class UserPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:User');
+    }
+
+    public function view(AuthUser $authUser, User $user): bool
+    {
+        return $authUser->can('View:User');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:User');
+    }
+
+    public function update(AuthUser $authUser, User $user): bool
+    {
+        return $authUser->can('Update:User');
+    }
+
+    public function delete(AuthUser $authUser, User $user): bool
+    {
+        return $authUser->can('Delete:User');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:User');
+    }
+
+    public function restore(AuthUser $authUser, User $user): bool
+    {
+        return $authUser->can('Restore:User');
+    }
+
+    public function forceDelete(AuthUser $authUser, User $user): bool
+    {
+        return $authUser->can('ForceDelete:User');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:User');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:User');
+    }
+
+    public function replicate(AuthUser $authUser, User $user): bool
+    {
+        return $authUser->can('Replicate:User');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:User');
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -7,6 +7,7 @@ use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Navigation\MenuItem;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
@@ -17,6 +18,8 @@ use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Joaopaulolndev\FilamentEditProfile\FilamentEditProfilePlugin;
+use Joaopaulolndev\FilamentEditProfile\Pages\EditProfilePage;
 
 class AdminPanelProvider extends PanelProvider
 {
@@ -45,7 +48,22 @@ class AdminPanelProvider extends PanelProvider
             // Roles and permissions, plus the Roles resource for managing them.
             // Permissions are generated from the panel's own entities by
             // `php artisan shield:generate --all`.
-            ->plugin(FilamentShieldPlugin::make())
+            // Grouped with the Users resource, which manages who holds them.
+            ->plugin(FilamentShieldPlugin::make()->navigationGroup('Access Management'))
+            // Self-service profile page, reached from the user menu rather
+            // than the sidebar. Account deletion stays off: accounts are
+            // provisioned and removed by admins here.
+            ->plugin(
+                FilamentEditProfilePlugin::make()
+                    ->shouldRegisterNavigation(false)
+                    ->shouldShowDeleteAccountForm(false)
+            )
+            ->userMenuItems([
+                'profile' => MenuItem::make()
+                    ->label(fn (): string => auth()->user()->name)
+                    ->url(fn (): string => EditProfilePage::getUrl())
+                    ->icon('heroicon-m-user-circle'),
+            ])
             // The bell, where a package's own releases and failed syncs land.
             // Syncing happens on a queue in response to a push, so there is
             // often nobody watching the page it happened on.

--- a/app/Services/GitHub/GitHubApp.php
+++ b/app/Services/GitHub/GitHubApp.php
@@ -2,12 +2,15 @@
 
 namespace App\Services\GitHub;
 
+use App\Enums\WebhookState;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use RuntimeException;
+use Throwable;
 
 /**
  * The registered GitHub App, which is how this registry authenticates against
@@ -47,6 +50,149 @@ class GitHubApp
     {
         return filled(config('services.github.app.id'))
             && filled(config('services.github.app.private_key'));
+    }
+
+    /**
+     * Whether the app's own webhook actually delivers to this registry.
+     *
+     * A secret in the environment is necessary — it is what proves a delivery
+     * came from GitHub — but it is not evidence of anything on GitHub's side.
+     * An app whose webhook was never switched on, or whose payload URL points
+     * at another environment, will happily let a registry believe it is
+     * covered while nothing is ever delivered, which is the one failure this
+     * feature must not have. So GitHub is asked.
+     *
+     * A false answer is not a fault: it means packages fall back to a webhook
+     * on their own repository, which is the general case anyway.
+     */
+    public function hasWebhook(): bool
+    {
+        return match ($this->webhookState()) {
+            WebhookState::Delivering => true,
+            // Nothing to ask GitHub with, or GitHub could not be reached. The
+            // configured secret keeps its benefit of the doubt: an outage is
+            // not evidence the webhook is gone, and treating it as such would
+            // grow a repository hook on every package created during one.
+            WebhookState::Unverifiable => true,
+            WebhookState::NoSecret, WebhookState::Absent, WebhookState::Elsewhere => false,
+        };
+    }
+
+    /**
+     * What GitHub says about the app's webhook, which is not always what the
+     * environment implies.
+     */
+    public function webhookState(): WebhookState
+    {
+        if (blank(config('services.github.app.webhook_secret'))) {
+            return WebhookState::NoSecret;
+        }
+
+        if (! $this->isConfigured()) {
+            return WebhookState::Unverifiable;
+        }
+
+        try {
+            $configured = $this->webhookConfiguration();
+        } catch (Throwable) {
+            // GitHub being unreachable is not evidence that the webhook is
+            // gone, and treating it as such would have every package created
+            // during an outage grow a repository hook it does not need. The
+            // configured secret keeps its benefit of the doubt.
+            return WebhookState::Unverifiable;
+        }
+
+        return match (true) {
+            $configured === null => WebhookState::Absent,
+            ($configured['url'] ?? null) === $this->webhookUrl() => WebhookState::Delivering,
+            default => WebhookState::Elsewhere,
+        };
+    }
+
+    /**
+     * Where the app's webhook actually posts, when that is knowable and is
+     * somewhere other than here — the detail that turns "pointing elsewhere"
+     * into something an admin can act on.
+     */
+    public function deliveringTo(): ?string
+    {
+        try {
+            $url = $this->isConfigured() ? ($this->webhookConfiguration()['url'] ?? null) : null;
+        } catch (Throwable) {
+            return null;
+        }
+
+        return is_string($url) ? $url : null;
+    }
+
+    /**
+     * The app's webhook configuration as GitHub holds it, or null when the app
+     * has no webhook — which is what a 404 on this endpoint means.
+     *
+     * Cached briefly: it is read on every page that reports coverage, and it
+     * changes only when someone edits the app's settings.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function webhookConfiguration(): ?array
+    {
+        $this->ensureConfigured();
+
+        // "No webhook" is cached as false rather than null, because a null is
+        // indistinguishable from a cache miss and would put this request back
+        // on GitHub for every page that asks.
+        $configured = Cache::remember(
+            'github-app.webhook-config.'.config('services.github.app.id'),
+            now()->addMinutes(5),
+            function (): array|false {
+                $response = $this->request()->withToken($this->jwt())->get('/app/hook/config');
+
+                // GitHub answers 404 here when the app has no webhook at all,
+                // which is what an app registered with "Active" unchecked has.
+                if ($response->status() === 404) {
+                    return false;
+                }
+
+                return $response->throw()->json();
+            },
+        );
+
+        return $configured === false ? null : $configured;
+    }
+
+    /**
+     * Drop the cached answer, so a webhook just switched on is seen now rather
+     * than in five minutes.
+     */
+    public function forgetWebhookConfiguration(): void
+    {
+        Cache::forget('github-app.webhook-config.'.config('services.github.app.id'));
+    }
+
+    /**
+     * The payload URL to set on the app's webhook. One URL for every
+     * repository in every installation.
+     */
+    public function webhookUrl(): string
+    {
+        return route('webhooks.github');
+    }
+
+    /**
+     * A secret to offer an admin who has not set one, so that configuring the
+     * webhook is copying two values rather than inventing one.
+     *
+     * It is remembered for a day because it is shown in two places that have
+     * to agree — GitHub's settings page and an `.env` file — and a suggestion
+     * that changed on every page load could not be used for either.
+     */
+    public function suggestedWebhookSecret(): string
+    {
+        return Cache::remember(
+            'github-app.suggested-webhook-secret',
+            now()->addDay(),
+            fn (): string => Str::random(40),
+        );
     }
 
     /**

--- a/app/Services/GitHub/WebhookRegistrar.php
+++ b/app/Services/GitHub/WebhookRegistrar.php
@@ -11,11 +11,15 @@ use Throwable;
 /**
  * Gives a package a way to hear about its own pushes.
  *
- * Most packages need nothing: their source is an installed GitHub App, and the
- * app's single webhook already delivers for every repository the installation
- * can see. This is the fallback for the rest — a token-based source, or a
- * package carrying its own token — where the only place a hook can live is on
- * the repository itself.
+ * Creating a hook on the repository is the general answer, and the one every
+ * package gets: it needs nothing configured beforehand and works the same for
+ * a token-based source as for an installed app.
+ *
+ * The exception is worth taking when it is available. A GitHub App has one
+ * webhook of its own that already delivers for every repository in every
+ * installation, so a package under an installed app with that webhook set up
+ * is covered before it is created — and a hook on the repository would only
+ * mean the same push arriving twice.
  */
 class WebhookRegistrar
 {
@@ -30,12 +34,39 @@ class WebhookRegistrar
      *
      * @return WebhookCoverage the coverage the package ended up with
      */
+    /**
+     * Make GitHub match what the package asks for.
+     *
+     * The toggle is the intent and this is what carries it out, in both
+     * directions: switching auto-sync on creates whatever is missing,
+     * switching it off takes the repository hook back down rather than
+     * leaving GitHub posting to an endpoint that now ignores it.
+     */
+    public function reconcile(Package $package): WebhookCoverage
+    {
+        if (! $package->webhook_enabled) {
+            $this->deregister($package);
+
+            return WebhookCoverage::Disabled;
+        }
+
+        return $this->register($package);
+    }
+
     public function register(Package $package): WebhookCoverage
     {
         $coverage = $package->webhookCoverage();
 
-        // Already covered, one way or the other.
-        if ($coverage->isActive() || $coverage === WebhookCoverage::Unconfigured) {
+        // Nothing to arrange for a package that has asked not to be synced.
+        if ($coverage === WebhookCoverage::Disabled) {
+            return $coverage;
+        }
+
+        // Already covered, one way or the other. Everything else — including
+        // an app-installed package on a registry whose app webhook is not set
+        // up — falls through and gets a hook of its own, because a package
+        // that hears about its pushes beats one waiting on configuration.
+        if ($coverage->isActive()) {
             return $coverage;
         }
 
@@ -109,9 +140,15 @@ class WebhookRegistrar
             return;
         }
 
-        // The record may be gone already; only touch it while it is still there.
+        // The record may be gone already; only touch it while it is still
+        // there. An old failure goes with the hook, so switching auto-sync
+        // back on starts from a clean slate rather than from last time.
         if ($package->exists) {
-            $package->forceFill(['webhook_id' => null, 'webhook_secret' => null])->save();
+            $package->forceFill([
+                'webhook_id' => null,
+                'webhook_secret' => null,
+                'webhook_error' => null,
+            ])->save();
         }
     }
 
@@ -121,13 +158,32 @@ class WebhookRegistrar
     public function unmetRequirement(Package $package): ?string
     {
         return match ($package->webhookCoverage()) {
-            WebhookCoverage::Application, WebhookCoverage::Repository => null,
-            WebhookCoverage::Unconfigured => 'This package is covered by the GitHub App\'s webhook, but no GITHUB_APP_WEBHOOK_SECRET is set here, so deliveries cannot be verified. '
-                .'Set the secret on the app\'s webhook and in this app\'s environment — see docs/webhooks.md.',
-            WebhookCoverage::Failed => "The repository webhook could not be created: {$package->webhook_error}",
-            WebhookCoverage::None => 'No webhook covers this repository, so pushes will not sync it. '
-                .'Connect its account as a GitHub App source, or use "Create webhook" to add one to the repository — which needs a credential with admin rights on it.',
+            // Off on purpose is not something left undone.
+            WebhookCoverage::Application, WebhookCoverage::Repository, WebhookCoverage::Disabled => null,
+            WebhookCoverage::Failed => "The repository webhook could not be created: {$package->webhook_error} {$this->remedy($package)}",
+            WebhookCoverage::None => "No webhook covers this repository, so pushes will not sync it. {$this->remedy($package)}",
         };
+    }
+
+    /**
+     * How to get this particular package syncing itself.
+     *
+     * Creating a hook needs write access to the repository's webhooks, which
+     * neither a read-only token nor an app installed for Contents alone has.
+     * Where an app is involved there is a second way out that needs no
+     * repository permission at all, and it is usually the better one — it
+     * covers every repository the installation can see, not just this one.
+     */
+    private function remedy(Package $package): string
+    {
+        if ($package->source?->usesInstallation()) {
+            return 'Either turn on the GitHub App\'s own webhook and set GITHUB_APP_WEBHOOK_SECRET, which covers every repository in the installation at once, '
+                .'or give the app "Webhooks: Read and write" so it can create one on the repository. See docs/webhooks.md.';
+        }
+
+        return 'The credential this package authenticates with needs write access to the repository\'s webhooks '
+            .'(a fine-grained token with Webhooks: Read and write, or a classic token with admin:repo_hook), '
+            .'then use "Create webhook" to try again.';
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "^8.3",
         "bezhansalleh/filament-shield": "^4.3",
         "filament/filament": "^5.0",
+        "joaopaulolndev/filament-edit-profile": "^3.0",
         "laravel/framework": "^13.17",
         "laravel/slack-notification-channel": "^3.10",
         "laravel/tinker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bc3314a14555a541be1297b572802a7",
+    "content-hash": "31369479e77cf0cc480c525ebb908aac",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -2351,6 +2351,215 @@
             "time": "2026-07-17T13:53:03+00:00"
         },
         {
+            "name": "jaybizzle/crawler-detect",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JayBizzle/Crawler-Detect.git",
+                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/770e00e5bcd35054871a6f790f380123cc3b8b0c",
+                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.52|^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jaybizzle\\CrawlerDetect\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Beech",
+                    "email": "m@rkbee.ch",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CrawlerDetect is a PHP class for detecting bots/crawlers/spiders via the user agent",
+            "homepage": "https://github.com/JayBizzle/Crawler-Detect/",
+            "keywords": [
+                "crawler",
+                "crawler detect",
+                "crawler detector",
+                "crawlerdetect",
+                "php crawler detect"
+            ],
+            "support": {
+                "issues": "https://github.com/JayBizzle/Crawler-Detect/issues",
+                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.4.1"
+            },
+            "time": "2026-07-10T14:15:38+00:00"
+        },
+        {
+            "name": "jenssegers/agent",
+            "version": "v2.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jenssegers/agent.git",
+                "reference": "daa11c43729510b3700bc34d414664966b03bffe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jenssegers/agent/zipball/daa11c43729510b3700bc34d414664966b03bffe",
+                "reference": "daa11c43729510b3700bc34d414664966b03bffe",
+                "shasum": ""
+            },
+            "require": {
+                "jaybizzle/crawler-detect": "^1.2",
+                "mobiledetect/mobiledetectlib": "^2.7.6",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5.0|^6.0|^7.0"
+            },
+            "suggest": {
+                "illuminate/support": "Required for laravel service providers"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Agent": "Jenssegers\\Agent\\Facades\\Agent"
+                    },
+                    "providers": [
+                        "Jenssegers\\Agent\\AgentServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jenssegers\\Agent\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jens Segers",
+                    "homepage": "https://jenssegers.com"
+                }
+            ],
+            "description": "Desktop/mobile user agent parser with support for Laravel, based on Mobiledetect",
+            "homepage": "https://github.com/jenssegers/agent",
+            "keywords": [
+                "Agent",
+                "browser",
+                "desktop",
+                "laravel",
+                "mobile",
+                "platform",
+                "user agent",
+                "useragent"
+            ],
+            "support": {
+                "issues": "https://github.com/jenssegers/agent/issues",
+                "source": "https://github.com/jenssegers/agent/tree/v2.6.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jenssegers",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/jenssegers/agent",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-13T08:05:20+00:00"
+        },
+        {
+            "name": "joaopaulolndev/filament-edit-profile",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joaopaulolndev/filament-edit-profile.git",
+                "reference": "88f2a7e9b5cc3ac4279ded6bcbe70c2fd9a965e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joaopaulolndev/filament-edit-profile/zipball/88f2a7e9b5cc3ac4279ded6bcbe70c2fd9a965e7",
+                "reference": "88f2a7e9b5cc3ac4279ded6bcbe70c2fd9a965e7",
+                "shasum": ""
+            },
+            "require": {
+                "filament/filament": "^5.3",
+                "jenssegers/agent": "^2.6",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.15.0"
+            },
+            "require-dev": {
+                "laradumps/laradumps": "^3.1",
+                "larastan/larastan": "^3.9",
+                "laravel/pint": "^1.0",
+                "nunomaduro/collision": "^7.9|^8.6",
+                "orchestra/testbench": "^8.0|^9.0|^10.0",
+                "pestphp/pest": "^2.1|^3.4.7",
+                "pestphp/pest-plugin-arch": "^2.0|^3.0",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Joaopaulolndev\\FilamentEditProfile\\FilamentEditProfileServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joaopaulolndev\\FilamentEditProfile\\": "src/",
+                    "Joaopaulolndev\\FilamentEditProfile\\Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "João Paulo Leite Nascimento",
+                    "email": "joaopauloln7@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Filament package to edit profile",
+            "homepage": "https://github.com/joaopaulolndev/filament-edit-profile",
+            "keywords": [
+                "filament-edit-profile",
+                "joaopaulolndev",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/joaopaulolndev/filament-edit-profile/issues",
+                "source": "https://github.com/joaopaulolndev/filament-edit-profile"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/joaopaulolndev",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-04T02:40:49+00:00"
+        },
+        {
             "name": "kirschbaum-development/eloquent-power-joins",
             "version": "4.3.3",
             "source": {
@@ -3758,6 +3967,68 @@
                 }
             ],
             "time": "2026-08-03T04:09:44+00:00"
+        },
+        {
+            "name": "mobiledetect/mobiledetectlib",
+            "version": "2.8.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/serbanghita/Mobile-Detect.git",
+                "reference": "28e9045958dcaf771f9b56564549d5b174e38b0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/28e9045958dcaf771f9b56564549d5b174e38b0e",
+                "reference": "28e9045958dcaf771f9b56564549d5b174e38b0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Detection": "namespaced/"
+                },
+                "classmap": [
+                    "Mobile_Detect.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Serban Ghita",
+                    "email": "serbanghita@gmail.com",
+                    "homepage": "http://mobiledetect.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mobile_Detect is a lightweight PHP class for detecting mobile devices. It uses the User-Agent string combined with specific HTTP headers to detect the mobile environment.",
+            "homepage": "https://github.com/serbanghita/Mobile-Detect",
+            "keywords": [
+                "detect mobile devices",
+                "mobile",
+                "mobile detect",
+                "mobile detector",
+                "php mobile detect"
+            ],
+            "support": {
+                "issues": "https://github.com/serbanghita/Mobile-Detect/issues",
+                "source": "https://github.com/serbanghita/Mobile-Detect/tree/2.8.47"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/serbanghita",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-14T12:32:34+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/database/migrations/2026_08_03_193145_create_packages_table.php
+++ b/database/migrations/2026_08_03_193145_create_packages_table.php
@@ -33,6 +33,11 @@ return new class extends Migration
             // exists as the fallback for repositories the GitHub App's own
             // webhook does not deliver for. Packages under an installed app
             // leave all three null and are covered account-wide.
+            // Whether this package should sync itself when its repository is
+            // pushed to. On by default — a package is added to be published,
+            // and publishing it late is the surprising behaviour.
+            $table->boolean('webhook_enabled')->default(true);
+
             $table->unsignedBigInteger('webhook_id')->nullable();
             $table->text('webhook_secret')->nullable();
             $table->text('webhook_error')->nullable();

--- a/database/seeders/ShieldPermissionSeeder.php
+++ b/database/seeders/ShieldPermissionSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Artisan;
+use Spatie\Permission\PermissionRegistrar;
 
 /**
  * Creates the permission rows that Shield's policies check against.
@@ -22,10 +23,20 @@ class ShieldPermissionSeeder extends Seeder
 {
     public function run(): void
     {
+        // Shield creates the rows in a way that skips Spatie's cache-clearing
+        // hook, then resolves them *through* the cache to grant them to the
+        // super admin role. A cache primed while the table was empty (any web
+        // request or command before first seeding does this) then aborts the
+        // generate with PermissionDoesNotExist — so start from a cold cache,
+        // and leave a cold one behind for whatever runs next.
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
         Artisan::call('shield:generate', [
             '--all' => true,
             '--option' => 'permissions',
             '--panel' => 'admin',
         ]);
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
     }
 }

--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -30,7 +30,13 @@ organisation that will own it):
 Subscribe the app to **Push**, **Branch or tag creation** and **Branch or tag
 deletion** under **Permissions & events**. That one webhook covers every
 repository in every installation, so packages sync themselves the moment
-something is pushed — see [webhooks.md](webhooks.md) for the whole picture.
+something is pushed.
+
+This is optional, and can be done later — the panel shows the payload URL and
+generates a secret for you under **Auto-sync** on any connected source. Without
+it, each package instead gets a webhook on its own repository when it is
+created, which needs the app to also have **Webhooks: Read and write**. See
+[webhooks.md](webhooks.md) for both paths.
 
 Repository permissions — read-only is enough for syncing and serving dists:
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -294,14 +294,16 @@ onboarded (`Client::createWebhook`).
 **Implemented**, with three deliberate departures from Packistry's design — see
 [webhooks.md](webhooks.md):
 
-- **One app-level webhook, not one per package.** Sources authenticate as a GitHub App, and an App
-  has a single webhook covering every repository in every installation (`POST /incoming/github`,
-  signed with `GITHUB_APP_WEBHOOK_SECRET`). Nothing is created per package, repositories added to an
-  installation later are covered for free, and no new repository permission is requested —
-  per-repository hooks need **Repository webhooks: write**, which every installation owner would
-  have to re-approve. Packistry has no App path, so per-repo hooks are its only option.
-  `POST /incoming/github/{package}` remains as exactly that fallback, for token-based sources, and
-  `WebhookRegistrar` creates one on package create.
+- **An app-level webhook in front of Packistry's per-package one.** Packistry only has token auth,
+  so a hook on each repository is its only option. Sources here can authenticate as a GitHub App,
+  which has a single webhook covering every repository in every installation
+  (`POST /incoming/github`, signed with `GITHUB_APP_WEBHOOK_SECRET`) — nothing per package, new
+  repositories covered for free, and no permission beyond the read-only ones syncing already needs.
+  Packistry's approach remains as the fallback and the general case: `WebhookRegistrar` creates a
+  hook on the repository at package-create time (`POST /incoming/github/{package}`, its own
+  encrypted secret) whenever the app webhook is not covering it — including on a registry that has
+  simply not set the app webhook up. Configuring it is offered on the source page, where the payload
+  URL and a generated secret are shown, rather than left to this document.
 - **A full sync per delivery, not a single-ref import.** `PackageSynchronizer::unchanged()` already
   skips refs whose sha has not moved, so a delivery costs two API calls when nothing changed;
   a separate surgical import path would be a second implementation of version building to keep

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -21,7 +21,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 
 | # | Feature | Status | Depends on |
 |---|---------|--------|------------|
-| 1 | Composer v2 API completeness (search.json, list.json, stable/dev split) | 🟡 | — |
+| 1 | Composer v2 API completeness (search.json, list.json, stable/dev split) | ✅ | — |
 | 2 | Local archive storage + dist serving (zips, sha1, cleanup) | 🟡 | — |
 | 3 | Version normalization & ordering (composer/semver) | ❌ | — |
 | 4 | Artifact upload endpoint (CI pushes a zip) | ❌ | 2 |
@@ -56,20 +56,13 @@ serves only stable versions; `/p2/{vendor}/{name}~dev.json` serves only `dev-*` 
 Packistry does **not** use `available-packages` (which package-pipeline currently emits — it defeats
 lazy loading and leaks the package list).
 
-**Gap**: package-pipeline lacks `search.json`/`list.json`, and exposes all names via `available-packages`.
-
-```text
-In this Laravel app (a private Composer v2 repository), extend app/Http/Controllers/ComposerRepositoryController.php:
-1. Replace the `available-packages` key in root() with `list` and `search` keys pointing to new
-   routes /list.json and /search.json?q=%query%&type=%type% (absolute URLs via url()).
-2. Add search(): filter Package by name prefix (LIKE "q%") and optional composer `type` column,
-   return {total, results: [{name, description, downloads}]} (downloads 0 if not tracked yet).
-3. Add list(): return {packageNames: [...]} sorted by name.
-4. Keep the existing /p2 metadata behavior (stable vs ~dev split already implemented).
-5. Register routes in routes/web.php next to the existing composer.* routes and add feature tests
-   covering root/search/list JSON shapes, verifying Composer v2 spec compliance
-   (https://repo.packagist.org/packages.json format). Run the full test suite.
-```
+**Implemented**: `root()` now advertises `search` and `list` instead of `available-packages`;
+`/search.json` filters served packages by name prefix (LIKE wildcards in the query are escaped) and
+optional `type`, returning `{total, results:[{name, description, downloads}]}` with `downloads: 0`
+until download tracking (item 15) exists; `/list.json` returns `{packageNames:[...]}` sorted. Both
+endpoints only advertise packages that have at least one synced version — an unsynced package
+resolves to nothing, so listing it would be a dead end. Covered in
+`tests/Feature/ComposerRepositoryTest.php`.
 
 ## 2. Local archive storage + dist serving
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -18,14 +18,49 @@ commit landing on `main` changes what `dev-main` resolves to, and that is a
 push, not a creation — subscribe to creations alone and dev versions quietly
 go stale.
 
-## The GitHub App's webhook (nearly always what you want)
+Every package gets one of these two, and it is arranged when the package is
+created — nothing has to be set up first:
 
-A GitHub App has **one** webhook of its own, and it delivers for every
-repository in every installation. There is nothing to create per package and
-nothing to create when a repository is added to an installation later — it is
-covered the moment it is shared.
+- **The GitHub App's own webhook**, if the app has one. It covers every
+  repository in every installation at once, so a package under an installed
+  app is already covered before it is created.
+- **A webhook on the repository**, otherwise. This is the fallback and the
+  general case: it works for a token-based source and for an app-installed one
+  whose registry has no app webhook set up.
 
-Set it up once, on the app's settings page:
+The app's webhook is the better of the two where it is available — one thing to
+configure instead of one per repository, no repository permission beyond the
+read-only ones syncing already needs, and repositories added to an installation
+later are covered without anyone doing anything. Nothing waits on it, though;
+a registry that never sets it up still auto-syncs, one repository hook at a
+time.
+
+## The GitHub App's webhook
+
+This webhook lives on the **app**, not on any repository — a repository's
+Settings → Webhooks page stays empty, which is the point of it. Its deliveries
+are listed under the app's own **Advanced** tab.
+
+Set it up once, on the app's settings page. The panel will hand you both
+values: open any App-connected source and look under **Auto-sync**, which shows
+the payload URL and generates a secret to use.
+
+Setting `GITHUB_APP_WEBHOOK_SECRET` is not on its own enough, and the panel
+does not pretend otherwise: it asks GitHub (`GET /app/hook/config`) whether the
+app really has a webhook and whether it posts *here*, and reports one of
+
+| State | Meaning |
+| --- | --- |
+| **Delivering here** | GitHub confirms it posts to this registry |
+| **Not switched on** | The app has no webhook — Webhook → Active was never ticked |
+| **Pointing elsewhere** | Its payload URL is another environment's |
+| **No secret set** | Nothing here to verify a delivery with |
+| **Configured, unverified** | GitHub could not be reached; the secret is trusted meanwhile |
+
+Only **Delivering here** counts as coverage. In the other cases packages fall
+back to a webhook on their own repository, so a half-finished setup costs
+nothing except the extra hooks. The answer is cached for five minutes;
+**Re-check** on the source page asks again straight away.
 
 | Field | Value |
 | --- | --- |
@@ -45,27 +80,54 @@ No repository permission has to change for this. Contents (read-only) and
 Metadata (read-only) — what [github-app.md](github-app.md) already asks for —
 are enough to receive these events and to sync what they announce.
 
-Until the secret is set, deliveries are refused with a 503 rather than trusted,
-and the panel says so on every package the app covers. The secret is the whole
-of the authentication on an incoming request, so an unverifiable delivery is
-not something to act on.
+Until the secret is set, deliveries to `/incoming/github` are refused with a
+503 rather than trusted: the secret is the whole of the authentication on an
+incoming request, so an unverifiable delivery is not something to act on.
+Packages created in the meantime fall back to a webhook of their own.
 
-## The per-repository fallback
+## The per-repository webhook
 
-A package whose source is **not** an installed app — a source holding a
-personal access token, or a repository with only its own token — has no app
-webhook to ride on, so it needs a hook on the repository itself. This app
-creates one automatically when the package is created, and the panel offers
-**Create webhook** on the package page if it has to be done again.
+A package that has no app webhook to ride on gets a hook on the repository
+itself, created when the package is created. The panel also offers **Create
+webhook** on the package page when one has to be made again.
 
 That hook posts to `<APP_URL>/incoming/github/{package}` and is signed with a
 secret generated for that package alone, stored encrypted. Deleting the package
 removes the hook from GitHub.
 
-Creating a hook needs **admin rights on the repository**, which a read-only
-token does not have. When GitHub refuses, the package is still created — it
-simply syncs when asked rather than when pushed, and the reason is shown on
-the package page under **Auto-sync**.
+Creating one needs **write access to the repository's webhooks**, which not
+every credential has:
+
+| Credential | What it needs |
+| --- | --- |
+| GitHub App installation | **Webhooks: Read and write** on the app — or skip it and set the app's own webhook up instead |
+| Fine-grained token | **Webhooks: Read and write** |
+| Classic token | `admin:repo_hook` |
+
+When GitHub refuses, the package is still created — it simply syncs when asked
+rather than when pushed, and the reason plus the way out is shown on the
+package page under **Auto-sync**.
+
+An app-installed package that has already made its own hook keeps using it even
+if the app's webhook is set up later. The two would otherwise deliver the same
+push twice; the debounce below means that costs one extra delivery rather than
+one extra sync, but the hook is still worth removing on GitHub if you want the
+app's webhook to be the only path.
+
+## Switching it off for one package
+
+**Sync automatically on push** on the package's edit page controls this per
+package. It is on for new packages.
+
+Turning it off removes the package's webhook from the repository, and — for a
+package the app's webhook covers, where there is no hook to remove — makes the
+delivery endpoint ignore that repository. The app's webhook itself is left
+alone, because it belongs to every other package too. Either way the package
+stops syncing on push and still syncs when asked, from **Sync** in the panel or
+`php artisan packages:sync`.
+
+Turning it back on sets the webhook up again, and clears any earlier failure so
+the retry starts clean.
 
 ## What a delivery does
 
@@ -73,9 +135,9 @@ the package page under **Auto-sync**.
    match, no further reading of the payload.
 2. `ping` is answered `204`. GitHub sends one when a webhook is created.
 3. The repository named in the payload is matched to a package. A repository
-   that is not a package here is acknowledged and dropped — an app webhook
-   hears from every repository the installation can see, and most are not
-   packages.
+   that is not a package here — or whose packages have all switched auto-sync
+   off — is acknowledged and dropped; an app webhook hears from every
+   repository the installation can see, and most are not packages.
 4. The package's sync is queued, **15 seconds late on purpose**. `git push
    --tags` over ten tags is ten deliveries in about a second; the delay lets
    the pending job's uniqueness lock fold the whole burst into the one sync
@@ -86,11 +148,13 @@ queue:work`. Without one the deliveries are accepted and nothing syncs.
 
 ## Knowing it works
 
-The package page shows **Auto-sync** (which delivery path covers it, and what
-is missing if none does) and **Last delivery** (when GitHub last posted about
-it). On GitHub, the app's or the repository's **Recent Deliveries** tab shows
-each payload and the response it got, with a **Redeliver** button — a rejected
-delivery carries the reason in its response body.
+The package page shows **Auto-sync** (which delivery path covers it, what is
+missing if none does, or **Off** if it was switched off) and **Last delivery**
+(when GitHub last posted about it). On GitHub, **Recent Deliveries** shows each payload and the response it got,
+with a **Redeliver** button — a rejected delivery carries the reason in its
+response body. For a repository hook that is the repository's Settings →
+Webhooks; for the app's webhook it is the app's own **Advanced** tab, since no
+repository lists it.
 
 ## Being told about it
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,10 @@ Route::redirect('/', '/admin/login')->name('home');
 //   composer config repositories.private composer <this-app's-url>
 Route::get('/packages.json', [ComposerRepositoryController::class, 'root'])
     ->name('composer.root');
+Route::get('/search.json', [ComposerRepositoryController::class, 'search'])
+    ->name('composer.search');
+Route::get('/list.json', [ComposerRepositoryController::class, 'list'])
+    ->name('composer.list');
 Route::get('/p2/{vendor}/{package}.json', [ComposerRepositoryController::class, 'metadata'])
     // Greedy segment so package names containing dots still match.
     ->where('package', '[^/]+')

--- a/tests/Feature/ComposerRepositoryTest.php
+++ b/tests/Feature/ComposerRepositoryTest.php
@@ -20,6 +20,8 @@ class ComposerRepositoryTest extends TestCase
             'name' => 'acme/widgets',
             'repository' => 'https://github.com/acme/widgets',
             'token' => 'ghp_secret',
+            'description' => 'Widgets for Acme.',
+            'type' => 'library',
         ]);
 
         $package->versions()->create([
@@ -45,17 +47,98 @@ class ComposerRepositoryTest extends TestCase
         return $package;
     }
 
-    public function test_the_repository_root_advertises_metadata_and_packages(): void
+    private function makeServedPackageNamed(string $name, string $type = 'library'): Package
+    {
+        $package = Package::factory()->create(['name' => $name, 'type' => $type]);
+
+        $package->versions()->create([
+            'version' => 'v1.0.0',
+            'reference' => str_repeat('a', 40),
+            'is_dev' => false,
+            'metadata' => ['name' => $name, 'version' => 'v1.0.0'],
+        ]);
+
+        return $package;
+    }
+
+    public function test_the_repository_root_advertises_metadata_search_and_list(): void
     {
         $this->makeServedPackage();
-        Package::factory()->create(['name' => 'acme/unsynced']);
 
         $this->get('/packages.json')
             ->assertOk()
             ->assertJson([
                 'metadata-url' => '/p2/%package%.json',
-                'available-packages' => ['acme/widgets'],
+                'search' => url('/search.json').'?q=%query%&type=%type%',
+                'list' => url('/list.json'),
+            ])
+            // Inlining every name would defeat Composer's lazy loading and
+            // publish the package list to anyone fetching the root.
+            ->assertJsonMissingPath('available-packages');
+    }
+
+    public function test_search_filters_by_name_prefix(): void
+    {
+        $this->makeServedPackage();
+        $this->makeServedPackageNamed('acme/gadgets');
+        $this->makeServedPackageNamed('other/widgets');
+
+        $this->get('/search.json?q=acme/w')
+            ->assertOk()
+            ->assertExactJson([
+                'total' => 1,
+                'results' => [
+                    [
+                        'name' => 'acme/widgets',
+                        'description' => 'Widgets for Acme.',
+                        'downloads' => 0,
+                    ],
+                ],
             ]);
+    }
+
+    public function test_search_without_a_query_returns_every_served_package(): void
+    {
+        $this->makeServedPackage();
+        $this->makeServedPackageNamed('other/widgets');
+        Package::factory()->create(['name' => 'acme/unsynced']);
+
+        $response = $this->get('/search.json')->assertOk();
+
+        $this->assertSame(2, $response->json('total'));
+        $this->assertSame(['acme/widgets', 'other/widgets'], collect($response->json('results'))->pluck('name')->all());
+    }
+
+    public function test_search_filters_by_package_type(): void
+    {
+        $this->makeServedPackage();
+        $this->makeServedPackageNamed('acme/theme', type: 'wordpress-theme');
+
+        $response = $this->get('/search.json?q=acme/&type=wordpress-theme')->assertOk();
+
+        $this->assertSame(1, $response->json('total'));
+        $this->assertSame('acme/theme', $response->json('results.0.name'));
+    }
+
+    public function test_search_treats_like_wildcards_as_literals(): void
+    {
+        // A query of "%" must not enumerate the registry.
+        $this->makeServedPackage();
+
+        $this->get('/search.json?q=%25')
+            ->assertOk()
+            ->assertExactJson(['total' => 0, 'results' => []]);
+    }
+
+    public function test_list_returns_served_package_names_sorted(): void
+    {
+        $this->makeServedPackage();
+        $this->makeServedPackageNamed('aaa/first');
+        Package::factory()->create(['name' => 'acme/unsynced']);
+
+        $this->get('/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['aaa/first', 'acme/widgets']]);
     }
 
     public function test_stable_metadata_lists_tagged_versions_with_proxied_dists(): void

--- a/tests/Feature/GitHubWebhookTest.php
+++ b/tests/Feature/GitHubWebhookTest.php
@@ -297,6 +297,41 @@ class GitHubWebhookTest extends TestCase
         }
     }
 
+    /**
+     * The app's webhook cannot be told to skip one repository, so a package
+     * that has switched auto-sync off is skipped on the way in — otherwise
+     * the toggle would only mean something for packages carrying their own
+     * hook, which are the ones that did not need it explained.
+     */
+    public function test_a_package_with_auto_sync_switched_off_is_ignored(): void
+    {
+        $this->package()->forceFill(['webhook_enabled' => false])->save();
+
+        $this->deliver('push', $this->push())
+            ->assertAccepted()
+            ->assertJsonPath('status', 'ignored');
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_one_package_opting_out_does_not_hold_up_another_on_the_same_repository(): void
+    {
+        $this->package()->forceFill(['webhook_enabled' => false])->save();
+
+        $syncing = Package::factory()->create([
+            'name' => 'acme/widgets-mirror',
+            'repository' => 'acme/widgets',
+        ]);
+
+        $this->deliver('push', $this->push())->assertAccepted();
+
+        Queue::assertPushed(
+            SyncPackageJob::class,
+            fn (SyncPackageJob $job): bool => $job->package->is($syncing),
+        );
+        Queue::assertPushed(SyncPackageJob::class, 1);
+    }
+
     public function test_the_repository_being_created_publishes_nothing(): void
     {
         $this->package();

--- a/tests/Feature/PackageWebhookRegistrationTest.php
+++ b/tests/Feature/PackageWebhookRegistrationTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Enums\WebhookCoverage;
 use App\Filament\Resources\Packages\Pages\CreatePackage;
+use App\Filament\Resources\Packages\Pages\EditPackage;
 use App\Filament\Resources\Packages\Pages\ViewPackage;
 use App\Models\Package;
 use App\Models\Source;
@@ -26,6 +27,20 @@ class PackageWebhookRegistrationTest extends TestCase
         parent::setUp();
 
         config(['services.github.app.webhook_secret' => 'the-app-webhook-secret']);
+
+        // Without app credentials there is nothing to ask GitHub with, so the
+        // configured secret is taken at its word. Stated rather than inherited
+        // from whatever .env happens to hold, since it decides whether these
+        // tests reach for the network at all.
+        config(['services.github.app.id' => null, 'services.github.app.private_key' => null]);
+    }
+
+    /**
+     * An app whose webhook GitHub confirms posts to this registry.
+     */
+    private function fakeDeliveringAppWebhook(): void
+    {
+        Http::fake(['api.github.com/app/hook/config' => Http::response(['url' => route('webhooks.github')])]);
     }
 
     /**
@@ -40,6 +55,10 @@ class PackageWebhookRegistrationTest extends TestCase
                 'description' => 'Widgets, assembled.',
             ]),
             'api.github.com/repos/*/hooks' => Http::response(['id' => 8675309], 201),
+            'api.github.com/app/installations/*/access_tokens' => Http::response([
+                'token' => 'ghs_installation',
+                'expires_at' => '2099-01-01T00:00:00Z',
+            ]),
         ]);
     }
 
@@ -48,9 +67,29 @@ class PackageWebhookRegistrationTest extends TestCase
         return Source::factory()->withToken()->create(['account' => $account]);
     }
 
+    /**
+     * A source authenticating as an installed GitHub App, which has to be able
+     * to mint a token before it can create anything on a repository.
+     */
+    private function installedSource(string $account = 'acme'): Source
+    {
+        openssl_pkey_export(openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]), $privateKey);
+
+        config([
+            'services.github.app.id' => '123456',
+            'services.github.app.slug' => 'acme-pipeline',
+            'services.github.app.private_key' => $privateKey,
+        ]);
+
+        return Source::factory()->create(['account' => $account]);
+    }
+
     public function test_a_package_under_an_installed_app_needs_no_webhook_of_its_own(): void
     {
-        Http::fake();
+        $this->fakeDeliveringAppWebhook();
 
         $package = Package::factory()->create([
             'repository' => 'https://github.com/acme/widgets',
@@ -62,7 +101,30 @@ class PackageWebhookRegistrationTest extends TestCase
         $this->assertNull($package->refresh()->webhook_id);
 
         // Creating a second hook on the repository would only sync it twice.
-        Http::assertNothingSent();
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/hooks'));
+    }
+
+    /**
+     * The app's webhook is only coverage if GitHub says it delivers here. An
+     * app registered with Webhook → Active unchecked delivers nothing, and a
+     * package told it was covered would never get the repository hook that
+     * would have worked — silently, which is the one thing auto-sync must not
+     * do.
+     */
+    public function test_a_package_is_not_called_covered_by_an_app_webhook_that_was_never_switched_on(): void
+    {
+        $this->fakeGitHub();
+
+        Http::fake(['api.github.com/app/hook/config' => Http::response(['message' => 'Not Found'], 404)]);
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->installedSource()->id,
+        ]);
+
+        $this->assertSame(WebhookCoverage::None, $package->webhookCoverage());
+        $this->assertSame(WebhookCoverage::Repository, app(WebhookRegistrar::class)->register($package));
+        $this->assertSame(8675309, $package->refresh()->webhook_id);
     }
 
     public function test_a_package_the_app_does_not_cover_gets_a_repository_webhook(): void
@@ -173,20 +235,198 @@ class PackageWebhookRegistrationTest extends TestCase
         $this->assertStringContainsString('database went away', (string) $package->webhook_error);
     }
 
-    public function test_an_app_covered_package_is_flagged_when_no_secret_is_configured_here(): void
+    /**
+     * A registry that has not set the app's webhook up is not a registry
+     * whose packages should sit there waiting to be told about it.
+     */
+    public function test_an_app_installed_package_falls_back_to_its_own_webhook_when_no_secret_is_configured(): void
     {
         config(['services.github.app.webhook_secret' => null]);
 
+        $this->fakeGitHub();
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->installedSource()->id,
+        ]);
+
+        $this->assertSame(WebhookCoverage::Repository, app(WebhookRegistrar::class)->register($package));
+
+        $this->assertSame(8675309, $package->refresh()->webhook_id);
+        $this->assertNull(app(WebhookRegistrar::class)->unmetRequirement($package));
+    }
+
+    /**
+     * That fallback needs a permission the app may not have been given, and
+     * the way out of it is the app's own webhook rather than the repository's.
+     */
+    public function test_an_app_installed_package_is_told_both_ways_out_when_the_fallback_is_refused(): void
+    {
+        config(['services.github.app.webhook_secret' => null]);
+
+        Http::fake([
+            'api.github.com/repos/*/hooks' => Http::response(['message' => 'Resource not accessible by integration'], 403),
+            'api.github.com/app/installations/*/access_tokens' => Http::response([
+                'token' => 'ghs_installation',
+                'expires_at' => '2099-01-01T00:00:00Z',
+            ]),
+        ]);
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->installedSource()->id,
+        ]);
+
+        $this->assertSame(WebhookCoverage::Failed, app(WebhookRegistrar::class)->register($package));
+
+        $requirement = (string) app(WebhookRegistrar::class)->unmetRequirement($package);
+
+        $this->assertStringContainsString('GITHUB_APP_WEBHOOK_SECRET', $requirement);
+        $this->assertStringContainsString('Webhooks: Read and write', $requirement);
+    }
+
+    /**
+     * A hook that already exists keeps delivering whatever else is configured
+     * later, so it must not be described as covered by something it is not.
+     */
+    public function test_a_package_with_its_own_hook_keeps_it_once_the_app_webhook_is_set_up(): void
+    {
         $package = Package::factory()->create([
             'repository' => 'https://github.com/acme/widgets',
             'source_id' => Source::factory()->create(['account' => 'acme'])->id,
         ]);
 
-        $this->assertSame(WebhookCoverage::Unconfigured, $package->webhookCoverage());
-        $this->assertStringContainsString(
-            'GITHUB_APP_WEBHOOK_SECRET',
-            (string) app(WebhookRegistrar::class)->unmetRequirement($package),
-        );
+        $package->forceFill(['webhook_id' => 8675309, 'webhook_secret' => 'secret'])->save();
+
+        $this->assertSame(WebhookCoverage::Repository, $package->webhookCoverage());
+    }
+
+    public function test_a_new_package_syncs_on_push_unless_it_is_told_otherwise(): void
+    {
+        $this->assertTrue((new Package)->webhook_enabled);
+        $this->assertTrue(Package::factory()->create()->webhook_enabled);
+    }
+
+    public function test_a_package_with_auto_sync_switched_off_has_no_webhook_arranged(): void
+    {
+        Http::fake();
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->tokenSource()->id,
+            'webhook_enabled' => false,
+        ]);
+
+        $this->assertSame(WebhookCoverage::Disabled, $package->webhookCoverage());
+        $this->assertSame(WebhookCoverage::Disabled, app(WebhookRegistrar::class)->reconcile($package));
+        $this->assertNull($package->refresh()->webhook_id);
+
+        // Off is off, not "left undone".
+        $this->assertNull(app(WebhookRegistrar::class)->unmetRequirement($package));
+
+        Http::assertNothingSent();
+    }
+
+    public function test_switching_auto_sync_off_removes_the_webhook_from_github(): void
+    {
+        $this->fakeGitHub();
+        Http::fake(['api.github.com/repos/*/hooks/8675309' => Http::response(status: 204)]);
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->tokenSource()->id,
+        ]);
+
+        app(WebhookRegistrar::class)->reconcile($package);
+
+        $this->assertSame(8675309, $package->refresh()->webhook_id);
+
+        $package->forceFill(['webhook_enabled' => false])->save();
+
+        $this->assertSame(WebhookCoverage::Disabled, app(WebhookRegistrar::class)->reconcile($package));
+
+        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
+            && $request->url() === 'https://api.github.com/repos/acme/widgets/hooks/8675309');
+
+        $package->refresh();
+
+        $this->assertNull($package->webhook_id);
+        $this->assertNull($package->webhook_secret);
+    }
+
+    public function test_switching_auto_sync_on_again_sets_the_webhook_back_up(): void
+    {
+        $this->fakeGitHub();
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->tokenSource()->id,
+            'webhook_enabled' => false,
+        ]);
+
+        $package->forceFill(['webhook_enabled' => true])->save();
+
+        $this->assertSame(WebhookCoverage::Repository, app(WebhookRegistrar::class)->reconcile($package));
+        $this->assertSame(8675309, $package->refresh()->webhook_id);
+    }
+
+    public function test_the_toggle_on_the_edit_page_creates_and_removes_the_webhook(): void
+    {
+        $this->fakeGitHub();
+        Http::fake(['api.github.com/repos/*/hooks/8675309' => Http::response(status: 204)]);
+
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->tokenSource()->id,
+            'webhook_enabled' => false,
+        ]);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getKey()])
+            ->fillForm(['webhook_enabled' => true])
+            ->call('save')
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        $this->assertSame(8675309, $package->refresh()->webhook_id);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getKey()])
+            ->fillForm(['webhook_enabled' => false])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $package->refresh();
+
+        $this->assertFalse($package->webhook_enabled);
+        $this->assertNull($package->webhook_id);
+
+        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE');
+    }
+
+    /**
+     * Editing anything else must not cost an API call, nor quietly retry a
+     * webhook that failed for a reason nobody has fixed yet.
+     */
+    public function test_an_edit_that_leaves_the_toggle_alone_does_not_touch_github(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $package = Package::factory()->create([
+            'repository' => 'https://github.com/acme/widgets',
+            'source_id' => $this->tokenSource()->id,
+        ]);
+
+        Http::fake();
+
+        Livewire::test(EditPackage::class, ['record' => $package->getKey()])
+            ->fillForm(['description' => 'A better description.'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertSame('A better description.', $package->refresh()->description);
+
+        Http::assertNothingSent();
     }
 
     public function test_creating_a_package_through_the_wizard_registers_its_webhook(): void

--- a/tests/Feature/ShieldPermissionSeederTest.php
+++ b/tests/Feature/ShieldPermissionSeederTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class ShieldPermissionSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_the_permission_rows(): void
+    {
+        // The base TestCase already ran the seeder against a fresh database.
+        $this->assertGreaterThan(0, Permission::count());
+        $this->assertTrue(Permission::where('name', 'ViewAny:Package')->exists());
+    }
+
+    /**
+     * The first deploy on a hosting provider hits this order: a request or
+     * command touches the gate while the permissions table is still empty
+     * (caching that emptiness), and only then does `db:seed` run. Because
+     * DatabaseSeeder mutes model events, Shield's permission creates never
+     * invalidate that cache, and the very first grant resolves names against
+     * the stale empty snapshot — dying with PermissionDoesNotExist.
+     *
+     * Seeding through DatabaseSeeder (not the child seeder directly) is what
+     * reproduces this: the WithoutModelEvents trait lives there.
+     */
+    public function test_it_seeds_over_a_cache_primed_while_the_table_was_empty(): void
+    {
+        // Builder deletes skip the model events that would clear the cache,
+        // just like a database that simply has not been seeded yet.
+        DB::table(config('permission.table_names.permissions'))->delete();
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        // Prime the cache with the empty table, as any login attempt would.
+        $this->assertCount(0, app(PermissionRegistrar::class)->getPermissions());
+
+        $this->seed();
+
+        $this->assertTrue(Permission::where('name', 'ViewAny:Package')->exists());
+
+        // And the account command must survive the same staleness: it syncs
+        // the freshly seeded permission ids onto the super admin role.
+        Artisan::call('admin:create', ['email' => 'admin@example.com', '--no-interaction' => true]);
+
+        $user = User::where('email', 'admin@example.com')->sole();
+
+        $this->assertSame(
+            Permission::count(),
+            $user->roles()->sole()->permissions()->count(),
+        );
+    }
+}

--- a/tests/Feature/SourceResourceTest.php
+++ b/tests/Feature/SourceResourceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Enums\SourceProvider;
+use App\Enums\WebhookState;
 use App\Filament\Resources\Packages\Pages\EditPackage;
 use App\Filament\Resources\Sources\Pages\CreateSource;
 use App\Filament\Resources\Sources\Pages\EditSource;
@@ -12,6 +13,8 @@ use App\Filament\Resources\Sources\RelationManagers\PackagesRelationManager;
 use App\Models\Package;
 use App\Models\Source;
 use App\Models\User;
+use App\Services\GitHub\GitHubApp;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
@@ -39,6 +42,17 @@ class SourceResourceTest extends TestCase
             'private_key' => $pem,
             'api_url' => 'https://api.github.com',
         ]);
+    }
+
+    /**
+     * An app that can be asked about its webhook, and a secret to verify the
+     * deliveries it would send.
+     */
+    private function configureGitHubAppWebhook(): void
+    {
+        $this->configureGitHubApp();
+
+        config()->set('services.github.app.webhook_secret', 'the-app-webhook-secret');
     }
 
     public function test_the_index_offers_connecting_without_creating_a_record_first(): void
@@ -176,6 +190,134 @@ class SourceResourceTest extends TestCase
             ->assertOk()
             ->assertSee($source->account)
             ->assertSee('GitHub App installation #'.$source->installation_id);
+    }
+
+    /**
+     * The app's webhook is set up once and covers every repository under every
+     * source, so the source page is where an admin is told how — with the
+     * secret generated for them rather than asked for.
+     */
+    public function test_the_view_page_offers_the_webhook_settings_when_none_is_configured(): void
+    {
+        config(['services.github.app.webhook_secret' => null]);
+
+        $source = Source::factory()->create(['account' => 'acme']);
+
+        Livewire::test(ViewSource::class, ['record' => $source->getKey()])
+            ->assertOk()
+            ->assertSee('No secret set')
+            ->assertSee(route('webhooks.github'))
+            ->assertSee('GITHUB_APP_WEBHOOK_SECRET')
+            ->assertSee(app(GitHubApp::class)->suggestedWebhookSecret());
+    }
+
+    /**
+     * A secret in the environment says nothing about whether the app was ever
+     * given a webhook to sign with it, so GitHub is asked.
+     */
+    public function test_an_app_with_no_webhook_of_its_own_is_reported_as_not_switched_on(): void
+    {
+        $this->configureGitHubAppWebhook();
+
+        Http::fake(['api.github.com/app/hook/config' => Http::response(['message' => 'Not Found'], 404)]);
+
+        $this->assertSame(WebhookState::Absent, app(GitHubApp::class)->webhookState());
+        $this->assertFalse(app(GitHubApp::class)->hasWebhook());
+
+        Livewire::test(ViewSource::class, ['record' => Source::factory()->create()->getKey()])
+            ->assertOk()
+            ->assertSee('Not switched on');
+    }
+
+    public function test_an_app_webhook_pointing_at_another_environment_is_not_counted_as_coverage(): void
+    {
+        $this->configureGitHubAppWebhook();
+
+        Http::fake(['api.github.com/app/hook/config' => Http::response([
+            'url' => 'https://packages.example.com/incoming/github',
+            'content_type' => 'json',
+        ])]);
+
+        $this->assertSame(WebhookState::Elsewhere, app(GitHubApp::class)->webhookState());
+        $this->assertFalse(app(GitHubApp::class)->hasWebhook());
+        $this->assertSame('https://packages.example.com/incoming/github', app(GitHubApp::class)->deliveringTo());
+    }
+
+    public function test_an_app_webhook_posting_here_is_confirmed(): void
+    {
+        $this->configureGitHubAppWebhook();
+
+        Http::fake(['api.github.com/app/hook/config' => Http::response([
+            'url' => route('webhooks.github'),
+            'content_type' => 'json',
+        ])]);
+
+        $this->assertSame(WebhookState::Delivering, app(GitHubApp::class)->webhookState());
+        $this->assertTrue(app(GitHubApp::class)->hasWebhook());
+    }
+
+    /**
+     * GitHub being unreachable is not evidence that the webhook is gone, and
+     * treating it as such would grow a repository hook on every package
+     * created during an outage.
+     */
+    public function test_github_being_unreachable_leaves_the_configured_secret_its_benefit_of_the_doubt(): void
+    {
+        $this->configureGitHubAppWebhook();
+
+        Http::fake(['api.github.com/app/hook/config' => Http::response(['message' => 'Bad gateway'], 502)]);
+
+        $this->assertSame(WebhookState::Unverifiable, app(GitHubApp::class)->webhookState());
+        $this->assertTrue(app(GitHubApp::class)->hasWebhook());
+    }
+
+    public function test_rechecking_asks_github_again_rather_than_the_cache(): void
+    {
+        $this->configureGitHubAppWebhook();
+
+        // The webhook is switched on between the two checks, which the cached
+        // answer would go on denying for another five minutes.
+        Http::fakeSequence('api.github.com/app/hook/config')
+            ->push(['message' => 'Not Found'], 404)
+            ->push(['url' => route('webhooks.github')]);
+
+        $this->assertFalse(app(GitHubApp::class)->hasWebhook());
+
+        Livewire::test(ViewSource::class, ['record' => Source::factory()->create()->getKey()])
+            ->callAction(TestAction::make('recheckWebhook')->schemaComponent('webhook'))
+            ->assertNotified();
+
+        $this->assertTrue(app(GitHubApp::class)->hasWebhook());
+    }
+
+    public function test_the_view_page_stops_offering_a_secret_once_one_is_set(): void
+    {
+        config(['services.github.app.webhook_secret' => 'already-set']);
+
+        $source = Source::factory()->create(['account' => 'acme']);
+
+        Livewire::test(ViewSource::class, ['record' => $source->getKey()])
+            ->assertOk()
+            ->assertSee('Configured')
+            // The configured secret lives in the environment and is never read
+            // back out to a browser.
+            ->assertDontSee('already-set')
+            ->assertDontSee(app(GitHubApp::class)->suggestedWebhookSecret());
+    }
+
+    /**
+     * A token-based source does not authenticate as the app, so the app's
+     * webhook has nothing to do with its repositories.
+     */
+    public function test_a_token_source_is_not_offered_the_app_webhook_settings(): void
+    {
+        config(['services.github.app.webhook_secret' => null]);
+
+        $source = Source::factory()->withToken()->create(['account' => 'acme']);
+
+        Livewire::test(ViewSource::class, ['record' => $source->getKey()])
+            ->assertOk()
+            ->assertDontSee('GITHUB_APP_WEBHOOK_SECRET');
     }
 
     public function test_the_view_page_lists_the_packages_bridged_through_the_source(): void

--- a/tests/Feature/UserResourceTest.php
+++ b/tests/Feature/UserResourceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Users\Pages\CreateUser;
+use App\Filament\Resources\Users\Pages\EditUser;
+use App\Filament\Resources\Users\Pages\ListUsers;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class UserResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()->superAdmin()->create();
+        $this->actingAs($this->admin);
+    }
+
+    private function role(string $name): Role
+    {
+        return Role::findOrCreate($name, 'web');
+    }
+
+    public function test_a_user_with_no_role_cannot_reach_the_users_resource(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->get('/admin/users')->assertForbidden();
+    }
+
+    public function test_the_user_index_lists_records(): void
+    {
+        $users = User::factory()->count(3)->create();
+
+        $this->get('/admin/users')->assertOk();
+
+        Livewire::test(ListUsers::class)
+            ->assertCanSeeTableRecords($users);
+    }
+
+    public function test_a_user_can_be_created_with_a_role(): void
+    {
+        $role = $this->role('panel_user');
+
+        Livewire::test(CreateUser::class)
+            ->fillForm([
+                'name' => 'Jo Packager',
+                'email' => 'jo@example.com',
+                'password' => 'a-long-password',
+                'roles' => [$role->getKey()],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $user = User::query()->where('email', 'jo@example.com')->firstOrFail();
+
+        $this->assertTrue($user->hasRole('panel_user'));
+        $this->assertTrue(Hash::check('a-long-password', $user->password));
+    }
+
+    public function test_the_email_must_be_unique(): void
+    {
+        User::factory()->create(['email' => 'jo@example.com']);
+
+        Livewire::test(CreateUser::class)
+            ->fillForm([
+                'name' => 'Jo Duplicate',
+                'email' => 'jo@example.com',
+                'password' => 'a-long-password',
+            ])
+            ->call('create')
+            ->assertHasFormErrors(['email']);
+    }
+
+    public function test_a_users_roles_can_be_changed(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole($this->role('panel_user'));
+        $observer = $this->role('observer');
+
+        Livewire::test(EditUser::class, ['record' => $user->getKey()])
+            ->fillForm(['roles' => [$observer->getKey()]])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $user->refresh();
+
+        $this->assertTrue($user->hasRole('observer'));
+        $this->assertFalse($user->hasRole('panel_user'));
+    }
+
+    public function test_saving_without_a_new_password_keeps_the_existing_one(): void
+    {
+        $user = User::factory()->create(['password' => 'original-password']);
+
+        Livewire::test(EditUser::class, ['record' => $user->getKey()])
+            ->fillForm(['name' => 'Renamed'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $user->refresh();
+
+        $this->assertSame('Renamed', $user->name);
+        $this->assertTrue(Hash::check('original-password', $user->password));
+    }
+
+    public function test_an_admin_cannot_change_their_own_roles(): void
+    {
+        Livewire::test(EditUser::class, ['record' => $this->admin->getKey()])
+            ->assertFormFieldDisabled('roles')
+            ->fillForm(['roles' => []])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertTrue($this->admin->fresh()->hasRole('super_admin'));
+    }
+
+    public function test_an_admin_cannot_delete_their_own_account(): void
+    {
+        Livewire::test(EditUser::class, ['record' => $this->admin->getKey()])
+            ->assertActionHidden('delete');
+
+        Livewire::test(EditUser::class, ['record' => User::factory()->create()->getKey()])
+            ->assertActionVisible('delete');
+    }
+}


### PR DESCRIPTION
This pull request introduces several significant improvements to the application's admin panel, focusing on enhanced management of users and GitHub webhooks. It adds a complete user management interface, refines webhook configuration and status reporting, and improves the handling of package auto-sync settings. The most important changes are grouped below by theme.

**User Management Interface:**

* Added a full set of Filament resources for managing users, including `CreateUser`, `EditUser`, `ListUsers` pages, a `UserForm` schema for user creation/editing, and a `UsersTable` for listing users. These resources provide role assignment (with safeguards against self-lockout), password handling, and bulk actions, ensuring robust and safe user administration. [[1]](diffhunk://#diff-f160034ce383107b2b7899a31f10a250292bbffddeddd24a94c59520039947cfR1-R11) [[2]](diffhunk://#diff-960a677382a931f51d6ae8ff66e7a8357a8e615c963de8bc044d5dcb8ad696d1R1-R51) [[3]](diffhunk://#diff-c6d555edc80845e191bf708da7063366065aad1d78c0db0bfb67f0c81bf398baR1-R19) [[4]](diffhunk://#diff-5ad761b71d43a1e10ff62471427c3b3a744ae899f298fd64d4ae76a25aa88aabR1-R55) [[5]](diffhunk://#diff-2a179c39daa54692d79805d34aa4a0d84cc622284df0e978034df26fe07612ceR1-R21)

**Webhook Configuration and Status Reporting:**

* Introduced the `WebhookState` enum to represent the status of the GitHub App's webhook, with clear labels, colors, and remedies for each state. This makes webhook issues more visible and actionable.
* Added a `RecheckWebhookAction` to allow instant refresh of the webhook status from GitHub, ensuring admins can verify changes immediately after making them.
* Updated the source infolist (`SourceInfolist.php`) to display detailed webhook status, payload URL, and secret suggestions, integrating the new `WebhookState` and recheck action for improved transparency and guidance. [[1]](diffhunk://#diff-9ff34be93b314344a12183f16972b8f60ea2afb9796c89a22d37cfab5170be57R5-R10) [[2]](diffhunk://#diff-9ff34be93b314344a12183f16972b8f60ea2afb9796c89a22d37cfab5170be57R72-R118)

**Package Auto-Sync Improvements:**

* Added a `webhook_enabled` toggle to the package form, with dynamic helper text explaining its effect. This toggle now directly manages the creation and removal of repository webhooks, or defers to the app's webhook if present. [[1]](diffhunk://#diff-8bea0e04cf4ea577051bc4ac6aa307679becc47c7e896b3be3499abaacc355aaR5-R11) [[2]](diffhunk://#diff-8bea0e04cf4ea577051bc4ac6aa307679becc47c7e896b3be3499abaacc355aaR34-R61)
* Refined the package edit page to only trigger GitHub webhook reconciliation when the auto-sync toggle changes, minimizing unnecessary API calls and providing clear, persistent notifications about the result. [[1]](diffhunk://#diff-14af8e76ad32bb4a0a3df2434681c5fd658ad9c46770562ac70675cd39bda49fR5-R12) [[2]](diffhunk://#diff-14af8e76ad32bb4a0a3df2434681c5fd658ad9c46770562ac70675cd39bda49fR27-R62)

**Webhook Coverage Enum Update:**

* Updated the `WebhookCoverage` enum: removed the `Unconfigured` state, added a `Disabled` state, and adjusted label and color mappings for clarity in the UI. [[1]](diffhunk://#diff-6e0e799602745f83064c6b90ca1ffd28ee31f2bc5593b8ce901594c0f33e9260L23-R28) [[2]](diffhunk://#diff-6e0e799602745f83064c6b90ca1ffd28ee31f2bc5593b8ce901594c0f33e9260L37-R38) [[3]](diffhunk://#diff-6e0e799602745f83064c6b90ca1ffd28ee31f2bc5593b8ce901594c0f33e9260L48-R49)

**Admin User Creation Fix:**

* Fixed a potential issue in the `CreateAdmin` command by ensuring the Spatie permission cache is cleared before syncing permissions, preventing errors when permissions are newly seeded. [[1]](diffhunk://#diff-ded8ea4a75605044eae0669e48a7e3abda1e9935319c12d19e13822046c7564dR14) [[2]](diffhunk://#diff-ded8ea4a75605044eae0669e48a7e3abda1e9935319c12d19e13822046c7564dR102-R106)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches webhook delivery, GitHub API verification, and admin user/role management; mistakes could affect auto-sync behavior or panel access, but changes are guarded with tests and conservative fallbacks when GitHub is unreachable.
> 
> **Overview**
> Adds **Filament user administration** (list/create/edit, Shield-backed `UserPolicy`, role assignment with guards against deleting yourself or stripping your own roles) and wires **profile editing** via `filament-edit-profile` in the user menu.
> 
> **Composer v2** no longer exposes every package name on `packages.json`; the root advertises **`search.json`** and **`list.json`** instead, with prefix/type filtering and only packages that have synced versions.
> 
> **Auto-sync / webhooks** get a per-package **`webhook_enabled`** toggle that reconciles repository hooks through `WebhookRegistrar::reconcile()` (including removal when turned off) and is ignored on app-level deliveries when off. App-wide coverage is no longer inferred from env alone: **`GitHubApp`** calls GitHub’s hook config API (cached), introduces **`WebhookState`**, and the source view shows payload URL, suggested secret, and **Re-check**. **`WebhookCoverage`** drops `Unconfigured` and adds **`Disabled`**.
> 
> **Deploy/bootstrap reliability**: `admin:create` and **`ShieldPermissionSeeder`** clear Spatie’s permission cache around permission sync/seed so fresh deploys do not hit `PermissionDoesNotExist`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c220ca51781600011ecdad0caefb405d9abec12b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->