### PR TITLE
Persist archives and queue initial package sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Package Pipeline
 
-Package Pipeline is a self-hosted private Composer registry with a [Filament](https://filamentphp.com) admin panel. Point it at your GitHub repositories and it syncs their tags and branches into versioned package metadata, then serves everything over the standard [Composer v2 repository API](https://getcomposer.org/doc/05-repositories.md#composer) — so any project can `composer require` your private packages without them ever touching Packagist.
+Sharing private PHP packages across projects is a chore: every consuming app needs its own `repositories` entries in `composer.json`, its own GitHub credentials, and Composer crawls the GitHub API repo-by-repo just to resolve versions. Package Pipeline replaces all of that with one self-hosted registry. Point it at your GitHub repositories once, and every project can `composer require` your private packages as if they were on Packagist — one repository URL to configure, no per-repo wiring, and your code never leaves your infrastructure.
 
-**How it works, in one pass:** you register a **package** (a GitHub repository) in the admin panel, a sync job reads its tags and branches and stores each one as a version, and Composer clients fetch `/packages.json`, per-package metadata, and zipball dists straight from the app. Zipballs are proxied from GitHub once and cached on a local or S3 disk. Authentication against GitHub goes through a **source** (a connected GitHub App installation with short-lived, org-owned tokens), a per-package token, or a global fallback token — whichever is available, in that order.
+**How it works, in one pass:** you register a **package** (a GitHub repository) in the [Filament](https://filamentphp.com) admin panel, a sync job reads its tags and branches and stores each one as a version, and Composer clients fetch `/packages.json`, per-package metadata, and zipball dists straight from the app over the standard [Composer v2 repository API](https://getcomposer.org/doc/05-repositories.md#composer). Each version's zipball is downloaded from GitHub at sync time and stored on a local or S3 disk with its sha1 checksum, so dist downloads are served entirely from the app's own storage. Authentication against GitHub goes through a **source** (a connected GitHub App installation with short-lived, org-owned tokens), a per-package token, or a global fallback token — whichever is available, in that order.
 
 ## Requirements
 
@@ -103,7 +103,7 @@ composer config repositories.private composer https://packages.example.com
 composer require acme/core
 ```
 
-Composer will resolve versions from the registry and download dists through it; each zipball is fetched from GitHub once and cached.
+Composer will resolve versions from the registry and download dists through it; every zipball is served from the archive stored at sync time (and verified against its published `shasum`), so GitHub is never in the download path.
 
 > [!WARNING]
 > The Composer endpoints (`/packages.json`, `/p2/...`, `/dist/...`) are currently **unauthenticated** — anyone who can reach the app over the network can list and install your packages. Until repository-level auth lands, run the app somewhere access-controlled: a VPN, a private network, or behind a proxy that enforces auth.
@@ -117,7 +117,7 @@ Everything lives in `.env`; the interesting knobs beyond a stock Laravel app:
 | `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` | The GitHub App that powers sources. The key takes a path to the `.pem` or the key itself with `\n`-escaped newlines. |
 | `GITHUB_APP_SLUG` / `GITHUB_APP_API_URL` | Normally read from GitHub automatically; only set to skip that lookup or on GitHub Enterprise. |
 | `GITHUB_TOKEN` | Fallback token for packages with neither a connected source nor a token of their own. |
-| `DIST_DISK` | Disk for cached Composer zipballs. Defaults to `FILESYSTEM_DISK`; set to `s3` on any deployment whose containers don't share a local disk. |
+| `DIST_DISK` | Disk where version archives (Composer zipballs) are stored at sync time. Defaults to `FILESYSTEM_DISK`; set to `s3` on any deployment whose containers don't share a local disk. |
 
 ## Development
 
@@ -143,7 +143,8 @@ The short version for production:
 
 - **Seed the permissions** with `php artisan db:seed --force`, after migrating and on any deploy that adds a resource. Shield's policies check permissions that must exist as rows in the database; without them the panel denies everything, super admin included.
 - **Create the first admin account** with `php artisan admin:create you@example.com`. A command runner with no terminal attached (Laravel Cloud's, a deploy hook) can't prompt for a password, so the command prints a signed, single-use link that sets one in the browser instead — no password in the environment, and none in the provider's command log. The link expires after **5 minutes**; re-run the command for a fresh one. It needs no mail configuration.
-- **Set `DIST_DISK=s3`** (and the `AWS_*` variables) whenever app containers don't share a filesystem, so every instance sees the same zipball cache. On Laravel Cloud, attaching an object storage bucket injects the `AWS_*` values automatically.
+- **Set `DIST_DISK=s3`** (and the `AWS_*` variables) whenever app containers don't share a filesystem, so every instance sees the same stored archives. On Laravel Cloud, attaching an object storage bucket injects the `AWS_*` values automatically.
+- **Prune orphaned archives occasionally** with `php artisan archives:clean` (`--dry-run` to preview) — re-synced versions write fresh files and leave their old ones behind by design. It's a fine candidate for the scheduler alongside `packages:sync`.
 - **Register a separate GitHub App per environment** — an app's Setup URL points at exactly one deployment. See [docs/github-app.md](docs/github-app.md).
 - A health check endpoint is available at `/up`.
 
@@ -152,7 +153,7 @@ The short version for production:
 [Laravel Cloud](https://cloud.laravel.com) runs this app well with almost no configuration. Create the application from your fork of this repository, then:
 
 1. **Attach a database.** App containers are ephemeral, so the SQLite default won't survive a deploy — attach a Cloud database (MySQL or Postgres) from the environment's **Resources** and let Cloud inject the `DB_*` variables.
-2. **Attach an object storage bucket** and set `DIST_DISK=s3`. Cloud injects the `AWS_*` variables when the bucket is attached; without it, cached zipballs vanish on every deploy and each instance keeps its own cache.
+2. **Attach an object storage bucket** and set `DIST_DISK=s3`. Cloud injects the `AWS_*` variables when the bucket is attached; without it, stored version archives vanish on every deploy and Composer downloads 404 until the next sync rebuilds them.
 3. **Add the deploy commands** so migrations and Shield's permission rows are in place before anyone logs in:
 
    ```bash

--- a/app/Auth/OidcProvider.php
+++ b/app/Auth/OidcProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Auth;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Laravel\Socialite\Two\AbstractProvider;
+use Laravel\Socialite\Two\User;
+
+/**
+ * A generic OpenID Connect provider: endpoints come from the issuer's
+ * discovery document instead of being baked into a driver, so any compliant
+ * identity provider works without a package per vendor.
+ */
+class OidcProvider extends AbstractProvider
+{
+    /**
+     * @var array<int, string>
+     */
+    protected $scopes = ['openid', 'profile', 'email'];
+
+    protected $scopeSeparator = ' ';
+
+    /**
+     * @param  array{authorization_endpoint: string, token_endpoint: string, userinfo_endpoint: string}  $endpoints
+     */
+    public function __construct(
+        Request $request,
+        string $clientId,
+        string $clientSecret,
+        string $redirectUrl,
+        private readonly array $endpoints,
+    ) {
+        parent::__construct($request, $clientId, $clientSecret, $redirectUrl);
+    }
+
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase($this->endpoints['authorization_endpoint'], $state);
+    }
+
+    protected function getTokenUrl(): string
+    {
+        return $this->endpoints['token_endpoint'];
+    }
+
+    protected function getUserByToken($token): array
+    {
+        return Http::withToken($token)
+            ->acceptJson()
+            ->get($this->endpoints['userinfo_endpoint'])
+            ->throw()
+            ->json();
+    }
+
+    protected function mapUserToObject(array $user): User
+    {
+        return (new User)->setRaw($user)->map([
+            'id' => $user['sub'] ?? null,
+            'name' => $user['name'] ?? $user['preferred_username'] ?? null,
+            'email' => $user['email'] ?? null,
+        ]);
+    }
+}

--- a/app/Auth/SsoProviderFactory.php
+++ b/app/Auth/SsoProviderFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Auth;
+
+use App\Enums\AuthProvider;
+use App\Models\AuthenticationSource;
+use Illuminate\Support\Facades\Http;
+use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\GithubProvider;
+use Laravel\Socialite\Two\GitlabProvider;
+use Laravel\Socialite\Two\GoogleProvider;
+use RuntimeException;
+
+/**
+ * Builds a Socialite provider from an authentication source row — the
+ * credentials live in the database, not in config/services.php, so admins
+ * add login providers at runtime.
+ */
+class SsoProviderFactory
+{
+    public function provider(AuthenticationSource $source): Provider
+    {
+        $config = [
+            'client_id' => $source->client_id,
+            'client_secret' => $source->client_secret,
+            'redirect' => $source->callbackUrl(),
+        ];
+
+        return match ($source->provider) {
+            AuthProvider::Github => Socialite::buildProvider(GithubProvider::class, $config),
+            AuthProvider::Google => Socialite::buildProvider(GoogleProvider::class, $config),
+            AuthProvider::Gitlab => Socialite::buildProvider(GitlabProvider::class, $config),
+            AuthProvider::Oidc => new OidcProvider(
+                request(),
+                $source->client_id,
+                $source->client_secret,
+                $source->callbackUrl(),
+                $this->discover($source),
+            ),
+        };
+    }
+
+    /**
+     * The issuer's endpoints, read from its discovery document and cached —
+     * the document moves at the speed of infrastructure, not of logins.
+     *
+     * @return array{authorization_endpoint: string, token_endpoint: string, userinfo_endpoint: string}
+     */
+    private function discover(AuthenticationSource $source): array
+    {
+        throw_if(blank($source->discovery_url), new RuntimeException(
+            "The OIDC source \"{$source->name}\" has no discovery URL.",
+        ));
+
+        return cache()->remember(
+            "oidc-discovery:{$source->id}",
+            now()->addHour(),
+            function () use ($source): array {
+                $document = Http::acceptJson()->get($source->discovery_url)->throw()->json();
+
+                foreach (['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'] as $key) {
+                    throw_unless(
+                        is_string($document[$key] ?? null),
+                        new RuntimeException("The discovery document at {$source->discovery_url} is missing {$key}."),
+                    );
+                }
+
+                return [
+                    'authorization_endpoint' => $document['authorization_endpoint'],
+                    'token_endpoint' => $document['token_endpoint'],
+                    'userinfo_endpoint' => $document['userinfo_endpoint'],
+                ];
+            },
+        );
+    }
+}

--- a/app/Console/Commands/AddPackage.php
+++ b/app/Console/Commands/AddPackage.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Services\GitHub\WebhookRegistrar;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\text;
+
+/**
+ * The create wizard's job, scriptable: name a repository URL and the package
+ * is created, webhooked where possible, and queued for its first sync.
+ */
+class AddPackage extends Command
+{
+    protected $signature = 'package:add
+        {repository? : The VCS repository URL (https://github.com/owner/repo); prompted for when omitted}
+        {--name= : The composer name; guessed from the URL when omitted}
+        {--repo= : The Composer repository path to serve it from; the root repository when omitted}
+        {--token= : A GitHub token, for repositories no connected source covers}
+        {--no-webhook : Do not create a repository webhook}
+        {--no-sync : Do not queue the first sync}';
+
+    protected $description = 'Create a package from a VCS repository URL and queue its first sync';
+
+    public function handle(WebhookRegistrar $registrar): int
+    {
+        $url = $this->argument('repository');
+
+        if (blank($url) && $this->input->isInteractive() && defined('STDIN') && stream_isatty(STDIN)) {
+            $url = text(label: 'Repository URL', required: true, placeholder: 'https://github.com/vendor/package');
+        }
+
+        if (blank($url)) {
+            $this->components->error('A repository URL is required when the command cannot prompt for one.');
+
+            return self::FAILURE;
+        }
+
+        $repository = $this->composerRepository();
+
+        if ($repository === null) {
+            return self::FAILURE;
+        }
+
+        $package = new Package([
+            'repository' => $url,
+            'token' => $this->option('token') ?: null,
+            'repository_id' => $repository->id,
+        ]);
+
+        $name = $this->option('name') ?: $package->suggestedName();
+
+        if (blank($name)) {
+            $this->components->error("The composer name cannot be guessed from [{$url}]; pass it with --name.");
+
+            return self::FAILURE;
+        }
+
+        $package->name = $name;
+
+        $collision = $repository->packages()
+            ->where(fn ($query) => $query->where('name', $name)->orWhere('repository', $url))
+            ->first();
+
+        if ($collision instanceof Package) {
+            $this->components->error("\"{$collision->name}\" already serves from this Composer repository ({$collision->repository}).");
+
+            return self::FAILURE;
+        }
+
+        $package->save();
+
+        $this->components->info("Created {$package->name} in the \"{$repository->name}\" repository.");
+
+        if (! $this->option('no-webhook')) {
+            $registrar->register($package);
+
+            if ($reason = $registrar->unmetRequirement($package)) {
+                $this->components->warn("This package will not sync itself: {$reason}");
+            }
+        }
+
+        if (! $this->option('no-sync')) {
+            SyncPackageJob::dispatch($package);
+            $this->components->info('First sync queued; versions import in the background.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function composerRepository(): ?Repository
+    {
+        $path = $this->option('repo');
+
+        if (blank($path)) {
+            return Repository::default();
+        }
+
+        $repository = Repository::query()->where('path', $path)->first();
+
+        if (! $repository instanceof Repository) {
+            $this->components->error(sprintf(
+                'No Composer repository is served at /r/%s. Existing paths: %s.',
+                $path,
+                Repository::query()->whereNotNull('path')->orderBy('path')->pluck('path')->implode(', ') ?: '(none)',
+            ));
+
+            return null;
+        }
+
+        return $repository;
+    }
+}

--- a/app/Console/Commands/AddToken.php
+++ b/app/Console/Commands/AddToken.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\TokenAbility;
+use App\Models\DeployToken;
+use App\Models\Token;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Issues a Composer access token from the console — provisioning a CI system
+ * or a teammate's machine without a trip through the panel.
+ */
+class AddToken extends Command
+{
+    protected $signature = 'token:add
+        {name : What the token is for; shown in listings}
+        {--user= : Issue a personal token for the user with this email}
+        {--deploy= : Issue for the deploy token with this name, creating it if missing}
+        {--ability=* : read and/or write; read when omitted}
+        {--expires-days= : Expire after this many days; never when omitted}';
+
+    protected $description = 'Issue a Composer access token for a user or a deploy token';
+
+    public function handle(): int
+    {
+        $owner = $this->resolveOwner();
+
+        if ($owner === null) {
+            return self::FAILURE;
+        }
+
+        $abilities = $this->resolveAbilities();
+
+        if ($abilities === null) {
+            return self::FAILURE;
+        }
+
+        $days = $this->option('expires-days');
+
+        $new = Token::issue(
+            $owner,
+            (string) $this->argument('name'),
+            $abilities,
+            filled($days) ? now()->addDays((int) $days)->endOfDay() : null,
+        );
+
+        $host = parse_url((string) config('app.url'), PHP_URL_HOST) ?: 'localhost';
+
+        $this->components->info('Token created. Copy it now — it will not be shown again.');
+        $this->line($new->plainText);
+        $this->newLine();
+        $this->components->bulletList([
+            "composer config http-basic.{$host} token {$new->plainText}",
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The principal the token belongs to: exactly one of --user / --deploy.
+     */
+    private function resolveOwner(): ?Model
+    {
+        $email = $this->option('user');
+        $deploy = $this->option('deploy');
+
+        if (filled($email) === filled($deploy)) {
+            $this->components->error('Pass exactly one of --user=<email> or --deploy=<name>.');
+
+            return null;
+        }
+
+        if (filled($email)) {
+            $user = User::query()->where('email', $email)->first();
+
+            if (! $user instanceof User) {
+                $this->components->error("No user has the email address {$email}.");
+
+                return null;
+            }
+
+            return $user;
+        }
+
+        // A deploy token is only a name and its grants; naming a new one here
+        // creates an unscoped principal, exactly like the panel's create form
+        // before any grants are picked.
+        return DeployToken::query()->firstOrCreate(['name' => $deploy]);
+    }
+
+    /**
+     * @return list<TokenAbility>|null
+     */
+    private function resolveAbilities(): ?array
+    {
+        $options = (array) $this->option('ability') ?: ['read'];
+
+        $abilities = [];
+
+        foreach ($options as $option) {
+            $ability = match ($option) {
+                'read' => TokenAbility::RepositoryRead,
+                'write' => TokenAbility::RepositoryWrite,
+                default => TokenAbility::tryFrom($option),
+            };
+
+            if ($ability === null) {
+                $this->components->error("Unknown ability \"{$option}\". Use read and/or write.");
+
+                return null;
+            }
+
+            $abilities[$ability->value] = $ability;
+        }
+
+        return array_values($abilities);
+    }
+}

--- a/app/Console/Commands/AddUser.php
+++ b/app/Console/Commands/AddUser.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\Concerns\IssuesPasswordResetLinks;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\text;
+
+/**
+ * Provisions a regular panel account. `admin:create` remains the tool for
+ * the super admin; this one creates everyone else, with whatever roles an
+ * admin has shaped in the panel.
+ */
+class AddUser extends Command
+{
+    use IssuesPasswordResetLinks;
+
+    protected $signature = 'user:add
+        {email? : The account email address; prompted for when omitted}
+        {--name= : Display name; derived from the email when omitted}
+        {--role=* : Role names to assign; must already exist}';
+
+    protected $description = 'Create a panel user and print their password setup link';
+
+    public function handle(): int
+    {
+        $email = $this->argument('email');
+
+        if (blank($email) && $this->canPrompt()) {
+            $email = text(
+                label: 'Email address',
+                required: true,
+                validate: fn (string $value): ?string => $this->emailError($value),
+            );
+        }
+
+        if (blank($email) || filled($error = $this->emailError((string) $email))) {
+            $this->components->error($error ?? 'An email address is required when the command cannot prompt for one.');
+
+            return self::FAILURE;
+        }
+
+        if (User::query()->where('email', $email)->exists()) {
+            $this->components->error("A user with the email {$email} already exists. Manage them in the panel, or use user:reset-password.");
+
+            return self::FAILURE;
+        }
+
+        $roles = $this->resolveRoles();
+
+        if ($roles === null) {
+            return self::FAILURE;
+        }
+
+        $user = User::query()->create([
+            'name' => $this->option('name') ?: Str::headline(Str::before((string) $email, '@')),
+            'email' => $email,
+            // A placeholder nobody ever learns; the printed reset link is how
+            // the account gets a real password.
+            'password' => Str::password(64),
+        ]);
+
+        $user->assignRole($roles);
+
+        $this->components->info(sprintf(
+            'Created %s%s.',
+            $user->email,
+            $roles === [] ? ' with no roles' : ' with the '.implode(', ', $roles).' role'.(count($roles) === 1 ? '' : 's'),
+        ));
+
+        if ($roles === []) {
+            $this->components->warn('Without a role the account cannot sign in to the panel. Assign one in the panel, or re-run with --role.');
+        }
+
+        $this->outputResetLink($user);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The role names to assign, validated against the roles that exist —
+     * a typo must fail loudly, not produce an account that cannot log in.
+     *
+     * @return list<string>|null null when a named role does not exist
+     */
+    private function resolveRoles(): ?array
+    {
+        $available = Role::query()->where('guard_name', 'web')->orderBy('name')->pluck('name')->all();
+
+        $roles = array_values(array_unique((array) $this->option('role')));
+
+        if ($roles === [] && $this->canPrompt() && $available !== []) {
+            $roles = array_values(multiselect(
+                label: 'Roles to assign',
+                options: $available,
+                hint: 'Without one, the account cannot sign in to the panel.',
+            ));
+        }
+
+        $missing = array_diff($roles, $available);
+
+        if ($missing !== []) {
+            $this->components->error(sprintf(
+                'Unknown role%s: %s. Available: %s.',
+                count($missing) === 1 ? '' : 's',
+                implode(', ', $missing),
+                $available === [] ? '(none — create roles in the panel first)' : implode(', ', $available),
+            ));
+
+            return null;
+        }
+
+        return $roles;
+    }
+
+    private function emailError(string $email): ?string
+    {
+        return Validator::make(['email' => $email], ['email' => ['required', 'email']])
+            ->errors()
+            ->first('email') ?: null;
+    }
+}

--- a/app/Console/Commands/CleanArchives.php
+++ b/app/Console/Commands/CleanArchives.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PackageVersion;
+use App\Services\ArchiveStore;
+use Illuminate\Console\Command;
+
+class CleanArchives extends Command
+{
+    protected $signature = 'archives:clean
+        {--dry-run : List the files that would be deleted without touching them}';
+
+    protected $description = 'Delete stored archives that no package version references';
+
+    /**
+     * Orphans accumulate by design: a re-stored version writes a new file and
+     * leaves its old one, and bulk version deletes never fire per-row cleanup.
+     * This command is where they go away.
+     */
+    public function handle(ArchiveStore $archives): int
+    {
+        $disk = $archives->disk();
+        $dryRun = (bool) $this->option('dry-run');
+
+        $referenced = PackageVersion::query()
+            ->whereNotNull('archive_path')
+            ->pluck('archive_path')
+            ->flip();
+
+        $orphans = array_values(array_filter(
+            $disk->allFiles('packages'),
+            fn (string $file): bool => ! $referenced->has($file),
+        ));
+
+        if ($orphans === []) {
+            $this->components->info('Every stored archive is referenced by a version; nothing to clean.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($orphans as $file) {
+            if (! $dryRun) {
+                $disk->delete($file);
+            }
+
+            $this->components->twoColumnDetail($file, $dryRun ? 'would delete' : 'deleted');
+        }
+
+        $this->components->info(sprintf(
+            '%d orphaned archive%s %s.',
+            count($orphans),
+            count($orphans) === 1 ? '' : 's',
+            $dryRun ? 'found; none deleted (dry run)' : 'deleted',
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/CreateAdmin.php
+++ b/app/Console/Commands/CreateAdmin.php
@@ -2,12 +2,10 @@
 
 namespace App\Console\Commands;
 
+use App\Console\Concerns\IssuesPasswordResetLinks;
 use App\Models\User;
 use BezhanSalleh\FilamentShield\Support\Utils;
-use Filament\Facades\Filament;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Password;
-use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password as PasswordRule;
@@ -26,20 +24,14 @@ use function Laravel\Prompts\text;
  */
 class CreateAdmin extends Command
 {
+    use IssuesPasswordResetLinks;
+
     protected $signature = 'admin:create
         {email? : The account email address; prompted for when omitted}
         {--name= : Display name, applied on create and when explicitly passed}
         {--link : Print a password reset link rather than prompting for a password}';
 
     protected $description = 'Create or update an admin account without a password passing through the environment';
-
-    /**
-     * How long a printed reset link stays usable. Deliberately much shorter
-     * than the password broker's expiry: the URL lands in consoles and deploy
-     * logs, so it must go stale quickly. The `signed` middleware on the reset
-     * route enforces this, making the token unreachable once the URL expires.
-     */
-    private const LINK_TTL_MINUTES = 5;
 
     public function handle(): int
     {
@@ -166,18 +158,6 @@ class CreateAdmin extends Command
         return $this->option('link') || ! $this->canPrompt();
     }
 
-    /**
-     * Whether Laravel Prompts would actually accept input, which is stricter
-     * than Symfony's notion of interactive: some command runners (Laravel
-     * Cloud's among them) leave the input flagged interactive while STDIN is
-     * not a TTY, and a required prompt then aborts instead of asking.
-     */
-    private function canPrompt(): bool
-    {
-        return $this->input->isInteractive()
-            && ((defined('STDIN') && stream_isatty(STDIN)) || $this->laravel->runningUnitTests());
-    }
-
     private function promptForPassword(): string
     {
         return password(
@@ -188,33 +168,5 @@ class CreateAdmin extends Command
                 ['password' => ['required', PasswordRule::defaults()]],
             )->errors()->first('password') ?: null,
         );
-    }
-
-    /**
-     * Print a signed link to the panel's password reset screen. The token is
-     * the same single-use, expiring one the "forgot password" flow issues; it
-     * is written to the console rather than emailed so that bootstrapping an
-     * account does not depend on working mail.
-     */
-    private function outputResetLink(User $user): void
-    {
-        // Filament's own getResetPasswordUrl() signs without an expiry,
-        // leaving the link alive as long as the token (an hour by default).
-        $url = URL::temporarySignedRoute(
-            Filament::getPanel('admin')->generateRouteName('auth.password-reset.reset'),
-            now()->addMinutes(self::LINK_TTL_MINUTES),
-            [
-                'email' => $user->getEmailForPasswordReset(),
-                'token' => Password::broker()->createToken($user),
-            ],
-        );
-
-        $this->newLine();
-        $this->components->warn(sprintf(
-            'Set a password with this single-use link, which expires in %d minutes:',
-            self::LINK_TTL_MINUTES,
-        ));
-        $this->line($url);
-        $this->newLine();
     }
 }

--- a/app/Console/Commands/DeletePackage.php
+++ b/app/Console/Commands/DeletePackage.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Package;
+use App\Services\ArchiveStore;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\confirm;
+
+/**
+ * Removes a package, its versions, and the archives on the dist disk that
+ * served them — the whole footprint, not just the rows.
+ */
+class DeletePackage extends Command
+{
+    protected $signature = 'package:delete
+        {name : The composer name of the package}
+        {--repo= : The Composer repository path, when the name is served in more than one}
+        {--force : Skip the confirmation prompt}';
+
+    protected $description = 'Delete a package, its versions, and its stored archives';
+
+    public function handle(ArchiveStore $archives): int
+    {
+        $candidates = Package::query()
+            ->where('name', $this->argument('name'))
+            ->when($this->option('repo'), fn ($query, string $path) => $query->whereHas(
+                'composerRepository',
+                fn ($repositories) => $repositories->where('path', $path),
+            ))
+            ->with('composerRepository')
+            ->get();
+
+        if ($candidates->isEmpty()) {
+            $this->components->error('No matching package found.');
+
+            return self::FAILURE;
+        }
+
+        if ($candidates->count() > 1) {
+            $this->components->error(sprintf(
+                'That name is served from several Composer repositories (%s); pick one with --repo.',
+                $candidates->map(fn (Package $package): string => $package->composerRepository->path ?? '(root)')->implode(', '),
+            ));
+
+            return self::FAILURE;
+        }
+
+        /** @var Package $package */
+        $package = $candidates->sole();
+        $versions = $package->versions()->count();
+
+        if (! $this->option('force')) {
+            $confirmed = $this->input->isInteractive()
+                && confirm("Delete {$package->name} and its {$versions} stored versions?", default: false);
+
+            if (! $confirmed) {
+                $this->components->warn('Nothing deleted. Pass --force to skip the confirmation.');
+
+                return self::FAILURE;
+            }
+        }
+
+        // Collected before the rows cascade away; deleted after, so a failed
+        // delete never leaves versions pointing at missing files.
+        $paths = $package->versions()->whereNotNull('archive_path')->pluck('archive_path');
+
+        $package->delete();
+
+        $disk = $archives->disk();
+
+        foreach ($paths as $path) {
+            $disk->delete($path);
+        }
+
+        $this->components->info(sprintf(
+            'Deleted %s, %d version%s, and %d stored archive%s.',
+            $package->name,
+            $versions,
+            $versions === 1 ? '' : 's',
+            $paths->count(),
+            $paths->count() === 1 ? '' : 's',
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RebuildPackages.php
+++ b/app/Console/Commands/RebuildPackages.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Package;
+use App\Services\RebuildPackage;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * Rebuilds packages inline: every version re-imported from its source. The
+ * console flavour of the panel's Rebuild action, for recovery scripts and
+ * after-normalizer-change sweeps.
+ */
+class RebuildPackages extends Command
+{
+    protected $signature = 'package:rebuild
+        {name? : Only rebuild the package with this composer name; all synced packages when omitted}
+        {--repo= : The Composer repository path, when the name is served in more than one}';
+
+    protected $description = 'Re-import every version of one or all packages from their sources';
+
+    public function handle(RebuildPackage $rebuild): int
+    {
+        $packages = Package::query()
+            // Uploaded artifacts have no source to rebuild from.
+            ->whereNotNull('repository')
+            ->when($this->argument('name'), fn ($query, string $name) => $query->where('name', $name))
+            ->when($this->option('repo'), fn ($query, string $path) => $query->whereHas(
+                'composerRepository',
+                fn ($repositories) => $repositories->where('path', $path),
+            ))
+            ->get();
+
+        if ($packages->isEmpty()) {
+            $this->components->error('No matching packages with a source to rebuild from.');
+
+            return self::FAILURE;
+        }
+
+        $failures = [];
+
+        $this->withProgressBar($packages, function (Package $package) use ($rebuild, &$failures): void {
+            try {
+                $rebuild->rebuild($package);
+            } catch (Throwable $exception) {
+                $failures[$package->name] = $exception->getMessage();
+            }
+        });
+
+        $this->newLine(2);
+
+        foreach ($failures as $name => $reason) {
+            $this->components->twoColumnDetail($name, "failed: {$reason}");
+        }
+
+        $this->components->info(sprintf(
+            'Rebuilt %d package%s%s.',
+            $packages->count() - count($failures),
+            $packages->count() - count($failures) === 1 ? '' : 's',
+            $failures === [] ? '' : sprintf(', %d failed', count($failures)),
+        ));
+
+        return $failures === [] ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Console/Commands/RecalculateDownloads.php
+++ b/app/Console/Commands/RecalculateDownloads.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Rebuilds the denormalized total_downloads counters from the downloads
+ * table — the recovery tool for counters knocked out of step by imports,
+ * manual surgery, or a listener that never ran.
+ */
+class RecalculateDownloads extends Command
+{
+    protected $signature = 'downloads:recalculate';
+
+    protected $description = 'Rebuild the total_downloads counters from the downloads table';
+
+    public function handle(): int
+    {
+        // Correlated subqueries rather than chunked model updates: one
+        // statement per table, portable across SQLite, MySQL and Postgres.
+        DB::statement(<<<'SQL'
+            update packages set total_downloads = (
+                select count(*) from downloads where downloads.package_id = packages.id
+            )
+        SQL);
+
+        DB::statement(<<<'SQL'
+            update package_versions set total_downloads = (
+                select count(*) from downloads where downloads.package_version_id = package_versions.id
+            )
+        SQL);
+
+        $this->components->info('Download counters rebuilt from the downloads table.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ResetUserPassword.php
+++ b/app/Console/Commands/ResetUserPassword.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Console\Concerns\IssuesPasswordResetLinks;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\text;
+
+/**
+ * The recovery path for any account: prints the same short-lived signed
+ * reset link the "forgot password" flow would email, without depending on
+ * working mail.
+ */
+class ResetUserPassword extends Command
+{
+    use IssuesPasswordResetLinks;
+
+    protected $signature = 'user:reset-password
+        {email? : The account email address; prompted for when omitted}';
+
+    protected $description = 'Print a single-use password reset link for a user';
+
+    public function handle(): int
+    {
+        $email = $this->argument('email');
+
+        if (blank($email) && $this->canPrompt()) {
+            $email = text(label: 'Email address', required: true);
+        }
+
+        $user = User::query()->where('email', $email)->first();
+
+        if (! $user instanceof User) {
+            $this->components->error(sprintf('No user has the email address %s.', $email ?: '(none given)'));
+
+            return self::FAILURE;
+        }
+
+        $this->outputResetLink($user);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/RevokeToken.php
+++ b/app/Console/Commands/RevokeToken.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Token;
+use Illuminate\Console\Command;
+
+/**
+ * Revokes an access token by its prefix — the identifier every listing
+ * shows, and all anyone still has once the plain text is out in the wild.
+ */
+class RevokeToken extends Command
+{
+    protected $signature = 'token:revoke
+        {prefix : The token prefix shown in listings (e.g. pp_ab1cd)}';
+
+    protected $description = 'Revoke a Composer access token by its prefix';
+
+    public function handle(): int
+    {
+        $tokens = Token::query()->where('token_prefix', $this->argument('prefix'))->get();
+
+        if ($tokens->isEmpty()) {
+            $this->components->error('No live token has that prefix.');
+
+            return self::FAILURE;
+        }
+
+        foreach ($tokens as $token) {
+            $token->delete();
+
+            $this->components->twoColumnDetail(
+                "{$token->token_prefix}… ({$token->name})",
+                'revoked',
+            );
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Concerns/IssuesPasswordResetLinks.php
+++ b/app/Console/Concerns/IssuesPasswordResetLinks.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Concerns;
+
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Console-side password bootstrapping, shared by every command that manages
+ * accounts: a password never travels through the environment or the argument
+ * list — either a prompt asks for one, or a short-lived signed link sets it
+ * in the browser.
+ */
+trait IssuesPasswordResetLinks
+{
+    /**
+     * How long a printed reset link stays usable. Deliberately much shorter
+     * than the password broker's expiry: the URL lands in consoles and deploy
+     * logs, so it must go stale quickly. The `signed` middleware on the reset
+     * route enforces this, making the token unreachable once the URL expires.
+     */
+    private static int $linkTtlMinutes = 5;
+
+    /**
+     * Whether Laravel Prompts would actually accept input, which is stricter
+     * than Symfony's notion of interactive: some command runners (Laravel
+     * Cloud's among them) leave the input flagged interactive while STDIN is
+     * not a TTY, and a required prompt then aborts instead of asking.
+     */
+    private function canPrompt(): bool
+    {
+        return $this->input->isInteractive()
+            && ((defined('STDIN') && stream_isatty(STDIN)) || $this->laravel->runningUnitTests());
+    }
+
+    /**
+     * Print a signed link to the panel's password reset screen. The token is
+     * the same single-use, expiring one the "forgot password" flow issues; it
+     * is written to the console rather than emailed so that bootstrapping an
+     * account does not depend on working mail.
+     */
+    private function outputResetLink(User $user): void
+    {
+        // Filament's own getResetPasswordUrl() signs without an expiry,
+        // leaving the link alive as long as the token (an hour by default).
+        $url = URL::temporarySignedRoute(
+            Filament::getPanel('admin')->generateRouteName('auth.password-reset.reset'),
+            now()->addMinutes(static::$linkTtlMinutes),
+            [
+                'email' => $user->getEmailForPasswordReset(),
+                'token' => Password::broker()->createToken($user),
+            ],
+        );
+
+        $this->newLine();
+        $this->components->warn(sprintf(
+            'Set a password with this single-use link, which expires in %d minutes:',
+            static::$linkTtlMinutes,
+        ));
+        $this->line($url);
+        $this->newLine();
+    }
+}

--- a/app/Enums/AuthProvider.php
+++ b/app/Enums/AuthProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * The login providers an authentication source can speak. OIDC is the
+ * general case (any issuer with a discovery document); the rest are the
+ * name-brand OAuth providers Socialite ships drivers for.
+ */
+enum AuthProvider: string implements HasLabel
+{
+    case Oidc = 'oidc';
+    case Github = 'github';
+    case Google = 'google';
+    case Gitlab = 'gitlab';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Oidc => 'OIDC',
+            self::Github => 'GitHub',
+            self::Google => 'Google',
+            self::Gitlab => 'GitLab',
+        };
+    }
+}

--- a/app/Enums/SourceProvider.php
+++ b/app/Enums/SourceProvider.php
@@ -7,28 +7,39 @@ use Filament\Support\Contracts\HasLabel;
 /**
  * The version control providers a Source can connect to.
  *
- * Only GitHub is implemented; the enum exists so that the rest of the app is
- * written against a provider rather than assuming GitHub everywhere.
+ * GitHub and GitLab are implemented; Gitea and Bitbucket resolve to stub
+ * clients that refuse loudly, so the enum can be complete while the work
+ * behind it lands provider by provider.
  */
 enum SourceProvider: string implements HasLabel
 {
     case Github = 'github';
+    case Gitlab = 'gitlab';
+    case Gitea = 'gitea';
+    case Bitbucket = 'bitbucket';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::Github => 'GitHub',
+            self::Gitlab => 'GitLab',
+            self::Gitea => 'Gitea',
+            self::Bitbucket => 'Bitbucket',
         };
     }
 
     /**
      * The API root used when a source does not override it with a base_url,
-     * which self-hosted installations (GitHub Enterprise) need to do.
+     * which self-hosted installations (GitHub Enterprise, self-managed
+     * GitLab) need to do.
      */
     public function defaultApiUrl(): string
     {
         return match ($this) {
             self::Github => 'https://api.github.com',
+            self::Gitlab => 'https://gitlab.com/api/v4',
+            self::Gitea => 'https://gitea.com/api/v1',
+            self::Bitbucket => 'https://api.bitbucket.org/2.0',
         };
     }
 
@@ -40,6 +51,26 @@ enum SourceProvider: string implements HasLabel
     {
         return match ($this) {
             self::Github => 'github.com',
+            self::Gitlab => 'gitlab.com',
+            self::Gitea => 'gitea.com',
+            self::Bitbucket => 'bitbucket.org',
+        };
+    }
+
+    /**
+     * The provider a repository host most likely belongs to. Self-hosted
+     * instances follow the conventional naming often enough for this to be
+     * the right default; a package under a connected source never asks.
+     */
+    public static function forHost(?string $host): self
+    {
+        $host = mb_strtolower((string) $host);
+
+        return match (true) {
+            str_contains($host, 'gitlab') => self::Gitlab,
+            str_contains($host, 'gitea') => self::Gitea,
+            str_contains($host, 'bitbucket') => self::Bitbucket,
+            default => self::Github,
         };
     }
 }

--- a/app/Enums/TokenAbility.php
+++ b/app/Enums/TokenAbility.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * What an access token may do against the Composer endpoints.
+ */
+enum TokenAbility: string implements HasLabel
+{
+    case RepositoryRead = 'repository:read';
+    case RepositoryWrite = 'repository:write';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::RepositoryRead => 'Read — install packages',
+            self::RepositoryWrite => 'Write — publish artifact uploads',
+        };
+    }
+}

--- a/app/Events/PackageDownloaded.php
+++ b/app/Events/PackageDownloaded.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * A dist archive was served.
+ *
+ * Carries scalars rather than models: the recording listener runs on the
+ * queue, and by then the version row may have been pruned — the download
+ * still happened and must still count.
+ */
+class PackageDownloaded
+{
+    use Dispatchable;
+
+    public function __construct(
+        public int $packageId,
+        public ?int $packageVersionId,
+        public string $version,
+        public ?string $ip,
+        public ?string $tokenPrefix,
+    ) {}
+}

--- a/app/Filament/Pages/ApiTokens.php
+++ b/app/Filament/Pages/ApiTokens.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Enums\TokenAbility;
+use App\Models\Token;
+use App\Models\User;
+use BackedEnum;
+use Carbon\CarbonImmutable;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Enums\FontFamily;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Self-service personal access tokens, reached from the user menu.
+ *
+ * Every panel user manages their own tokens here — issuing one is how their
+ * Composer clients authenticate — and only their own: the page's queries are
+ * pinned to the signed-in user, so it needs no Shield permission.
+ */
+class ApiTokens extends Page implements HasTable
+{
+    use InteractsWithTable;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedKey;
+
+    // Reached from the user menu; it is nobody's workspace, so it stays out
+    // of the sidebar.
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected static ?string $title = 'API tokens';
+
+    protected string $view = 'filament.pages.api-tokens';
+
+    /**
+     * The plain text of a token created this request — the only time it ever
+     * exists outside the creator's clipboard.
+     */
+    public ?string $plainTextToken = null;
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(fn (): Builder => $this->user()->tokens()->getQuery())
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable(),
+                TextColumn::make('token_prefix')
+                    ->label('Token')
+                    ->formatStateUsing(fn (string $state): string => "{$state}…")
+                    ->fontFamily(FontFamily::Mono),
+                TextColumn::make('abilities')
+                    ->badge()
+                    ->formatStateUsing(fn (string $state): string => TokenAbility::tryFrom($state)?->getLabel() ?? $state),
+                TextColumn::make('last_used_at')
+                    ->label('Last used')
+                    ->since()
+                    ->placeholder('Never'),
+                TextColumn::make('expires_at')
+                    ->label('Expires')
+                    ->date()
+                    ->placeholder('Never'),
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->date(),
+            ])
+            ->recordActions([
+                DeleteAction::make()
+                    ->label('Revoke')
+                    ->modalHeading('Revoke token')
+                    ->modalDescription('Composer clients using this token stop authenticating immediately.')
+                    ->successNotificationTitle('Token revoked'),
+            ])
+            ->emptyStateHeading('No API tokens')
+            ->emptyStateDescription('Create one to let a Composer client authenticate against this registry.');
+    }
+
+    /**
+     * @return array<Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('create')
+                ->label('Create token')
+                ->icon(Heroicon::OutlinedPlus)
+                ->modalHeading('Create an API token')
+                ->modalDescription('The token is shown once, right after it is created.')
+                ->schema([
+                    TextInput::make('name')
+                        ->required()
+                        ->maxLength(255)
+                        ->placeholder('ci-deploy')
+                        ->helperText('What this token is for — shown in listings, and how you will recognise it later.'),
+                    CheckboxList::make('abilities')
+                        ->options(TokenAbility::class)
+                        ->default([TokenAbility::RepositoryRead->value])
+                        ->required(),
+                    DatePicker::make('expires_at')
+                        ->label('Expires')
+                        ->minDate(now()->addDay())
+                        ->helperText('Leave empty for a token that never expires.'),
+                ])
+                ->action(function (array $data): void {
+                    $new = Token::issue(
+                        $this->user(),
+                        $data['name'],
+                        $data['abilities'],
+                        // The whole chosen day is valid; expiring at its
+                        // midnight would cut the last day off.
+                        filled($data['expires_at'] ?? null) ? CarbonImmutable::parse($data['expires_at'])->endOfDay() : null,
+                    );
+
+                    $this->plainTextToken = $new->plainText;
+
+                    Notification::make()
+                        ->success()
+                        ->title('Token created')
+                        ->body('Copy it now — it will not be shown again.')
+                        ->send();
+                }),
+        ];
+    }
+
+    private function user(): User
+    {
+        /** @var User */
+        return auth()->user();
+    }
+}

--- a/app/Filament/Resources/AuthenticationSources/AuthenticationSourceResource.php
+++ b/app/Filament/Resources/AuthenticationSources/AuthenticationSourceResource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Resources\AuthenticationSources;
+
+use App\Filament\Resources\AuthenticationSources\Pages\CreateAuthenticationSource;
+use App\Filament\Resources\AuthenticationSources\Pages\EditAuthenticationSource;
+use App\Filament\Resources\AuthenticationSources\Pages\ListAuthenticationSources;
+use App\Filament\Resources\AuthenticationSources\Schemas\AuthenticationSourceForm;
+use App\Filament\Resources\AuthenticationSources\Tables\AuthenticationSourcesTable;
+use App\Models\AuthenticationSource;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class AuthenticationSourceResource extends Resource
+{
+    protected static ?string $model = AuthenticationSource::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedFingerPrint;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    protected static ?string $navigationLabel = 'Login providers';
+
+    protected static ?string $modelLabel = 'login provider';
+
+    protected static string|UnitEnum|null $navigationGroup = 'Access Management';
+
+    public static function form(Schema $schema): Schema
+    {
+        return AuthenticationSourceForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return AuthenticationSourcesTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListAuthenticationSources::route('/'),
+            'create' => CreateAuthenticationSource::route('/create'),
+            'edit' => EditAuthenticationSource::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/AuthenticationSources/Pages/CreateAuthenticationSource.php
+++ b/app/Filament/Resources/AuthenticationSources/Pages/CreateAuthenticationSource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\AuthenticationSources\Pages;
+
+use App\Filament\Resources\AuthenticationSources\AuthenticationSourceResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAuthenticationSource extends CreateRecord
+{
+    protected static string $resource = AuthenticationSourceResource::class;
+}

--- a/app/Filament/Resources/AuthenticationSources/Pages/EditAuthenticationSource.php
+++ b/app/Filament/Resources/AuthenticationSources/Pages/EditAuthenticationSource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AuthenticationSources\Pages;
+
+use App\Filament\Resources\AuthenticationSources\AuthenticationSourceResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAuthenticationSource extends EditRecord
+{
+    protected static string $resource = AuthenticationSourceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AuthenticationSources/Pages/ListAuthenticationSources.php
+++ b/app/Filament/Resources/AuthenticationSources/Pages/ListAuthenticationSources.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\AuthenticationSources\Pages;
+
+use App\Filament\Resources\AuthenticationSources\AuthenticationSourceResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAuthenticationSources extends ListRecords
+{
+    protected static string $resource = AuthenticationSourceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/AuthenticationSources/Schemas/AuthenticationSourceForm.php
+++ b/app/Filament/Resources/AuthenticationSources/Schemas/AuthenticationSourceForm.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Filament\Resources\AuthenticationSources\Schemas;
+
+use App\Enums\AuthProvider;
+use App\Models\AuthenticationSource;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Spatie\Permission\Models\Role;
+
+class AuthenticationSourceForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->placeholder('Acme SSO')
+                    ->helperText('The login button reads "Continue with {name}".'),
+                Select::make('provider')
+                    ->options(AuthProvider::class)
+                    ->required()
+                    ->live()
+                    ->selectablePlaceholder(false),
+                TextInput::make('discovery_url')
+                    ->label('OIDC discovery URL')
+                    ->url()
+                    ->maxLength(255)
+                    ->placeholder('https://id.example.com/.well-known/openid-configuration')
+                    ->visible(fn (Get $get): bool => AuthProvider::tryFrom((string) $get('provider')) === AuthProvider::Oidc)
+                    ->required(fn (Get $get): bool => AuthProvider::tryFrom((string) $get('provider')) === AuthProvider::Oidc)
+                    ->helperText('The issuer\'s openid-configuration document; endpoints are read from it.'),
+                TextInput::make('client_id')
+                    ->label('Client ID')
+                    ->required()
+                    ->maxLength(255)
+                    ->helperText(fn (?AuthenticationSource $record): string => $record
+                        ? "Register this callback URL on the OAuth client: {$record->callbackUrl()}"
+                        : 'The callback URL to register on the OAuth client is shown here after saving.'),
+                TextInput::make('client_secret')
+                    ->label('Client secret')
+                    ->password()
+                    ->revealable()
+                    ->maxLength(255)
+                    // The stored secret is never echoed back to the browser;
+                    // a blank input keeps it, a new value replaces it.
+                    ->afterStateHydrated(fn (TextInput $component) => $component->state(null))
+                    ->dehydrated(fn (?string $state): bool => filled($state))
+                    ->required(fn (?AuthenticationSource $record): bool => $record === null)
+                    ->placeholder(fn (?AuthenticationSource $record): string => $record
+                        ? 'Secret saved — enter a new one to replace it'
+                        : ''),
+                Toggle::make('active')
+                    ->default(true)
+                    ->helperText('Only active providers appear on the login page.'),
+                Toggle::make('allow_registration')
+                    ->label('Allow registration')
+                    ->default(true)
+                    ->helperText('Whether an identity with no matching account may create one.'),
+                TagsInput::make('allowed_domains')
+                    ->label('Allowed email domains')
+                    ->placeholder('example.com')
+                    ->helperText('Registration is limited to these domains. Leave empty to allow any.'),
+                Select::make('default_role')
+                    ->label('Role for new accounts')
+                    ->options(fn (): array => Role::query()
+                        ->where('guard_name', 'web')
+                        ->orderBy('name')
+                        ->pluck('name', 'name')
+                        ->all())
+                    ->helperText('Assigned to accounts this provider creates. Without a role they cannot sign in to the panel at all.'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/AuthenticationSources/Tables/AuthenticationSourcesTable.php
+++ b/app/Filament/Resources/AuthenticationSources/Tables/AuthenticationSourcesTable.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Filament\Resources\AuthenticationSources\Tables;
+
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class AuthenticationSourcesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('name')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('provider')
+                    ->badge()
+                    ->sortable(),
+                IconColumn::make('active')
+                    ->boolean(),
+                IconColumn::make('allow_registration')
+                    ->label('Registration')
+                    ->boolean(),
+                TextColumn::make('default_role')
+                    ->label('New accounts get')
+                    ->badge()
+                    ->color('gray')
+                    ->placeholder('No role'),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    ->modalDescription('Users who signed in through this provider keep their accounts; the login button disappears.'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/DeployTokens/DeployTokenResource.php
+++ b/app/Filament/Resources/DeployTokens/DeployTokenResource.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Filament\Resources\DeployTokens;
+
+use App\Filament\Resources\DeployTokens\Pages\CreateDeployToken;
+use App\Filament\Resources\DeployTokens\Pages\EditDeployToken;
+use App\Filament\Resources\DeployTokens\Pages\ListDeployTokens;
+use App\Filament\Resources\DeployTokens\Schemas\DeployTokenForm;
+use App\Filament\Resources\DeployTokens\Tables\DeployTokensTable;
+use App\Models\DeployToken;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+class DeployTokenResource extends Resource
+{
+    protected static ?string $model = DeployToken::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedKey;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    // Machine credentials sit with the other access management concerns,
+    // alongside Shield's roles and the users who hold them.
+    protected static string|UnitEnum|null $navigationGroup = 'Access Management';
+
+    public static function form(Schema $schema): Schema
+    {
+        return DeployTokenForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return DeployTokensTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDeployTokens::route('/'),
+            'create' => CreateDeployToken::route('/create'),
+            'edit' => EditDeployToken::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DeployTokens/Pages/CreateDeployToken.php
+++ b/app/Filament/Resources/DeployTokens/Pages/CreateDeployToken.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\DeployTokens\Pages;
+
+use App\Enums\TokenAbility;
+use App\Filament\Resources\DeployTokens\DeployTokenResource;
+use App\Models\DeployToken;
+use App\Models\Token;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDeployToken extends CreateRecord
+{
+    protected static string $resource = DeployTokenResource::class;
+
+    /**
+     * Issue the credential the machine will actually present.
+     *
+     * Deploy tokens read; publishing artifacts is a deliberate extra grant an
+     * admin makes by editing the token, not a default a CI box gets for free.
+     */
+    protected function afterCreate(): void
+    {
+        /** @var DeployToken $deployToken */
+        $deployToken = $this->getRecord();
+
+        $new = Token::issue($deployToken, $deployToken->name, [TokenAbility::RepositoryRead]);
+
+        // The one time the plain text exists: persistent so it survives the
+        // redirect to the index, dismissed only by the admin who copied it.
+        Notification::make()
+            ->success()
+            ->title('Deploy token created — copy it now')
+            ->body(
+                'It will not be shown again.<br><br><code>composer config http-basic.'.request()->getHost()
+                ." token {$new->plainText}</code>"
+            )
+            ->persistent()
+            ->send();
+    }
+}

--- a/app/Filament/Resources/DeployTokens/Pages/EditDeployToken.php
+++ b/app/Filament/Resources/DeployTokens/Pages/EditDeployToken.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Resources\DeployTokens\Pages;
+
+use App\Enums\TokenAbility;
+use App\Filament\Resources\DeployTokens\DeployTokenResource;
+use App\Models\DeployToken;
+use App\Models\Token;
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Support\Icons\Heroicon;
+
+class EditDeployToken extends EditRecord
+{
+    protected static string $resource = DeployTokenResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            // Rotation without ceremony: the old credential dies the moment
+            // the new one exists, and this is also where write ability is
+            // deliberately granted.
+            Action::make('regenerate')
+                ->label('Regenerate token')
+                ->icon(Heroicon::OutlinedArrowPath)
+                ->color('warning')
+                ->modalHeading('Regenerate the access token')
+                ->modalDescription('The current token stops authenticating immediately; whatever machine uses it needs the new one.')
+                ->schema([
+                    CheckboxList::make('abilities')
+                        ->options(TokenAbility::class)
+                        ->default(fn (DeployToken $record): array => $record->token?->abilities
+                            ?? [TokenAbility::RepositoryRead->value])
+                        ->required(),
+                ])
+                ->action(function (DeployToken $record, array $data): void {
+                    $record->tokens()->delete();
+
+                    $new = Token::issue($record, $record->name, $data['abilities']);
+
+                    Notification::make()
+                        ->success()
+                        ->title('Token regenerated — copy it now')
+                        ->body(
+                            'It will not be shown again.<br><br><code>composer config http-basic.'.request()->getHost()
+                            ." token {$new->plainText}</code>"
+                        )
+                        ->persistent()
+                        ->send();
+                }),
+            DeleteAction::make()
+                ->modalDescription('Its access token stops authenticating immediately.'),
+        ];
+    }
+}

--- a/app/Filament/Resources/DeployTokens/Pages/ListDeployTokens.php
+++ b/app/Filament/Resources/DeployTokens/Pages/ListDeployTokens.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\DeployTokens\Pages;
+
+use App\Filament\Resources\DeployTokens\DeployTokenResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDeployTokens extends ListRecords
+{
+    protected static string $resource = DeployTokenResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/DeployTokens/Schemas/DeployTokenForm.php
+++ b/app/Filament/Resources/DeployTokens/Schemas/DeployTokenForm.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Filament\Resources\DeployTokens\Schemas;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class DeployTokenForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->placeholder('production-deploys')
+                    ->helperText('Which machine or pipeline this token belongs to.'),
+                Select::make('repositories')
+                    ->relationship('repositories', 'name')
+                    ->multiple()
+                    ->preload()
+                    ->helperText('Grants every package in the chosen repositories.'),
+                Select::make('packages')
+                    ->relationship('packages', 'name')
+                    ->multiple()
+                    ->searchable()
+                    ->preload()
+                    ->helperText('Grants individual packages, wherever they are served. Leave both empty to grant the whole registry.'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/DeployTokens/Tables/DeployTokensTable.php
+++ b/app/Filament/Resources/DeployTokens/Tables/DeployTokensTable.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Resources\DeployTokens\Tables;
+
+use App\Models\DeployToken;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Support\Enums\FontFamily;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DeployTokensTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('name')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('token.token_prefix')
+                    ->label('Token')
+                    ->formatStateUsing(fn (string $state): string => "{$state}…")
+                    ->fontFamily(FontFamily::Mono)
+                    ->placeholder('Revoked'),
+                TextColumn::make('scope')
+                    ->state(fn (DeployToken $record): string => $record->isScoped()
+                        ? implode(' · ', array_filter([
+                            ($count = $record->repositories()->count()) ? "{$count} ".str('repository')->plural($count) : null,
+                            ($count = $record->packages()->count()) ? "{$count} ".str('package')->plural($count) : null,
+                        ]))
+                        : 'Whole registry')
+                    ->badge()
+                    ->color(fn (DeployToken $record): string => $record->isScoped() ? 'gray' : 'warning'),
+                TextColumn::make('token.last_used_at')
+                    ->label('Last used')
+                    ->since()
+                    ->placeholder('Never'),
+                TextColumn::make('created_at')
+                    ->label('Created')
+                    ->date()
+                    ->sortable(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    ->modalHeading('Delete deploy token')
+                    ->modalDescription('Its access token stops authenticating immediately.'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Packages/Actions/ImportFromSourceAction.php
+++ b/app/Filament/Resources/Packages/Actions/ImportFromSourceAction.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Filament\Resources\Packages\Actions;
+
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Source;
+use App\Services\GitHub\WebhookRegistrar;
+use App\Sources\Project;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Support\Icons\Heroicon;
+use Throwable;
+
+/**
+ * One-click onboarding: browse a source's projects, pick several, and each
+ * becomes a package with its webhook arranged and its first sync queued —
+ * the create wizard, multiplied.
+ */
+class ImportFromSourceAction
+{
+    public static function make(): Action
+    {
+        return Action::make('importFromSource')
+            ->label('Import from source')
+            ->icon(Heroicon::OutlinedCloudArrowDown)
+            ->color('gray')
+            ->visible(fn (): bool => Source::query()->exists())
+            ->modalHeading('Import packages from a source')
+            ->modalDescription('Each selected project becomes a package, wired up exactly as the create wizard would.')
+            ->modalSubmitActionLabel('Import')
+            ->schema([
+                Select::make('source_id')
+                    ->label('Source')
+                    ->options(fn (): array => Source::options())
+                    ->required()
+                    ->live()
+                    ->helperText('The connected account whose projects to browse.'),
+                Select::make('projects')
+                    ->multiple()
+                    ->required()
+                    ->searchable()
+                    ->options(fn (Get $get): array => self::projectOptions($get('source_id')))
+                    ->getSearchResultsUsing(fn (string $search, Get $get): array => self::projectOptions($get('source_id'), $search))
+                    ->helperText('Type to search what the source\'s credential can reach. Projects already onboarded are skipped.'),
+                Select::make('repository_id')
+                    ->label('Composer repository')
+                    ->options(fn (): array => Repository::query()->orderBy('name')->pluck('name', 'id')->all())
+                    ->default(fn (): int => Repository::default()->id)
+                    ->required()
+                    ->selectablePlaceholder(false),
+                Toggle::make('create_webhook')
+                    ->label('Sync automatically on push')
+                    ->default(true)
+                    ->helperText('Arranges a webhook per project, unless an installed app\'s webhook already covers it.'),
+            ])
+            ->action(fn (array $data) => self::import($data));
+    }
+
+    /**
+     * The source's projects as select options, keyed by their web URL — which
+     * is exactly what the package's repository column stores.
+     *
+     * @return array<string, string>
+     */
+    private static function projectOptions(mixed $sourceId, ?string $search = null): array
+    {
+        $source = Source::query()->find($sourceId);
+
+        if (! $source instanceof Source) {
+            return [];
+        }
+
+        try {
+            $projects = $source->client()->projects($search);
+        } catch (Throwable $exception) {
+            Notification::make()
+                ->danger()
+                ->title('Could not list the source\'s projects')
+                ->body($exception->getMessage())
+                ->send();
+
+            return [];
+        }
+
+        return collect($projects)
+            ->mapWithKeys(fn (Project $project): array => [$project->webUrl => $project->fullName])
+            ->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private static function import(array $data): void
+    {
+        $source = Source::query()->findOrFail($data['source_id']);
+        $repository = Repository::query()->findOrFail($data['repository_id']);
+        $registrar = app(WebhookRegistrar::class);
+
+        $created = [];
+        $skipped = 0;
+        $failures = [];
+
+        foreach ($data['projects'] as $webUrl) {
+            try {
+                $package = Package::query()->firstOrCreate(
+                    ['repository_id' => $repository->id, 'repository' => $webUrl],
+                    [
+                        'source_id' => $source->id,
+                        'name' => (new Package(['repository' => $webUrl]))->suggestedName() ?? $webUrl,
+                    ],
+                );
+            } catch (Throwable $exception) {
+                // One refused project — a name collision, say — must not
+                // abort the rest of the import.
+                $failures[] = "{$webUrl}: {$exception->getMessage()}";
+
+                continue;
+            }
+
+            if (! $package->wasRecentlyCreated) {
+                $skipped++;
+
+                continue;
+            }
+
+            $created[] = $package->name;
+
+            if ($data['create_webhook']) {
+                $registrar->register($package);
+
+                if ($reason = $registrar->unmetRequirement($package)) {
+                    $failures[] = "{$package->name}: {$reason}";
+                }
+            }
+
+            SyncPackageJob::dispatch($package);
+        }
+
+        if ($created !== [] || $skipped > 0) {
+            Notification::make()
+                ->success()
+                ->title(sprintf(
+                    'Imported %d package%s%s',
+                    count($created),
+                    count($created) === 1 ? '' : 's',
+                    $skipped > 0 ? " ({$skipped} already onboarded)" : '',
+                ))
+                ->body($created === [] ? null : implode(', ', $created).' — first syncs are running in the background.')
+                ->send();
+        }
+
+        if ($failures !== []) {
+            Notification::make()
+                ->warning()
+                ->title('Some projects need attention')
+                ->body(implode("\n", $failures))
+                ->persistent()
+                ->send();
+        }
+    }
+}

--- a/app/Filament/Resources/Packages/Actions/RebuildPackageAction.php
+++ b/app/Filament/Resources/Packages/Actions/RebuildPackageAction.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Filament\Resources\Packages\Actions;
+
+use App\Models\Package;
+use App\Services\RebuildPackage;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+
+class RebuildPackageAction
+{
+    /**
+     * Queue a full rebuild of the package's versions from its source.
+     *
+     * Distinct from Sync on purpose: a sync skips whatever looks already
+     * stored, a rebuild trusts none of it.
+     */
+    public static function make(): Action
+    {
+        return Action::make('rebuild')
+            ->label('Rebuild')
+            ->icon(Heroicon::OutlinedWrenchScrewdriver)
+            ->color('warning')
+            // A package published by artifact upload has no source to rebuild
+            // from.
+            ->visible(fn (Package $record): bool => filled($record->repository))
+            ->requiresConfirmation()
+            ->modalHeading('Rebuild this package')
+            ->modalDescription('Every version is re-imported from the source: metadata re-read, archives re-downloaded, versions gone upstream pruned. The package keeps serving while the rebuild runs, and running it twice is safe.')
+            ->modalSubmitActionLabel('Rebuild')
+            ->action(function (Package $record): void {
+                if (! app(RebuildPackage::class)->queue($record)) {
+                    Notification::make()
+                        ->info()
+                        ->title('Sync already queued')
+                        ->body("{$record->name} already has a sync waiting to run; the rebuild would only collide with it.")
+                        ->send();
+
+                    return;
+                }
+
+                Notification::make()
+                    ->success()
+                    ->title('Rebuild queued')
+                    ->body("{$record->name} is re-importing every version in the background.")
+                    ->send();
+            });
+    }
+}

--- a/app/Filament/Resources/Packages/Actions/SyncPackageAction.php
+++ b/app/Filament/Resources/Packages/Actions/SyncPackageAction.php
@@ -23,6 +23,9 @@ class SyncPackageAction
         return Action::make('sync')
             ->label('Sync')
             ->icon(Heroicon::OutlinedArrowPath)
+            // A package published by artifact upload has no repository to
+            // pull from; offering a sync would only manufacture a failure.
+            ->visible(fn (Package $record): bool => filled($record->repository))
             ->action(function (Package $record): void {
                 // The job is unique per package until it starts, so a sync a
                 // webhook already queued swallows this one — say so instead

--- a/app/Filament/Resources/Packages/PackageResource.php
+++ b/app/Filament/Resources/Packages/PackageResource.php
@@ -15,6 +15,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class PackageResource extends Resource
 {
@@ -23,6 +24,16 @@ class PackageResource extends Resource
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
 
     protected static ?string $recordTitleAttribute = 'name';
+
+    /**
+     * Row-level scoping for users without Unscoped:Package: the table, and
+     * every page that resolves a record through it, only reaches packages
+     * the signed-in user has been granted.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->visibleToUser(auth()->user());
+    }
 
     public static function form(Schema $schema): Schema
     {

--- a/app/Filament/Resources/Packages/Pages/CreatePackage.php
+++ b/app/Filament/Resources/Packages/Pages/CreatePackage.php
@@ -5,7 +5,9 @@ namespace App\Filament\Resources\Packages\Pages;
 use App\Enums\WebhookCoverage;
 use App\Filament\Resources\Packages\PackageResource;
 use App\Filament\Resources\Packages\Schemas\PackageWizard;
+use App\Jobs\SyncPackageJob;
 use App\Models\Package;
+use App\Models\Source;
 use App\Services\GitHub\WebhookRegistrar;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
@@ -24,6 +26,19 @@ class CreatePackage extends CreateRecord
     public function getSteps(): array
     {
         return PackageWizard::steps();
+    }
+
+    /**
+     * Arriving from a source's packages list pre-selects that source, so the
+     * new package authenticates through it without being told to again.
+     */
+    protected function afterFill(): void
+    {
+        $sourceId = request()->integer('source');
+
+        if ($sourceId && Source::whereKey($sourceId)->exists()) {
+            $this->data['source_id'] = $sourceId;
+        }
     }
 
     /**
@@ -62,5 +77,16 @@ class CreatePackage extends CreateRecord
                 ->persistent()
                 ->send();
         }
+
+        // The package exists but has no versions until something syncs it, and
+        // the next push could be months away — so the first sync runs now,
+        // with everything above already configured.
+        SyncPackageJob::dispatch($package);
+
+        Notification::make()
+            ->success()
+            ->title('First sync queued')
+            ->body("{$package->name} is importing its versions in the background.")
+            ->send();
     }
 }

--- a/app/Filament/Resources/Packages/Pages/ListPackages.php
+++ b/app/Filament/Resources/Packages/Pages/ListPackages.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Packages\Pages;
 
+use App\Filament\Resources\Packages\Actions\ImportFromSourceAction;
 use App\Filament\Resources\Packages\PackageResource;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
@@ -13,6 +14,7 @@ class ListPackages extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ImportFromSourceAction::make(),
             CreateAction::make(),
         ];
     }

--- a/app/Filament/Resources/Packages/Pages/ViewPackage.php
+++ b/app/Filament/Resources/Packages/Pages/ViewPackage.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Packages\Pages;
 
 use App\Filament\Resources\Packages\Actions\CreateWebhookAction;
+use App\Filament\Resources\Packages\Actions\RebuildPackageAction;
 use App\Filament\Resources\Packages\Actions\SyncPackageAction;
 use App\Filament\Resources\Packages\PackageResource;
 use App\Filament\Resources\Packages\Widgets\PackageSyncProgress;
@@ -17,6 +18,7 @@ class ViewPackage extends ViewRecord
     {
         return [
             SyncPackageAction::make(),
+            RebuildPackageAction::make(),
             CreateWebhookAction::make(),
             EditAction::make(),
         ];

--- a/app/Filament/Resources/Packages/Pages/ViewPackage.php
+++ b/app/Filament/Resources/Packages/Pages/ViewPackage.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Packages\Pages;
 use App\Filament\Resources\Packages\Actions\CreateWebhookAction;
 use App\Filament\Resources\Packages\Actions\SyncPackageAction;
 use App\Filament\Resources\Packages\PackageResource;
+use App\Filament\Resources\Packages\Widgets\PackageSyncProgress;
 use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ViewRecord;
 
@@ -18,6 +19,13 @@ class ViewPackage extends ViewRecord
             SyncPackageAction::make(),
             CreateWebhookAction::make(),
             EditAction::make(),
+        ];
+    }
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            PackageSyncProgress::class,
         ];
     }
 }

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -4,12 +4,15 @@ namespace App\Filament\Resources\Packages\Schemas;
 
 use App\Enums\WebhookCoverage;
 use App\Models\Package;
+use App\Models\Repository;
 use App\Models\Source;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 /**
  * The flat package form used when editing.
@@ -27,6 +30,7 @@ class PackageForm
             ->components([
                 self::name(),
                 self::repository(),
+                self::composerRepository(),
                 self::source(),
                 self::token(),
                 self::latestVersion(),
@@ -34,6 +38,32 @@ class PackageForm
                 self::webhookEnabled(),
                 self::description(),
             ]);
+    }
+
+    /**
+     * The Composer repository the package is served from. Names and VCS URLs
+     * are unique per repository, so this select is what the two unique rules
+     * below scope themselves by.
+     */
+    public static function composerRepository(): Select
+    {
+        return Select::make('repository_id')
+            ->label('Composer repository')
+            ->relationship('composerRepository', 'name')
+            ->default(fn (): int => Repository::default()->id)
+            ->required()
+            ->selectablePlaceholder(false)
+            ->helperText('Which of this registry\'s repositories serves the package.');
+    }
+
+    /**
+     * Scope a unique rule to the repository chosen in the form, since both
+     * package names and VCS URLs are unique per Composer repository rather
+     * than globally.
+     */
+    private static function uniquePerRepository(Unique $rule, Get $get): Unique
+    {
+        return $rule->where('repository_id', $get('repository_id') ?? Repository::default()->id);
     }
 
     /**
@@ -64,7 +94,10 @@ class PackageForm
         return TextInput::make('name')
             ->required()
             ->maxLength(255)
-            ->unique(ignoreRecord: true)
+            ->unique(
+                ignoreRecord: true,
+                modifyRuleUsing: fn (Unique $rule, Get $get): Unique => self::uniquePerRepository($rule, $get),
+            )
             ->placeholder('vendor/package')
             ->helperText('Overwritten by the composer.json name on sync.');
     }
@@ -76,7 +109,10 @@ class PackageForm
             ->required()
             ->url()
             ->maxLength(255)
-            ->unique(ignoreRecord: true)
+            ->unique(
+                ignoreRecord: true,
+                modifyRuleUsing: fn (Unique $rule, Get $get): Unique => self::uniquePerRepository($rule, $get),
+            )
             ->placeholder('https://github.com/vendor/package');
     }
 

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -106,14 +106,20 @@ class PackageForm
     {
         return TextInput::make('repository')
             ->label('Repository URL')
-            ->required()
+            // Required for a synced package; a package published by artifact
+            // upload legitimately has none. The create wizard, whose whole
+            // point is deciphering a repository, re-requires it.
+            ->required(fn (?Package $record): bool => $record === null || filled($record->repository))
             ->url()
             ->maxLength(255)
             ->unique(
                 ignoreRecord: true,
                 modifyRuleUsing: fn (Unique $rule, Get $get): Unique => self::uniquePerRepository($rule, $get),
             )
-            ->placeholder('https://github.com/vendor/package');
+            ->placeholder('https://github.com/vendor/package')
+            ->helperText(fn (?Package $record): ?string => $record !== null && blank($record->repository)
+                ? 'This package is published by artifact upload; setting a repository URL turns syncing on.'
+                : null);
     }
 
     public static function source(): Select

--- a/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
@@ -21,9 +21,10 @@ class PackageInfolist
                 TextEntry::make('name'),
                 TextEntry::make('repository')
                     ->label('Repository URL')
-                    ->url(fn (Package $record): string => $record->repository)
+                    ->url(fn (Package $record): ?string => $record->repository)
                     ->openUrlInNewTab()
-                    ->color('primary'),
+                    ->color('primary')
+                    ->placeholder('None — published by artifact upload'),
                 TextEntry::make('latest_version')
                     ->label('Latest version')
                     ->badge()

--- a/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
@@ -31,6 +31,13 @@ class PackageInfolist
                 TextEntry::make('type')
                     ->badge()
                     ->placeholder('-'),
+                TextEntry::make('composerRepository.name')
+                    ->label('Served in')
+                    ->badge()
+                    ->color('gray')
+                    ->helperText(fn (Package $record): string => $record->composerRepository->public
+                        ? 'Public repository — readable without a token.'
+                        : 'Private repository — consumers need an access token.'),
                 TextEntry::make('source.name')
                     ->label('Source')
                     ->badge()

--- a/app/Filament/Resources/Packages/Schemas/PackageWizard.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageWizard.php
@@ -4,7 +4,6 @@ namespace App\Filament\Resources\Packages\Schemas;
 
 use App\Models\Package;
 use App\Models\Source;
-use App\Services\GitHub\GitHubClient;
 use Filament\Forms\Components\Hidden;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Section;
@@ -90,7 +89,7 @@ class PackageWizard
         $failure = null;
 
         try {
-            $composerJson = GitHubClient::for($package)->composerJson();
+            $composerJson = $package->client()->composerJson();
         } catch (Throwable $exception) {
             $composerJson = null;
             $failure = $exception->getMessage();

--- a/app/Filament/Resources/Packages/Schemas/PackageWizard.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageWizard.php
@@ -62,6 +62,7 @@ class PackageWizard
                 ->schema([
                     PackageForm::name()
                         ->helperText('Read from the repository\'s composer.json, and overwritten by it again on every sync.'),
+                    PackageForm::composerRepository(),
                     PackageForm::description(),
                 ]),
         ];

--- a/app/Filament/Resources/Packages/Tables/PackagesTable.php
+++ b/app/Filament/Resources/Packages/Tables/PackagesTable.php
@@ -64,6 +64,11 @@ class PackagesTable
                     ->label('Versions')
                     ->counts('versions')
                     ->sortable(),
+                TextColumn::make('total_downloads')
+                    ->label('Downloads')
+                    ->numeric()
+                    ->sortable()
+                    ->toggleable(),
                 TextColumn::make('last_synced_at')
                     ->label('Last synced')
                     ->since()

--- a/app/Filament/Resources/Packages/Tables/PackagesTable.php
+++ b/app/Filament/Resources/Packages/Tables/PackagesTable.php
@@ -34,6 +34,12 @@ class PackagesTable
                     ->openUrlInNewTab()
                     ->color('primary')
                     ->limit(50),
+                TextColumn::make('composerRepository.name')
+                    ->label('Served in')
+                    ->badge()
+                    ->color('gray')
+                    ->sortable()
+                    ->toggleable(),
                 TextColumn::make('source.name')
                     ->label('Source')
                     ->badge()
@@ -79,6 +85,11 @@ class PackagesTable
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
+                SelectFilter::make('composerRepository')
+                    ->label('Composer repository')
+                    ->relationship('composerRepository', 'name')
+                    ->multiple()
+                    ->preload(),
                 SelectFilter::make('source')
                     ->relationship('source', 'name')
                     ->multiple()

--- a/app/Filament/Resources/Packages/Tables/PackagesTable.php
+++ b/app/Filament/Resources/Packages/Tables/PackagesTable.php
@@ -30,10 +30,11 @@ class PackagesTable
                 TextColumn::make('repository')
                     ->label('Repository')
                     ->searchable()
-                    ->url(fn (Package $record): string => $record->repository)
+                    ->url(fn (Package $record): ?string => $record->repository)
                     ->openUrlInNewTab()
                     ->color('primary')
-                    ->limit(50),
+                    ->limit(50)
+                    ->placeholder('Uploaded artifacts'),
                 TextColumn::make('composerRepository.name')
                     ->label('Served in')
                     ->badge()

--- a/app/Filament/Resources/Packages/Tables/PackagesTable.php
+++ b/app/Filament/Resources/Packages/Tables/PackagesTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Packages\Tables;
 
+use App\Filament\Resources\Packages\Actions\RebuildPackageAction;
 use App\Filament\Resources\Packages\Actions\SyncPackageAction;
 use App\Models\Package;
 use Filament\Actions\BulkActionGroup;
@@ -109,6 +110,7 @@ class PackagesTable
             ])
             ->recordActions([
                 SyncPackageAction::make(),
+                RebuildPackageAction::make(),
                 ViewAction::make(),
                 EditAction::make(),
             ])

--- a/app/Filament/Resources/Packages/Widgets/PackageSyncProgress.php
+++ b/app/Filament/Resources/Packages/Widgets/PackageSyncProgress.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Packages\Widgets;
+
+use App\Models\Package;
+use Filament\Widgets\Widget;
+
+/**
+ * Live progress of the sync batch importing this package's versions, shown at
+ * the top of the package's view page.
+ *
+ * The view polls, so the widget appears on its own a few seconds after a sync
+ * is queued and leaves once every import has run. A batch that finished with
+ * failures is not "in progress": what it left behind is on the package's
+ * sync_error, which the page below already shows.
+ */
+class PackageSyncProgress extends Widget
+{
+    protected string $view = 'filament.resources.packages.widgets.package-sync-progress';
+
+    protected int|string|array $columnSpan = 'full';
+
+    /**
+     * Filled by the view page via InteractsWithRecord::getWidgetData().
+     */
+    public ?Package $record = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getViewData(): array
+    {
+        $batch = $this->record?->syncBatch();
+
+        if ($batch === null || ! $this->record->syncRunning()) {
+            return ['running' => false];
+        }
+
+        // The batch's first job is the discovery that fans the imports out, so
+        // the import counts leave it off — "1 of 5 jobs" is not what anyone
+        // watching a four-version repository wants to read.
+        return [
+            'running' => true,
+            'discovering' => $batch->totalJobs <= 1,
+            'imported' => max(0, $batch->processedJobs() - 1),
+            'total' => max(0, $batch->totalJobs - 1),
+            'failed' => $batch->failedJobs,
+            'progress' => $batch->progress(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Repositories/Pages/CreateRepository.php
+++ b/app/Filament/Resources/Repositories/Pages/CreateRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Repositories\Pages;
+
+use App\Filament\Resources\Repositories\RepositoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRepository extends CreateRecord
+{
+    protected static string $resource = RepositoryResource::class;
+}

--- a/app/Filament/Resources/Repositories/Pages/EditRepository.php
+++ b/app/Filament/Resources/Repositories/Pages/EditRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Repositories\Pages;
+
+use App\Filament\Resources\Repositories\RepositoryResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRepository extends EditRecord
+{
+    protected static string $resource = RepositoryResource::class;
+}

--- a/app/Filament/Resources/Repositories/Pages/ListRepositories.php
+++ b/app/Filament/Resources/Repositories/Pages/ListRepositories.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\Repositories\Pages;
+
+use App\Filament\Resources\Repositories\RepositoryResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRepositories extends ListRecords
+{
+    protected static string $resource = RepositoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Repositories/RepositoryResource.php
+++ b/app/Filament/Resources/Repositories/RepositoryResource.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Repositories;
+
+use App\Filament\Resources\Repositories\Pages\CreateRepository;
+use App\Filament\Resources\Repositories\Pages\EditRepository;
+use App\Filament\Resources\Repositories\Pages\ListRepositories;
+use App\Filament\Resources\Repositories\Schemas\RepositoryForm;
+use App\Filament\Resources\Repositories\Tables\RepositoriesTable;
+use App\Models\Repository;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class RepositoryResource extends Resource
+{
+    protected static ?string $model = Repository::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedArchiveBox;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    // "Repository" alone would read as the VCS repository packages sync from;
+    // these are the registries Composer consumes.
+    protected static ?string $navigationLabel = 'Composer repositories';
+
+    protected static ?string $modelLabel = 'Composer repository';
+
+    protected static ?string $pluralModelLabel = 'Composer repositories';
+
+    public static function form(Schema $schema): Schema
+    {
+        return RepositoryForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return RepositoriesTable::configure($table);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListRepositories::route('/'),
+            'create' => CreateRepository::route('/create'),
+            'edit' => EditRepository::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Repositories/Schemas/RepositoryForm.php
+++ b/app/Filament/Resources/Repositories/Schemas/RepositoryForm.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Resources\Repositories\Schemas;
+
+use App\Models\Repository;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+
+class RepositoryForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->placeholder('Internal packages')
+                    ->helperText('A label for this repository; only shown in the admin.'),
+                TextInput::make('path')
+                    ->label('URL path')
+                    ->prefix(url('/r').'/')
+                    // The default repository is the one exception: it is
+                    // served at the site root and created by the system, so
+                    // its (null) path is shown but never edited — retyping it
+                    // would orphan every consumer pointed at the root.
+                    ->required(fn (?Repository $record): bool => ! $record?->isDefault())
+                    ->disabled(fn (?Repository $record): bool => (bool) $record?->isDefault())
+                    ->placeholder(fn (?Repository $record): string => $record?->isDefault()
+                        ? 'None — served at the registry root'
+                        : 'internal')
+                    ->maxLength(64)
+                    ->regex('/^[a-z0-9]+(?:-[a-z0-9]+)*$/')
+                    ->validationMessages([
+                        'regex' => 'Only lowercase letters, numbers and hyphens — it becomes part of a URL.',
+                    ])
+                    ->unique(ignoreRecord: true)
+                    ->helperText(fn (?Repository $record): string => $record?->isDefault()
+                        ? 'This is the default repository, answering at the registry root.'
+                        : 'The repository is served at this path, e.g. /r/internal/packages.json.'),
+                Toggle::make('public')
+                    ->label('Public')
+                    ->helperText('Public repositories are readable without a token. Private ones require an access token that grants them.'),
+                Textarea::make('description')
+                    ->rows(3)
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Repositories/Tables/RepositoriesTable.php
+++ b/app/Filament/Resources/Repositories/Tables/RepositoriesTable.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Filament\Resources\Repositories\Tables;
+
+use App\Models\Repository;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class RepositoriesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('name')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('path')
+                    ->label('Served at')
+                    ->formatStateUsing(fn (?string $state): string => "/r/{$state}")
+                    // The default repository's null path is the registry root,
+                    // not a missing value.
+                    ->placeholder('/ (registry root)')
+                    ->sortable(),
+                IconColumn::make('public')
+                    ->boolean()
+                    ->tooltip(fn (Repository $record): string => $record->public
+                        ? 'Readable without a token'
+                        : 'Requires an access token'),
+                TextColumn::make('packages_count')
+                    ->label('Packages')
+                    ->counts('packages')
+                    ->sortable(),
+                TextColumn::make('description')
+                    ->limit(60)
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    // The database restricts the delete anyway; disabling it
+                    // here says why instead of failing with a query error. The
+                    // default repository is simply not deletable — the root
+                    // mount has to resolve to something.
+                    ->disabled(fn (Repository $record): bool => $record->isDefault() || $record->packages()->exists())
+                    ->tooltip(fn (Repository $record): ?string => match (true) {
+                        $record->isDefault() => 'The default repository cannot be deleted.',
+                        $record->packages()->exists() => 'Move or delete its packages first.',
+                        default => null,
+                    }),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Sources/RelationManagers/PackagesRelationManager.php
+++ b/app/Filament/Resources/Sources/RelationManagers/PackagesRelationManager.php
@@ -4,7 +4,9 @@ namespace App\Filament\Resources\Sources\RelationManagers;
 
 use App\Filament\Resources\Packages\PackageResource;
 use App\Models\Package;
+use Filament\Actions\Action;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
@@ -22,6 +24,16 @@ class PackagesRelationManager extends RelationManager
             ->recordTitleAttribute('name')
             ->defaultSort('name')
             ->recordUrl(fn (Package $record): string => PackageResource::getUrl('view', ['record' => $record]))
+            ->headerActions([
+                Action::make('createPackage')
+                    ->label('New package')
+                    ->icon(Heroicon::OutlinedPlus)
+                    // Creation is a wizard of its own, so this links out to it
+                    // rather than opening a modal — carrying the source along
+                    // so the new package authenticates through it from the start.
+                    ->url(fn (): string => PackageResource::getUrl('create', ['source' => $this->getOwnerRecord()->getKey()]))
+                    ->visible(fn (): bool => PackageResource::canCreate()),
+            ])
             ->columns([
                 TextColumn::make('name')
                     ->searchable()

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -46,6 +46,19 @@ class UserForm
                     ->helperText(fn (?User $record): string => $record !== null && $record->is(auth()->user())
                         ? 'You cannot change your own roles — ask another admin.'
                         : 'Without a role the account cannot sign in to the panel. What a role may do is defined under Roles.'),
+                Select::make('repositories')
+                    ->label('Granted repositories')
+                    ->relationship('repositories', 'name')
+                    ->multiple()
+                    ->preload()
+                    ->helperText('Every package in the chosen repositories, for accounts whose role lacks Unscoped:Package. Public repositories are visible to everyone.'),
+                Select::make('packages')
+                    ->label('Granted packages')
+                    ->relationship('packages', 'name')
+                    ->multiple()
+                    ->searchable()
+                    ->preload()
+                    ->helperText('Individual packages, wherever they are served. Ignored for accounts that can already see everything.'),
             ]);
     }
 }

--- a/app/Filament/Widgets/DownloadsChart.php
+++ b/app/Filament/Widgets/DownloadsChart.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Download;
+use Carbon\CarbonImmutable;
+use Filament\Widgets\ChartWidget;
+
+/**
+ * Downloads per day over the last 90 days, scoped like everything else on
+ * the dashboard to the packages the signed-in user may see.
+ */
+class DownloadsChart extends ChartWidget
+{
+    protected ?string $heading = 'Downloads';
+
+    protected ?string $description = 'Dist downloads per day, last 90 days.';
+
+    protected static ?int $sort = -1;
+
+    protected int|string|array $columnSpan = 'full';
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getData(): array
+    {
+        $end = CarbonImmutable::now()->endOfDay();
+        $start = $end->subDays(89)->startOfDay();
+
+        // Grouped in PHP rather than SQL for the same reason as the release
+        // heatmap: date truncation has no portable spelling, and 90 days of
+        // timestamps is a small set.
+        $byDay = Download::query()
+            ->where('created_at', '>=', $start)
+            ->when(
+                auth()->user(),
+                fn ($query, $user) => $query->whereHas(
+                    'package',
+                    fn ($packages) => $packages->visibleToUser($user),
+                ),
+            )
+            ->pluck('created_at')
+            ->countBy(fn (CarbonImmutable $created): string => $created->toDateString());
+
+        $labels = [];
+        $counts = [];
+
+        for ($day = $start; $day <= $end; $day = $day->addDay()) {
+            $labels[] = $day->format('M j');
+            $counts[] = $byDay[$day->toDateString()] ?? 0;
+        }
+
+        return [
+            'datasets' => [
+                [
+                    'label' => 'Downloads',
+                    'data' => $counts,
+                    'fill' => 'start',
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+}

--- a/app/Filament/Widgets/DownloadsChart.php
+++ b/app/Filament/Widgets/DownloadsChart.php
@@ -20,9 +20,33 @@ class DownloadsChart extends ChartWidget
 
     protected int|string|array $columnSpan = 'full';
 
+    protected ?string $maxHeight = '160px';
+
     protected function getType(): string
     {
         return 'line';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getOptions(): array
+    {
+        return [
+            'plugins' => [
+                'legend' => ['display' => false],
+            ],
+            'scales' => [
+                'y' => [
+                    // Counts can't go negative, and suggestedMax keeps the
+                    // axis from collapsing to a flat band when every day is
+                    // zero (Chart.js otherwise pads the scale to [-1, 1]).
+                    'min' => 0,
+                    'suggestedMax' => 5,
+                    'ticks' => ['precision' => 0],
+                ],
+            ],
+        ];
     }
 
     /**

--- a/app/Filament/Widgets/RegistryStatsOverview.php
+++ b/app/Filament/Widgets/RegistryStatsOverview.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Download;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/**
+ * The dashboard's headline numbers, scoped to what the signed-in user may
+ * see — a user granted three packages reads a dashboard about those three.
+ */
+class RegistryStatsOverview extends StatsOverviewWidget
+{
+    protected static ?int $sort = -3;
+
+    protected function getStats(): array
+    {
+        $packages = Package::query()
+            ->when(auth()->user(), fn ($query, $user) => $query->visibleToUser($user));
+
+        $packageIds = (clone $packages)->select('packages.id');
+
+        $downloads = Download::query()->whereIn('package_id', $packageIds);
+
+        return [
+            Stat::make('Packages', number_format($packages->count()))
+                ->description(number_format((clone $packages)->has('versions')->count()).' with synced versions'),
+            Stat::make('Versions', number_format(
+                PackageVersion::query()->whereIn('package_id', $packageIds)->count(),
+            )),
+            Stat::make('Downloads · 30 days', number_format(
+                (clone $downloads)->where('created_at', '>=', now()->subDays(30))->count(),
+            ))
+                ->description(number_format($downloads->count()).' all time'),
+        ];
+    }
+}

--- a/app/Filament/Widgets/RegistryTotals.php
+++ b/app/Filament/Widgets/RegistryTotals.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Download;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use Filament\Widgets\Concerns\CanPoll;
+use Filament\Widgets\Widget;
+
+/**
+ * The registry's four running totals — repositories, packages, versions,
+ * downloads — as one quad card, scoped like the rest of the dashboard to
+ * what the signed-in user may see.
+ *
+ * The top row is what the registry hosts, the bottom row what it has
+ * shipped; the two tones follow that split.
+ */
+class RegistryTotals extends Widget
+{
+    use CanPoll;
+
+    protected string $view = 'filament.widgets.registry-totals';
+
+    protected static ?int $sort = -4;
+
+    /**
+     * One column of the dashboard's default two: half the page.
+     */
+    protected int|string|array $columnSpan = 1;
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getViewData(): array
+    {
+        $user = auth()->user();
+
+        $repositories = Repository::query()
+            ->when($user, fn ($query, $user) => $query->visibleToUser($user));
+
+        $packages = Package::query()
+            ->when($user, fn ($query, $user) => $query->visibleToUser($user));
+
+        $packageIds = (clone $packages)->select('packages.id');
+
+        return [
+            'stats' => [
+                [
+                    'label' => 'Repositories',
+                    'value' => number_format($repositories->count()),
+                    'tone' => 'info',
+                ],
+                [
+                    'label' => 'Packages',
+                    'value' => number_format($packages->count()),
+                    'tone' => 'info',
+                ],
+                [
+                    'label' => 'Versions',
+                    'value' => number_format(
+                        PackageVersion::query()->whereIn('package_id', $packageIds)->count(),
+                    ),
+                    'tone' => 'success',
+                ],
+                [
+                    'label' => 'Downloads',
+                    'value' => number_format(
+                        Download::query()->whereIn('package_id', $packageIds)->count(),
+                    ),
+                    'tone' => 'success',
+                ],
+            ],
+            'pollingInterval' => $this->getPollingInterval(),
+        ];
+    }
+}

--- a/app/Filament/Widgets/VersionReleaseHeatmap.php
+++ b/app/Filament/Widgets/VersionReleaseHeatmap.php
@@ -88,6 +88,15 @@ class VersionReleaseHeatmap extends Widget
         return PackageVersion::query()
             ->where('is_dev', false)
             ->whereBetween('released_at', [$start, $end])
+            // A user with row-level scoping sees their packages' history, not
+            // the whole registry's.
+            ->when(
+                auth()->user(),
+                fn ($query, $user) => $query->whereHas(
+                    'package',
+                    fn ($packages) => $packages->visibleToUser($user),
+                ),
+            )
             ->with('package:id,name')
             ->get(['id', 'package_id', 'version', 'released_at']);
     }

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -148,14 +148,19 @@ class ComposerRepositoryController extends Controller
 
         abort_if($versions->isEmpty(), 404, "Reference {$reference} is not a known version of {$name}.");
 
-        // A tag and a branch can share a commit; any row with a stored
-        // archive serves for both.
-        $version = $versions->first(fn (PackageVersion $version): bool => $version->archive_path !== null);
-
         $disk = $this->archives->disk();
 
+        // A tag and a branch can share a commit; any row with a stored
+        // archive serves for both. The disk is asked per row rather than
+        // once, because a row's path can outlive its file — a sibling row
+        // may still hold a live zip for the same commit.
+        $version = $versions->first(
+            fn (PackageVersion $version): bool => $version->archive_path !== null
+                && $disk->exists($version->archive_path),
+        );
+
         abort_unless(
-            $version instanceof PackageVersion && $disk->exists($version->archive_path),
+            $version instanceof PackageVersion,
             404,
             "No archive is stored for {$name}@{$reference}; syncing the package will build it.",
         );

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Middleware\ResolveComposerRepository;
 use App\Models\Package;
 use App\Models\PackageVersion;
+use App\Models\Repository;
 use App\Services\ArchiveStore;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -13,6 +15,12 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * Serves the app as a Composer v2 repository, so a project can point at it
  * with a `composer config repositories.private composer <app-url>` entry.
+ *
+ * Every action serves one Repository — resolved by the middleware from the
+ * mount the request arrived through — and scopes all of its queries to it,
+ * so /r/internal and the root are entirely separate registries.
+ *
+ * @see ResolveComposerRepository
  */
 class ComposerRepositoryController extends Controller
 {
@@ -21,15 +29,17 @@ class ComposerRepositoryController extends Controller
     /**
      * The repository root that Composer fetches first.
      */
-    public function root(): JsonResponse
+    public function root(Request $request): JsonResponse
     {
+        $repository = $this->repository($request);
+
         // `search` and `list` rather than `available-packages`: inlining every
         // name defeats Composer's lazy metadata loading and hands the full
         // package list to anyone who fetches the root.
         return response()->json([
-            'metadata-url' => '/p2/%package%.json',
-            'search' => url('/search.json').'?q=%query%&type=%type%',
-            'list' => url('/list.json'),
+            'metadata-url' => $repository->pathPrefix().'/p2/%package%.json',
+            'search' => $repository->url('/search.json').'?q=%query%&type=%type%',
+            'list' => $repository->url('/list.json'),
         ]);
     }
 
@@ -43,7 +53,7 @@ class ComposerRepositoryController extends Controller
         // "acme/%" must not enumerate the registry.
         $prefix = addcslashes($request->string('q')->toString(), '\\%_');
 
-        $results = $this->servedPackages()
+        $results = $this->servedPackages($request)
             ->whereLike('name', "{$prefix}%")
             ->when(
                 $request->filled('type'),
@@ -69,35 +79,25 @@ class ComposerRepositoryController extends Controller
     /**
      * Every package name this repository serves.
      */
-    public function list(): JsonResponse
+    public function list(Request $request): JsonResponse
     {
         return response()->json([
-            'packageNames' => $this->servedPackages()->orderBy('name')->pluck('name'),
+            'packageNames' => $this->servedPackages($request)->orderBy('name')->pluck('name'),
         ]);
-    }
-
-    /**
-     * Packages the repository actually serves. A package with no synced
-     * versions resolves to nothing, so advertising it in search or list
-     * results would only produce dead ends.
-     *
-     * @return Builder<Package>
-     */
-    private function servedPackages(): Builder
-    {
-        return Package::query()->has('versions');
     }
 
     /**
      * Version metadata for one package. Composer requests both
      * `vendor/name.json` (releases) and `vendor/name~dev.json` (branches).
      */
-    public function metadata(string $vendor, string $package): JsonResponse
+    public function metadata(Request $request, string $vendor, string $package): JsonResponse
     {
+        $repository = $this->repository($request);
+
         $dev = str_ends_with($package, '~dev');
         $name = "{$vendor}/".($dev ? substr($package, 0, -4) : $package);
 
-        $record = Package::query()->where('name', $name)->first();
+        $record = $repository->packages()->where('name', $name)->first();
 
         abort_unless($record instanceof Package, 404, "Package {$name} is not served by this repository.");
 
@@ -115,11 +115,9 @@ class ComposerRepositoryController extends Controller
                 ...($version->released_at ? ['time' => $version->released_at->toIso8601String()] : []),
                 'dist' => [
                     'type' => 'zip',
-                    'url' => route('composer.dist', [
-                        'vendor' => $vendor,
-                        'package' => explode('/', $name)[1],
-                        'reference' => $version->reference,
-                    ]),
+                    'url' => $repository->url(
+                        '/dist/'.$vendor.'/'.explode('/', $name)[1]."/{$version->reference}.zip",
+                    ),
                     'reference' => $version->reference,
                     // Composer verifies the downloaded zip against this. A
                     // version synced before archives were stored has none, and
@@ -138,11 +136,11 @@ class ComposerRepositoryController extends Controller
      * a consumer needs no GitHub credentials, and an archive that was never
      * stored (or has gone missing) is a 404 the next sync repairs.
      */
-    public function dist(string $vendor, string $package, string $reference): StreamedResponse
+    public function dist(Request $request, string $vendor, string $package, string $reference): StreamedResponse
     {
         $name = "{$vendor}/{$package}";
 
-        $record = Package::query()->where('name', $name)->first();
+        $record = $this->repository($request)->packages()->where('name', $name)->first();
 
         abort_unless($record instanceof Package, 404, "Package {$name} is not served by this repository.");
 
@@ -165,5 +163,25 @@ class ComposerRepositoryController extends Controller
         return $disk->download($version->archive_path, "{$vendor}-{$package}-{$reference}.zip", [
             'Content-Type' => 'application/zip',
         ]);
+    }
+
+    /**
+     * The repository this request is addressed to, resolved by the middleware.
+     */
+    private function repository(Request $request): Repository
+    {
+        return $request->attributes->get('composerRepository');
+    }
+
+    /**
+     * Packages the repository actually serves. A package with no synced
+     * versions resolves to nothing, so advertising it in search or list
+     * results would only produce dead ends.
+     *
+     * @return Builder<Package>
+     */
+    private function servedPackages(Request $request): Builder
+    {
+        return $this->repository($request)->packages()->has('versions')->getQuery();
     }
 }

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\ResolveComposerRepository;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Models\Repository;
+use App\Models\Token;
 use App\Services\ArchiveStore;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -97,7 +98,10 @@ class ComposerRepositoryController extends Controller
         $dev = str_ends_with($package, '~dev');
         $name = "{$vendor}/".($dev ? substr($package, 0, -4) : $package);
 
-        $record = $repository->packages()->where('name', $name)->first();
+        $record = $repository->packages()
+            ->visibleTo($this->token($request))
+            ->where('name', $name)
+            ->first();
 
         abort_unless($record instanceof Package, 404, "Package {$name} is not served by this repository.");
 
@@ -140,7 +144,10 @@ class ComposerRepositoryController extends Controller
     {
         $name = "{$vendor}/{$package}";
 
-        $record = $this->repository($request)->packages()->where('name', $name)->first();
+        $record = $this->repository($request)->packages()
+            ->visibleTo($this->token($request))
+            ->where('name', $name)
+            ->first();
 
         abort_unless($record instanceof Package, 404, "Package {$name} is not served by this repository.");
 
@@ -179,14 +186,25 @@ class ComposerRepositoryController extends Controller
     }
 
     /**
-     * Packages the repository actually serves. A package with no synced
-     * versions resolves to nothing, so advertising it in search or list
-     * results would only produce dead ends.
+     * The access token the request authenticated with, if any.
+     */
+    private function token(Request $request): ?Token
+    {
+        return $request->attributes->get('composerToken');
+    }
+
+    /**
+     * Packages the repository actually serves to this request's principal.
+     * A package with no synced versions resolves to nothing, so advertising
+     * it in search or list results would only produce dead ends.
      *
      * @return Builder<Package>
      */
     private function servedPackages(Request $request): Builder
     {
-        return $this->repository($request)->packages()->has('versions')->getQuery();
+        return $this->repository($request)->packages()
+            ->visibleTo($this->token($request))
+            ->has('versions')
+            ->getQuery();
     }
 }

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Events\PackageDownloaded;
 use App\Http\Middleware\ResolveComposerRepository;
 use App\Models\DeployToken;
 use App\Models\Package;
@@ -64,14 +65,11 @@ class ComposerRepositoryController extends Controller
                 fn (Builder $query) => $query->where('type', $request->string('type')->toString()),
             )
             ->orderBy('name')
-            ->get(['name', 'description'])
+            ->get(['name', 'description', 'total_downloads'])
             ->map(fn (Package $package): array => [
                 'name' => $package->name,
                 'description' => (string) $package->description,
-                // Downloads are not tracked yet; the key is part of the
-                // packagist.org response shape, so it is served as zero
-                // rather than omitted.
-                'downloads' => 0,
+                'downloads' => $package->total_downloads,
             ]);
 
         return response()->json([
@@ -173,6 +171,16 @@ class ComposerRepositoryController extends Controller
             $version instanceof PackageVersion,
             404,
             "No archive is stored for {$name}@{$reference}; syncing the package will build it.",
+        );
+
+        // Only an archive actually being served counts; every 404 above
+        // returned before reaching this line.
+        PackageDownloaded::dispatch(
+            $record->id,
+            $version->id,
+            $version->version,
+            $request->ip(),
+            $this->token($request)?->token_prefix,
         );
 
         return $disk->download($version->archive_path, "{$vendor}-{$package}-{$reference}.zip", [

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -108,7 +108,11 @@ class ComposerRepositoryController extends Controller
 
         $versions = $record->versions()
             ->where('is_dev', $dev)
-            ->orderByDesc('version')
+            // Releases sort by the normalizer's order string, whose lexical
+            // order is semantic order (1.10.0 above 1.9.0). Branches have no
+            // release line to sort along, so dev versions keep name order.
+            ->when($dev, fn (Builder $query) => $query->orderByDesc('version'))
+            ->unless($dev, fn (Builder $query) => $query->orderByDesc('order'))
             ->get()
             ->map(fn (PackageVersion $version): array => [
                 ...$version->metadata,

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -4,13 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Models\Package;
 use App\Models\PackageVersion;
-use App\Services\GitHub\GitHubClient;
-use Illuminate\Contracts\Filesystem\Filesystem;
+use App\Services\ArchiveStore;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -19,6 +16,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class ComposerRepositoryController extends Controller
 {
+    public function __construct(private readonly ArchiveStore $archives) {}
+
     /**
      * The repository root that Composer fetches first.
      */
@@ -122,6 +121,10 @@ class ComposerRepositoryController extends Controller
                         'reference' => $version->reference,
                     ]),
                     'reference' => $version->reference,
+                    // Composer verifies the downloaded zip against this. A
+                    // version synced before archives were stored has none, and
+                    // omitting the key beats advertising a null.
+                    ...($version->shasum ? ['shasum' => $version->shasum] : []),
                 ],
             ]);
 
@@ -129,8 +132,11 @@ class ComposerRepositoryController extends Controller
     }
 
     /**
-     * Proxy a version's zipball from GitHub, caching it on the dist disk so
-     * each commit is only downloaded once.
+     * Stream a version's stored archive from the dist disk.
+     *
+     * Archives are built at sync time, so serving never reaches for GitHub —
+     * a consumer needs no GitHub credentials, and an archive that was never
+     * stored (or has gone missing) is a 404 the next sync repairs.
      */
     public function dist(string $vendor, string $package, string $reference): StreamedResponse
     {
@@ -139,63 +145,25 @@ class ComposerRepositoryController extends Controller
         $record = Package::query()->where('name', $name)->first();
 
         abort_unless($record instanceof Package, 404, "Package {$name} is not served by this repository.");
+
+        $versions = $record->versions()->where('reference', $reference)->get();
+
+        abort_if($versions->isEmpty(), 404, "Reference {$reference} is not a known version of {$name}.");
+
+        // A tag and a branch can share a commit; any row with a stored
+        // archive serves for both.
+        $version = $versions->first(fn (PackageVersion $version): bool => $version->archive_path !== null);
+
+        $disk = $this->archives->disk();
+
         abort_unless(
-            $record->versions()->where('reference', $reference)->exists(),
+            $version instanceof PackageVersion && $disk->exists($version->archive_path),
             404,
-            "Reference {$reference} is not a known version of {$name}.",
+            "No archive is stored for {$name}@{$reference}; syncing the package will build it.",
         );
 
-        $disk = Storage::disk(config('filesystems.dists'));
-        $path = "composer-dists/{$vendor}/{$package}/{$reference}.zip";
-
-        if (! $disk->exists($path)) {
-            $this->cacheZipball($disk, $path, $record, $reference);
-        }
-
-        return $disk->download($path, "{$vendor}-{$package}-{$reference}.zip", [
+        return $disk->download($version->archive_path, "{$vendor}-{$package}-{$reference}.zip", [
             'Content-Type' => 'application/zip',
         ]);
-    }
-
-    /**
-     * Download a zipball to a temporary file and stream it onto the dist disk.
-     *
-     * Going via a temporary file keeps the whole archive out of memory and
-     * means a failed download never publishes a partial zip that a later
-     * request would serve as a cache hit.
-     */
-    private function cacheZipball(Filesystem $disk, string $path, Package $record, string $reference): void
-    {
-        $temporary = tempnam(sys_get_temp_dir(), 'composer-dist-');
-
-        throw_if($temporary === false, new \RuntimeException('Unable to create a temporary file for the zipball.'));
-
-        try {
-            GitHubClient::for($record)->downloadZipball($reference, $temporary);
-
-            $stream = fopen($temporary, 'r');
-
-            throw_if($stream === false, new \RuntimeException("Unable to read the downloaded zipball for {$reference}."));
-
-            try {
-                throw_if(
-                    $disk->writeStream($path, $stream) === false,
-                    new \RuntimeException("Unable to write {$path} to the dist disk."),
-                );
-            } catch (\Throwable $exception) {
-                // A write that fails part way through can leave a truncated
-                // object behind, which the next request would serve as a
-                // cache hit.
-                $disk->delete($path);
-
-                throw $exception;
-            } finally {
-                if (is_resource($stream)) {
-                    fclose($stream);
-                }
-            }
-        } finally {
-            File::delete($temporary);
-        }
     }
 }

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers;
 
 use App\Http\Middleware\ResolveComposerRepository;
+use App\Models\DeployToken;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Models\Repository;
 use App\Models\Token;
+use App\Models\User;
 use App\Services\ArchiveStore;
+use App\Services\CreateVersionFromZip;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -175,6 +178,72 @@ class ComposerRepositoryController extends Controller
         return $disk->download($version->archive_path, "{$vendor}-{$package}-{$reference}.zip", [
             'Content-Type' => 'application/zip',
         ]);
+    }
+
+    /**
+     * Publish a version from an uploaded zip — CI pushing what it built.
+     *
+     * Requires a token with the write ability; the middleware never lets an
+     * unauthenticated request through to here.
+     */
+    public function upload(Request $request, CreateVersionFromZip $creator, string $vendor, string $package): JsonResponse
+    {
+        $validated = $request->validate([
+            'file' => ['required', 'file', 'mimes:zip'],
+            'version' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $repository = $this->repository($request);
+        $name = mb_strtolower("{$vendor}/{$package}");
+
+        abort_unless(
+            $this->mayUploadTo($request, $repository, $name),
+            403,
+            'This token may not publish into this repository.',
+        );
+
+        $version = $creator->create(
+            $repository,
+            $name,
+            $validated['file']->getRealPath(),
+            $validated['version'] ?? null,
+        );
+
+        return response()->json([
+            'name' => $name,
+            'version' => $version->version,
+            'shasum' => $version->shasum,
+        ], 201);
+    }
+
+    /**
+     * Whether the authenticated principal's scope reaches this repository.
+     *
+     * The write ability says "may publish"; the scope says where. A scoped
+     * principal needs the repository itself granted — or the existing package
+     * when only packages were granted. A public repository is readable by
+     * anyone, which grants nothing about writing into it.
+     */
+    private function mayUploadTo(Request $request, Repository $repository, string $name): bool
+    {
+        $principal = $this->token($request)?->tokenable;
+
+        $existingPackageGranted = fn ($grants): bool => ($existing = $repository->packages()->where('name', $name)->first())
+            && $grants->whereKey($existing->id)->exists();
+
+        if ($principal instanceof User) {
+            return $principal->hasUnscopedAccess()
+                || $principal->repositories()->whereKey($repository->id)->exists()
+                || $existingPackageGranted($principal->packages());
+        }
+
+        if ($principal instanceof DeployToken) {
+            return ! $principal->isScoped()
+                || $principal->repositories()->whereKey($repository->id)->exists()
+                || $existingPackageGranted($principal->packages());
+        }
+
+        return false;
     }
 
     /**

--- a/app/Http/Controllers/GitLabWebhookController.php
+++ b/app/Http/Controllers/GitLabWebhookController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response as ResponseCode;
+
+/**
+ * Turns a GitLab push into a sync.
+ *
+ * GitLab authenticates deliveries differently from GitHub: instead of an HMAC
+ * over the body it replays the hook's secret verbatim in X-Gitlab-Token, so
+ * verification is a constant-time comparison against the secret stored on the
+ * package. Only the per-repository leg exists — there is no GitLab equivalent
+ * of the GitHub App's account-wide webhook.
+ */
+class GitLabWebhookController extends Controller
+{
+    /**
+     * The events that can change what a version resolves to. Anything else
+     * the hook is subscribed to is acknowledged and dropped.
+     */
+    private const HANDLED_EVENTS = ['Push Hook', 'Tag Push Hook'];
+
+    public function repository(Request $request, Package $package): JsonResponse
+    {
+        if (blank($package->webhook_secret)) {
+            return $this->reject('This package has no repository webhook.', ResponseCode::HTTP_NOT_FOUND);
+        }
+
+        if (! hash_equals($package->webhook_secret, (string) $request->header('X-Gitlab-Token'))) {
+            return $this->reject('The token did not match.', ResponseCode::HTTP_UNAUTHORIZED);
+        }
+
+        $event = (string) $request->header('X-Gitlab-Event');
+
+        if (! in_array($event, self::HANDLED_EVENTS, true)) {
+            return response()->json([
+                'status' => 'ignored',
+                'detail' => "Nothing here acts on a \"{$event}\" event.",
+            ], ResponseCode::HTTP_ACCEPTED);
+        }
+
+        if (! $package->webhook_enabled) {
+            return response()->json([
+                'status' => 'ignored',
+                'detail' => "Auto-sync is switched off for {$package->name}.",
+            ], ResponseCode::HTTP_ACCEPTED);
+        }
+
+        $package->forceFill(['webhook_received_at' => now()])->save();
+
+        SyncPackageJob::debounced($package);
+
+        return response()->json([
+            'status' => 'accepted',
+            'package' => $package->name,
+            'detail' => "Syncing {$package->name}.",
+        ], ResponseCode::HTTP_ACCEPTED);
+    }
+
+    private function reject(string $detail, int $status): JsonResponse
+    {
+        return response()->json(['status' => 'rejected', 'detail' => $detail], $status);
+    }
+}

--- a/app/Http/Controllers/SsoController.php
+++ b/app/Http/Controllers/SsoController.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Auth\SsoProviderFactory;
+use App\Models\AuthenticationSource;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirect;
+use Throwable;
+
+/**
+ * The SSO round trip: off to the identity provider, back with an identity,
+ * and into the panel as whichever user that identity resolves to.
+ */
+class SsoController extends Controller
+{
+    public function __construct(private readonly SsoProviderFactory $providers) {}
+
+    public function redirect(AuthenticationSource $source): SymfonyRedirect
+    {
+        abort_unless($source->active, 404);
+
+        return $this->providers->provider($source)->redirect();
+    }
+
+    public function callback(AuthenticationSource $source): RedirectResponse
+    {
+        abort_unless($source->active, 404);
+
+        try {
+            $identity = $this->providers->provider($source)->user();
+        } catch (Throwable) {
+            // Cancelled consent, a stale state token, a provider outage — the
+            // user's next move is the same for all of them.
+            return $this->refuse('Sign-in failed or was cancelled. Try again.');
+        }
+
+        $externalId = (string) $identity->getId();
+        $email = $identity->getEmail();
+
+        $user = User::query()
+            ->where('authentication_source_id', $source->id)
+            ->where('external_id', $externalId)
+            ->first();
+
+        // Fall back to the email for accounts that predate the source, and
+        // bind the identity so renaming an email at the provider later does
+        // not mint a second account. Never rebind an already-bound account:
+        // that would let one provider quietly take over another's users.
+        if (! $user instanceof User && filled($email)) {
+            $user = User::query()->where('email', $email)->first();
+
+            if ($user instanceof User && $user->external_id === null) {
+                $user->forceFill([
+                    'authentication_source_id' => $source->id,
+                    'external_id' => $externalId,
+                ])->save();
+            }
+        }
+
+        if (! $user instanceof User) {
+            $user = $this->register($source, $externalId, $email, $identity->getName());
+
+            if ($user === null) {
+                return $this->refuse($source->allow_registration
+                    ? 'That account is not allowed to register here.'
+                    : 'This sign-in is limited to existing accounts.');
+            }
+        }
+
+        if (! $user->canAccessPanel(Filament::getPanel('admin'))) {
+            return $this->refuse('Your account has no role on this registry yet — ask an admin to assign one.');
+        }
+
+        Auth::login($user, remember: true);
+        session()->regenerate();
+
+        return redirect()->intended(Filament::getPanel('admin')->getUrl());
+    }
+
+    /**
+     * Provision the account an unknown identity is entitled to, or null when
+     * it is not entitled to one.
+     */
+    private function register(AuthenticationSource $source, string $externalId, ?string $email, ?string $name): ?User
+    {
+        if (! $source->allow_registration || blank($email) || ! $source->allowsDomain($email)) {
+            return null;
+        }
+
+        $user = User::query()->create([
+            'name' => $name ?: Str::headline(Str::before($email, '@')),
+            'email' => $email,
+            // Never learned by anyone; this account signs in through SSO.
+            'password' => Str::password(64),
+        ]);
+
+        $user->forceFill([
+            'authentication_source_id' => $source->id,
+            'external_id' => $externalId,
+            // The identity provider vouched for the address.
+            'email_verified_at' => now(),
+        ])->save();
+
+        if (filled($source->default_role)) {
+            $user->assignRole($source->default_role);
+        }
+
+        return $user;
+    }
+
+    private function refuse(string $message): RedirectResponse
+    {
+        return redirect()
+            ->route('filament.admin.auth.login')
+            ->with('sso_error', $message);
+    }
+}

--- a/app/Http/Middleware/AuthenticateComposer.php
+++ b/app/Http/Middleware/AuthenticateComposer.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Enums\TokenAbility;
+use App\Models\Repository;
+use App\Models\Token;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Authenticates Composer clients with access tokens.
+ *
+ * The token travels as the HTTP Basic password (any username) or as a bearer
+ * token. Reads on a public repository pass without one; everything else needs
+ * a live token holding the required ability. Runs after
+ * ResolveComposerRepository, whose resolved repository decides the public
+ * bypass.
+ */
+class AuthenticateComposer
+{
+    /**
+     * @param  'read'|'write'  $ability
+     */
+    public function handle(Request $request, Closure $next, string $ability = 'read'): Response
+    {
+        $required = $ability === 'write' ? TokenAbility::RepositoryWrite : TokenAbility::RepositoryRead;
+
+        $plain = $request->getPassword() ?: $request->bearerToken();
+
+        if (blank($plain)) {
+            /** @var Repository|null $repository */
+            $repository = $request->attributes->get('composerRepository');
+
+            if ($required === TokenAbility::RepositoryRead && $repository?->public) {
+                return $next($request);
+            }
+
+            return $this->challenge($request);
+        }
+
+        $token = Token::findByPlainText($plain);
+
+        // A presented credential is always checked, public repository or not:
+        // a CI system with a revoked token should hear about it as a 401, not
+        // keep working by accident until the repository goes private.
+        if (! $token instanceof Token || $token->isExpired()) {
+            return $this->challenge($request);
+        }
+
+        if (! $token->can($required)) {
+            return response()->json([
+                'message' => "The token \"{$token->name}\" does not have the {$required->value} ability.",
+            ], 403);
+        }
+
+        $token->markUsed();
+
+        $request->attributes->set('composerToken', $token);
+
+        return $next($request);
+    }
+
+    /**
+     * The 401 that tells a human how to fix it. The Basic challenge is also
+     * what makes an interactive `composer install` prompt for credentials.
+     */
+    private function challenge(Request $request): JsonResponse
+    {
+        $host = $request->getHttpHost();
+
+        return response()->json([
+            'message' => 'Authentication required. Create an access token in the admin panel, then run: '
+                ."composer config http-basic.{$host} token <your-token>",
+        ], 401, ['WWW-Authenticate' => 'Basic realm="Composer repository"']);
+    }
+}

--- a/app/Http/Middleware/ResolveComposerRepository.php
+++ b/app/Http/Middleware/ResolveComposerRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Repository;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Resolves which Composer repository a request is addressed to.
+ *
+ * The Composer routes are mounted twice — at the site root for the default
+ * repository and under /r/{repositoryPath} for named ones — and every
+ * endpoint scopes its queries to the repository resolved here, so the two
+ * mounts share one controller.
+ */
+class ResolveComposerRepository
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $path = $request->route('repositoryPath');
+
+        $repository = Repository::forPath($path);
+
+        abort_unless(
+            $repository instanceof Repository,
+            404,
+            "No Composer repository is served at /r/{$path}.",
+        );
+
+        if ($path !== null) {
+            // Controller methods receive route parameters positionally, and
+            // both mounts must dispatch with identical signatures — the
+            // repository travels as a request attribute instead.
+            $request->route()->forgetParameter('repositoryPath');
+        }
+
+        $request->attributes->set('composerRepository', $repository);
+
+        return $next($request);
+    }
+}

--- a/app/Jobs/DiscoverVersions.php
+++ b/app/Jobs/DiscoverVersions.php
@@ -34,7 +34,7 @@ class DiscoverVersions implements ShouldQueue
      */
     public bool $deleteWhenMissingModels = true;
 
-    public function __construct(public Package $package) {}
+    public function __construct(public Package $package, public bool $force = false) {}
 
     /**
      * Wait between attempts rather than retrying straight into whatever
@@ -59,7 +59,7 @@ class DiscoverVersions implements ShouldQueue
             $synchronizer->resolveComposerName($this->package);
             $synchronizer->prune($this->package, array_map(strval(...), array_keys($refs)));
 
-            $changed = $synchronizer->changed($this->package, $refs);
+            $changed = $synchronizer->changed($this->package, $refs, $this->force);
         } catch (Throwable $exception) {
             // Every attempt leaves the reason where the panel reads it, not
             // just the one that exhausts the retries.
@@ -71,7 +71,7 @@ class DiscoverVersions implements ShouldQueue
         $imports = [];
 
         foreach ($changed as $version => $ref) {
-            $imports[] = new ImportVersion($this->package, (string) $version, $ref['reference'], $ref['is_dev']);
+            $imports[] = new ImportVersion($this->package, (string) $version, $ref['reference'], $ref['is_dev'], $this->force);
         }
 
         if ($imports !== []) {

--- a/app/Jobs/DiscoverVersions.php
+++ b/app/Jobs/DiscoverVersions.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Package;
+use App\Notifications\PackageSyncFailed;
+use App\Services\AdminNotifier;
+use App\Services\PackageSynchronizer;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Throwable;
+
+/**
+ * The first job of a sync batch: list what the repository publishes, drop what
+ * it no longer does, and fan out one ImportVersion job per ref that needs
+ * work. Refs whose sha has not moved add no job at all, so a routine sync is
+ * a batch of nothing but this.
+ */
+class DiscoverVersions implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    public int $tries = 3;
+
+    /**
+     * Listing refs is paginated API reads, not archive downloads; even a
+     * repository at the pagination ceiling fits well inside this.
+     */
+    public int $timeout = 300;
+
+    /**
+     * Deleting a package while its sync is still queued is not a failure.
+     */
+    public bool $deleteWhenMissingModels = true;
+
+    public function __construct(public Package $package) {}
+
+    /**
+     * Wait between attempts rather than retrying straight into whatever
+     * failed — GitHub's outages tend to outlast a few seconds.
+     *
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        return [60, 300];
+    }
+
+    public function handle(PackageSynchronizer $synchronizer): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        try {
+            $refs = $synchronizer->discover($this->package);
+
+            $synchronizer->resolveComposerName($this->package);
+            $synchronizer->prune($this->package, array_map(strval(...), array_keys($refs)));
+
+            $changed = $synchronizer->changed($this->package, $refs);
+        } catch (Throwable $exception) {
+            // Every attempt leaves the reason where the panel reads it, not
+            // just the one that exhausts the retries.
+            $this->package->forceFill(['sync_error' => $exception->getMessage()])->save();
+
+            throw $exception;
+        }
+
+        $imports = [];
+
+        foreach ($changed as $version => $ref) {
+            $imports[] = new ImportVersion($this->package, (string) $version, $ref['reference'], $ref['is_dev']);
+        }
+
+        if ($imports !== []) {
+            $this->batch()->add($imports);
+        }
+    }
+
+    /**
+     * Discovery failing means the sync as a whole failed: nothing was listed,
+     * so nothing will import. Cancel the batch so FinalizePackageSync does not
+     * stamp the package as freshly synced, and say so out loud — a package
+     * that stops syncing stops receiving releases.
+     */
+    public function failed(?Throwable $exception): void
+    {
+        $reason = $exception?->getMessage() ?: 'The sync failed without reporting a reason.';
+
+        $this->package->forceFill(['sync_error' => $reason])->save();
+
+        $this->batch()?->cancel();
+
+        app(AdminNotifier::class)->send(new PackageSyncFailed($this->package, $reason));
+    }
+}

--- a/app/Jobs/FinalizePackageSync.php
+++ b/app/Jobs/FinalizePackageSync.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Package;
+use App\Notifications\PackageSyncFailed;
+use App\Notifications\PackageVersionsPublished;
+use App\Services\AdminNotifier;
+use App\Services\PackageSynchronizer;
+use Illuminate\Bus\Batch;
+use Throwable;
+
+/**
+ * The sync batch's `finally` callback: once every import has run — succeeded
+ * or not — refresh the package's own columns, and announce a release or a
+ * package arriving for the first time.
+ *
+ * Serialized with the batch, so it carries only scalars: the package id, and
+ * the versions the package had when the batch was dispatched, which is what
+ * "what changed" is measured against.
+ */
+class FinalizePackageSync
+{
+    /**
+     * @param  list<string>  $known
+     */
+    public function __construct(
+        public int $packageId,
+        public array $known,
+    ) {}
+
+    public function __invoke(Batch $batch): void
+    {
+        // A cancelled batch is a failed discovery: DiscoverVersions::failed()
+        // has already recorded the reason and raised the alarm, and stamping
+        // last_synced_at here would contradict it.
+        if ($batch->cancelled()) {
+            return;
+        }
+
+        $package = Package::query()->find($this->packageId);
+
+        if (! $package instanceof Package) {
+            return;
+        }
+
+        $attempted = max(0, $batch->totalJobs - 1);
+
+        try {
+            $outcome = app(PackageSynchronizer::class)->finalize($package, $this->known, $attempted, $batch->failedJobs);
+        } catch (Throwable $exception) {
+            $package->forceFill(['sync_error' => $exception->getMessage()])->save();
+
+            app(AdminNotifier::class)->send(new PackageSyncFailed($package, $exception->getMessage()));
+
+            return;
+        }
+
+        // Dev versions move on every commit and removals are usually a branch
+        // being tidied up, so a release — or a package arriving for the first
+        // time — is all that is worth anyone's attention.
+        if ($outcome->releases === [] && ! $outcome->initialImport) {
+            return;
+        }
+
+        app(AdminNotifier::class)->send(new PackageVersionsPublished($package, $outcome));
+    }
+}

--- a/app/Jobs/ImportVersion.php
+++ b/app/Jobs/ImportVersion.php
@@ -37,6 +37,7 @@ class ImportVersion implements ShouldQueue
         public string $version,
         public string $reference,
         public bool $isDev,
+        public bool $force = false,
     ) {}
 
     /**
@@ -58,6 +59,6 @@ class ImportVersion implements ShouldQueue
         $synchronizer->import($this->package, $this->version, [
             'reference' => $this->reference,
             'is_dev' => $this->isDev,
-        ]);
+        ], $this->force);
     }
 }

--- a/app/Jobs/ImportVersion.php
+++ b/app/Jobs/ImportVersion.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Package;
+use App\Services\PackageSynchronizer;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Import one ref of one package, as part of a sync batch.
+ *
+ * The batch allows failures, so a tag whose zipball is broken costs exactly
+ * that tag: every other job still runs, and FinalizePackageSync counts the
+ * casualties on the package afterwards.
+ */
+class ImportVersion implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    public int $tries = 3;
+
+    /**
+     * Room to stream a large archive; a whole repository no longer has to fit
+     * in one job's timeout, only its biggest version.
+     */
+    public int $timeout = 300;
+
+    /**
+     * Deleting a package while its imports are still queued is not a failure.
+     */
+    public bool $deleteWhenMissingModels = true;
+
+    public function __construct(
+        public Package $package,
+        public string $version,
+        public string $reference,
+        public bool $isDev,
+    ) {}
+
+    /**
+     * Wait out a GitHub hiccup rather than retrying straight into it.
+     *
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        return [30, 120];
+    }
+
+    public function handle(PackageSynchronizer $synchronizer): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        $synchronizer->import($this->package, $this->version, [
+            'reference' => $this->reference,
+            'is_dev' => $this->isDev,
+        ]);
+    }
+}

--- a/app/Jobs/PackageSyncBatch.php
+++ b/app/Jobs/PackageSyncBatch.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Package;
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Facades\Bus;
+
+/**
+ * A package sync as a queued job batch: one DiscoverVersions job that fans out
+ * one ImportVersion per ref needing work, closed out by FinalizePackageSync.
+ *
+ * allowFailures() is the point of the shape: importing a repository with two
+ * hundred tags is two hundred jobs, and one broken tag costs one job rather
+ * than the sync. The batch id is stored on the package so the panel can show
+ * progress while the imports run.
+ */
+class PackageSyncBatch
+{
+    public static function dispatchFor(Package $package): Batch
+    {
+        // What "changed" means afterwards is measured against what was stored
+        // when the sync began, captured here because the batch's callbacks
+        // only ever see the end state.
+        $known = array_map(strval(...), $package->versions()->pluck('version')->all());
+
+        $batch = Bus::batch([new DiscoverVersions($package)])
+            ->name("Sync {$package->name}")
+            ->allowFailures()
+            ->finally(new FinalizePackageSync((int) $package->getKey(), $known))
+            ->dispatch();
+
+        // Only the batch id is dirty, so this cannot clobber columns the
+        // batch itself already rewrote (on the sync driver it has run and
+        // finished before this line).
+        $package->forceFill(['sync_batch_id' => $batch->id])->save();
+
+        return $batch;
+    }
+}

--- a/app/Jobs/PackageSyncBatch.php
+++ b/app/Jobs/PackageSyncBatch.php
@@ -17,15 +17,15 @@ use Illuminate\Support\Facades\Bus;
  */
 class PackageSyncBatch
 {
-    public static function dispatchFor(Package $package): Batch
+    public static function dispatchFor(Package $package, bool $force = false): Batch
     {
         // What "changed" means afterwards is measured against what was stored
         // when the sync began, captured here because the batch's callbacks
         // only ever see the end state.
         $known = array_map(strval(...), $package->versions()->pluck('version')->all());
 
-        $batch = Bus::batch([new DiscoverVersions($package)])
-            ->name("Sync {$package->name}")
+        $batch = Bus::batch([new DiscoverVersions($package, $force)])
+            ->name(($force ? 'Rebuild' : 'Sync')." {$package->name}")
             ->allowFailures()
             ->finally(new FinalizePackageSync((int) $package->getKey(), $known))
             ->dispatch();

--- a/app/Jobs/SyncPackageJob.php
+++ b/app/Jobs/SyncPackageJob.php
@@ -160,12 +160,17 @@ class SyncPackageJob implements ShouldBeUniqueUntilProcessing, ShouldQueue
         // progress, and must not wedge the package forever.
         $batch = $this->package->syncBatch();
 
-        if ($batch !== null
-            && $this->package->syncRunning()
-            && $batch->createdAt->gt(now()->subHours(self::STALE_BATCH_HOURS))) {
-            self::dispatch($this->package, $this->force)->delay(now()->addSeconds(30));
+        if ($batch !== null && $this->package->syncRunning()) {
+            if ($batch->createdAt->gt(now()->subHours(self::STALE_BATCH_HOURS))) {
+                self::dispatch($this->package, $this->force)->delay(now()->addSeconds(30));
 
-            return;
+                return;
+            }
+
+            // Presumed lost, but its import jobs may still be sitting on the
+            // queue; cancelled, they no-op instead of racing the new batch's
+            // prune and imports.
+            $batch->cancel();
         }
 
         PackageSyncBatch::dispatchFor($this->package, $this->force);

--- a/app/Jobs/SyncPackageJob.php
+++ b/app/Jobs/SyncPackageJob.php
@@ -4,9 +4,7 @@ namespace App\Jobs;
 
 use App\Models\Package;
 use App\Notifications\PackageSyncFailed;
-use App\Notifications\PackageVersionsPublished;
 use App\Services\AdminNotifier;
-use App\Services\PackageSynchronizer;
 use Illuminate\Bus\UniqueLock;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Contracts\Cache\Repository as Cache;
@@ -17,27 +15,34 @@ use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Throwable;
 
 /**
- * Rebuild one package's versions from its repository, off the request.
+ * Start one package's sync, off the request.
  *
- * A first sync reads two GitHub endpoints per version, which is far too long
- * to hold an HTTP request open, so the panel and the console command both hand
- * the work here rather than running it inline.
+ * The sync itself runs as a job batch (PackageSyncBatch): discovery fans out
+ * one import job per ref, so this job's own work is only to start it — but it
+ * stays the single entry point because it is what carries the debounce and
+ * uniqueness rules every caller (panel, console, webhooks) relies on.
  */
 class SyncPackageJob implements ShouldBeUniqueUntilProcessing, ShouldQueue
 {
     use Queueable;
 
     /**
-     * A sync reads GitHub and then writes in a single transaction, so a
-     * partial run leaves nothing behind and re-running is safe.
+     * Dispatching the batch is a couple of writes; re-running it is safe
+     * because the batch's own jobs are idempotent per ref.
      */
     public int $tries = 3;
 
     /**
-     * The default 60 seconds only covers a repository with a handful of
-     * versions. Give a first import of a long-lived one room to finish.
+     * Starting the batch does not read GitHub at all — the batch's jobs carry
+     * their own timeouts for that.
      */
-    public int $timeout = 600;
+    public int $timeout = 60;
+
+    /**
+     * How long a rebuild may sit unfinished before it is presumed lost and a
+     * new sync may start over it. @see handle()
+     */
+    public const STALE_BATCH_HOURS = 2;
 
     /**
      * Deleting a package while its sync is still queued is not a failure.
@@ -144,24 +149,32 @@ class SyncPackageJob implements ShouldBeUniqueUntilProcessing, ShouldQueue
         return true;
     }
 
-    public function handle(PackageSynchronizer $synchronizer, AdminNotifier $notifier): void
+    public function handle(): void
     {
-        $outcome = $synchronizer->sync($this->package);
+        // Two rebuilds of one package must never run concurrently, or the
+        // loser's prune deletes rows the winner just wrote. WithoutOverlapping
+        // cannot see the batch — it only guards this job — so a sync arriving
+        // while a batch is still importing steps aside and comes back once it
+        // is done, exactly as a push made mid-sync always has. A batch that
+        // has sat unfinished for hours is a worker lost mid-run, not a sync in
+        // progress, and must not wedge the package forever.
+        $batch = $this->package->syncBatch();
 
-        // Dev versions move on every commit and removals are usually a branch
-        // being tidied up, so a release — or a package arriving for the first
-        // time — is all that is worth anyone's attention.
-        if ($outcome->releases === [] && ! $outcome->initialImport) {
+        if ($batch !== null
+            && $this->package->syncRunning()
+            && $batch->createdAt->gt(now()->subHours(self::STALE_BATCH_HOURS))) {
+            self::dispatch($this->package)->delay(now()->addSeconds(30));
+
             return;
         }
 
-        $notifier->send(new PackageVersionsPublished($this->package, $outcome));
+        PackageSyncBatch::dispatchFor($this->package);
     }
 
     /**
-     * The synchronizer records its own failure reason before rethrowing, but a
-     * job can die without ever reaching it — a timeout, or a worker killed
-     * mid-run. Leave a reason in the column the panel reads either way.
+     * The batch's own jobs record their failure reasons, but this job can die
+     * before the batch exists at all — a queue connection refusing, a worker
+     * killed mid-dispatch. Leave a reason in the column the panel reads.
      */
     public function failed(?Throwable $exception): void
     {

--- a/app/Jobs/SyncPackageJob.php
+++ b/app/Jobs/SyncPackageJob.php
@@ -60,7 +60,7 @@ class SyncPackageJob implements ShouldBeUniqueUntilProcessing, ShouldQueue
      */
     public const DEBOUNCE_SECONDS = 15;
 
-    public function __construct(public Package $package) {}
+    public function __construct(public Package $package, public bool $force = false) {}
 
     /**
      * Wait between attempts rather than retrying straight into whatever
@@ -126,9 +126,9 @@ class SyncPackageJob implements ShouldBeUniqueUntilProcessing, ShouldQueue
      * job then goes straight to the dispatcher, which performs no second
      * uniqueness check.
      */
-    public static function dispatchUnlessPending(Package $package): bool
+    public static function dispatchUnlessPending(Package $package, bool $force = false): bool
     {
-        $job = new self($package);
+        $job = new self($package, $force);
         $lock = new UniqueLock(app(Cache::class));
 
         if (! $lock->acquire($job)) {
@@ -163,12 +163,12 @@ class SyncPackageJob implements ShouldBeUniqueUntilProcessing, ShouldQueue
         if ($batch !== null
             && $this->package->syncRunning()
             && $batch->createdAt->gt(now()->subHours(self::STALE_BATCH_HOURS))) {
-            self::dispatch($this->package)->delay(now()->addSeconds(30));
+            self::dispatch($this->package, $this->force)->delay(now()->addSeconds(30));
 
             return;
         }
 
-        PackageSyncBatch::dispatchFor($this->package);
+        PackageSyncBatch::dispatchFor($this->package, $this->force);
     }
 
     /**

--- a/app/Listeners/RecordDownload.php
+++ b/app/Listeners/RecordDownload.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\PackageDownloaded;
+use App\Models\Download;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * Writes the download row and bumps the denormalized counters, on the queue
+ * so serving the archive never waits on bookkeeping.
+ */
+class RecordDownload implements ShouldQueue
+{
+    public function handle(PackageDownloaded $event): void
+    {
+        Download::query()->create([
+            'package_id' => $event->packageId,
+            'package_version_id' => $event->packageVersionId,
+            'version' => $event->version,
+            'ip' => $event->ip,
+            'token_prefix' => $event->tokenPrefix,
+            'created_at' => now(),
+        ]);
+
+        Package::query()->whereKey($event->packageId)->increment('total_downloads');
+        PackageVersion::query()->whereKey($event->packageVersionId)->increment('total_downloads');
+    }
+}

--- a/app/Models/AuthenticationSource.php
+++ b/app/Models/AuthenticationSource.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AuthProvider;
+use Database\Factories\AuthenticationSourceFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+/**
+ * A login provider configured at runtime: the OAuth client this registry is
+ * registered as with an identity provider, plus the rules for who may sign
+ * in — and who may sign *up* — through it.
+ */
+#[Fillable(['name', 'provider', 'client_id', 'client_secret', 'discovery_url', 'active', 'allow_registration', 'allowed_domains', 'default_role'])]
+class AuthenticationSource extends Model
+{
+    /** @use HasFactory<AuthenticationSourceFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'provider' => AuthProvider::class,
+            'client_secret' => 'encrypted',
+            'active' => 'boolean',
+            'allow_registration' => 'boolean',
+            'allowed_domains' => 'array',
+        ];
+    }
+
+    /**
+     * Where the identity provider sends the browser back to — the redirect
+     * URI to register on the OAuth client.
+     */
+    public function callbackUrl(): string
+    {
+        return route('sso.callback', $this);
+    }
+
+    /**
+     * Whether an email address passes this source's domain allowlist. An
+     * empty list allows every domain — the allowlist narrows registration,
+     * it does not exist to be mandatory.
+     */
+    public function allowsDomain(string $email): bool
+    {
+        $domains = array_filter((array) $this->allowed_domains);
+
+        if ($domains === []) {
+            return true;
+        }
+
+        $domain = mb_strtolower(Str::after($email, '@'));
+
+        return in_array($domain, array_map(mb_strtolower(...), $domains), true);
+    }
+}

--- a/app/Models/DeployToken.php
+++ b/app/Models/DeployToken.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\DeployTokenFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+/**
+ * A machine principal for CI/CD access, without a user account behind it.
+ *
+ * The deploy token itself is the identity; what it presents to the Composer
+ * endpoints is the access token issued against it. Its visibility is the
+ * union of its granted repositories and packages — or everything, when it
+ * holds no grants at all.
+ */
+#[Fillable(['name'])]
+class DeployToken extends Model
+{
+    /** @use HasFactory<DeployTokenFactory> */
+    use HasFactory;
+
+    protected static function booted(): void
+    {
+        // Deleting the principal revokes its credentials; the soft-deleted
+        // token rows keep the audit trail of what it was and when it was
+        // last used. The grant pivots cascade away in the database.
+        static::deleted(fn (self $deployToken) => $deployToken->tokens()->delete());
+    }
+
+    /**
+     * @return MorphMany<Token, $this>
+     */
+    public function tokens(): MorphMany
+    {
+        return $this->morphMany(Token::class, 'tokenable');
+    }
+
+    /**
+     * The access token currently presented for this principal.
+     *
+     * @return MorphOne<Token, $this>
+     */
+    public function token(): MorphOne
+    {
+        return $this->morphOne(Token::class, 'tokenable')->latestOfMany();
+    }
+
+    /**
+     * @return BelongsToMany<Package, $this>
+     */
+    public function packages(): BelongsToMany
+    {
+        return $this->belongsToMany(Package::class);
+    }
+
+    /**
+     * @return BelongsToMany<Repository, $this>
+     */
+    public function repositories(): BelongsToMany
+    {
+        return $this->belongsToMany(Repository::class);
+    }
+
+    /**
+     * Whether this token's reach is limited at all. No grants means every
+     * package — an explicit design choice, so that "one token for the whole
+     * registry" needs no ceremony.
+     */
+    public function isScoped(): bool
+    {
+        return $this->packages()->exists() || $this->repositories()->exists();
+    }
+}

--- a/app/Models/Download.php
+++ b/app/Models/Download.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One served dist download. Append-only: rows are written by the download
+ * listener and only ever read after that, so there is no updated_at.
+ */
+#[Fillable(['package_id', 'package_version_id', 'version', 'ip', 'token_prefix', 'created_at'])]
+class Download extends Model
+{
+    public const ?string UPDATED_AT = null;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'immutable_datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Package, $this>
+     */
+    public function package(): BelongsTo
+    {
+        return $this->belongsTo(Package::class);
+    }
+
+    /**
+     * @return BelongsTo<PackageVersion, $this>
+     */
+    public function packageVersion(): BelongsTo
+    {
+        return $this->belongsTo(PackageVersion::class);
+    }
+}

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -241,7 +241,13 @@ class Package extends Model
      */
     public function repositoryPath(): string
     {
-        $repository = trim($this->repository);
+        $repository = trim((string) $this->repository);
+
+        if ($repository === '') {
+            throw new InvalidArgumentException(
+                'This package has no VCS repository URL; it is published by artifact upload.',
+            );
+        }
 
         if (preg_match('#github\.com[:/]+([^/]+)/([^/]+?)(?:\.git)?/?$#i', $repository, $matches)) {
             return "{$matches[1]}/{$matches[2]}";
@@ -405,6 +411,26 @@ class Package extends Model
         }
 
         return $devVersions->first();
+    }
+
+    /**
+     * Recompute latest_version from the versions actually stored: the highest
+     * stable tag, or null when only pre-releases and branches exist.
+     *
+     * The synchronizer maintains the column during syncs; this is for the
+     * paths that change versions without one — artifact uploads, rebuilds.
+     */
+    public function refreshLatestVersion(): void
+    {
+        $latest = $this->versions()
+            ->where('is_dev', false)
+            ->pluck('version')
+            ->map(strval(...))
+            ->reject(fn (string $version): bool => (bool) preg_match('/(alpha|beta|rc|dev)/i', $version))
+            ->sort(fn (string $a, string $b): int => version_compare(ltrim($a, 'vV'), ltrim($b, 'vV')))
+            ->last();
+
+        $this->forceFill(['latest_version' => $latest])->save();
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -10,6 +10,7 @@ use Database\Factories\PackageFactory;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\BatchRepository;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -93,6 +94,40 @@ class Package extends Model
     public function composerRepository(): BelongsTo
     {
         return $this->belongsTo(Repository::class, 'repository_id');
+    }
+
+    /**
+     * Narrow to the packages the presenting token may see — the one place
+     * the Composer endpoints' access control lives.
+     *
+     * No token sees public repositories only. A user's personal token sees
+     * everything its owner does. A deploy token sees public repositories
+     * plus whatever it was granted — or everything, when it holds no grants.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeVisibleTo(Builder $query, ?Token $token): Builder
+    {
+        $principal = $token?->tokenable;
+
+        if ($principal instanceof User) {
+            return $query;
+        }
+
+        if ($principal instanceof DeployToken && ! $principal->isScoped()) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $query) use ($principal): void {
+            $query->whereHas('composerRepository', fn (Builder $repositories) => $repositories->where('public', true));
+
+            if ($principal instanceof DeployToken) {
+                $query
+                    ->orWhereIn('packages.id', $principal->packages()->select('packages.id'))
+                    ->orWhereIn('packages.repository_id', $principal->repositories()->select('repositories.id'));
+            }
+        });
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -101,7 +101,7 @@ class Package extends Model
      * the Composer endpoints' access control lives.
      *
      * No token sees public repositories only. A user's personal token sees
-     * everything its owner does. A deploy token sees public repositories
+     * exactly what its owner does. A deploy token sees public repositories
      * plus whatever it was granted — or everything, when it holds no grants.
      *
      * @param  Builder<self>  $query
@@ -112,7 +112,7 @@ class Package extends Model
         $principal = $token?->tokenable;
 
         if ($principal instanceof User) {
-            return $query;
+            return $query->visibleToUser($principal);
         }
 
         if ($principal instanceof DeployToken && ! $principal->isScoped()) {
@@ -127,6 +127,30 @@ class Package extends Model
                     ->orWhereIn('packages.id', $principal->packages()->select('packages.id'))
                     ->orWhereIn('packages.repository_id', $principal->repositories()->select('repositories.id'));
             }
+        });
+    }
+
+    /**
+     * Narrow to the packages a panel user may see: everything for a user
+     * holding Unscoped:Package, otherwise public repositories plus their
+     * explicit package and repository grants.
+     *
+     * Applied by the package table, the dashboard widgets, and — through
+     * visibleTo() — the user's own personal access tokens.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeVisibleToUser(Builder $query, User $user): Builder
+    {
+        if ($user->hasUnscopedAccess()) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $query) use ($user): void {
+            $query->whereHas('composerRepository', fn (Builder $repositories) => $repositories->where('public', true))
+                ->orWhereIn('packages.id', $user->packages()->select('packages.id'))
+                ->orWhereIn('packages.repository_id', $user->repositories()->select('repositories.id'));
         });
     }
 

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
-#[Fillable(['source_id', 'repository', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error', 'webhook_enabled'])]
+#[Fillable(['repository_id', 'source_id', 'repository', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error', 'webhook_enabled'])]
 class Package extends Model
 {
     /** @use HasFactory<PackageFactory> */
@@ -51,7 +51,14 @@ class Package extends Model
 
     protected static function booted(): void
     {
-        static::saving(fn (self $package) => $package->linkSource());
+        static::saving(function (self $package): void {
+            // Every package is served from a repository; anything created
+            // without choosing one lands in the default repository at the
+            // registry root.
+            $package->repository_id ??= Repository::default()->id;
+
+            $package->linkSource();
+        });
 
         // A repository hook left behind on GitHub would keep posting to a URL
         // that resolves to nothing. Removing it is best effort: the package is
@@ -73,6 +80,19 @@ class Package extends Model
     public function source(): BelongsTo
     {
         return $this->belongsTo(Source::class);
+    }
+
+    /**
+     * The Composer repository this package is served from.
+     *
+     * Named for what it is rather than `repository()`, because that name is
+     * taken: the `repository` attribute is the VCS URL the package syncs from.
+     *
+     * @return BelongsTo<Repository, $this>
+     */
+    public function composerRepository(): BelongsTo
+    {
+        return $this->belongsTo(Repository::class, 'repository_id');
     }
 
     /**
@@ -281,8 +301,18 @@ class Package extends Model
      */
     public function installCommands(): array
     {
+        $repository = $this->composerRepository;
+
+        // A package in a named repository is reached through that mount, and
+        // the config key carries the path so two repositories on the same
+        // registry never fight over one entry in the consumer's composer.json.
         $repositoryKey = Str::slug(config('app.name')) ?: 'private';
-        $repositoryUrl = rtrim(url('/'), '/');
+
+        if (! $repository->isDefault()) {
+            $repositoryKey .= "-{$repository->path}";
+        }
+
+        $repositoryUrl = rtrim($repository->url(), '/');
 
         $require = $this->name;
 

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -5,7 +5,11 @@ namespace App\Models;
 use App\Enums\SourceProvider;
 use App\Enums\WebhookCoverage;
 use App\Services\GitHub\GitHubApp;
+use App\Services\GitHub\GitHubClient;
 use App\Services\GitHub\WebhookRegistrar;
+use App\Services\GitLab\GitLabClient;
+use App\Sources\RepositoryClient;
+use App\Sources\StubClient;
 use Database\Factories\PackageFactory;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\BatchRepository;
@@ -206,7 +210,41 @@ class Package extends Model
             return;
         }
 
-        $this->source_id = Source::forRepositoryPath($path)?->id;
+        $this->source_id = Source::forRepositoryPath($path, $this->provider())?->id;
+
+        // Anything resolved through the relation from here on must see the
+        // source just linked, not a null cached while it was being decided.
+        $this->unsetRelation('source');
+    }
+
+    /**
+     * The provider this package's repository lives on: the connected source's
+     * word for it, or the repository URL's host as the honest guess.
+     *
+     * The relation is only touched when a source is actually linked: this
+     * runs inside linkSource() itself (via repositoryPath), and lazy-loading
+     * there would cache the relation as null before source_id is decided.
+     */
+    public function provider(): SourceProvider
+    {
+        if ($this->source_id !== null && $this->source instanceof Source) {
+            return $this->source->provider;
+        }
+
+        return SourceProvider::forHost($this->parsedRepository()['host']);
+    }
+
+    /**
+     * The client that speaks this package's provider — the one seam through
+     * which syncing, webhooks and the wizard reach any VCS API.
+     */
+    public function client(): RepositoryClient
+    {
+        return match ($provider = $this->provider()) {
+            SourceProvider::Github => GitHubClient::for($this),
+            SourceProvider::Gitlab => GitLabClient::for($this),
+            default => new StubClient($provider),
+        };
     }
 
     /**
@@ -221,7 +259,9 @@ class Package extends Model
     {
         return $this->source?->accessToken()
             ?? $this->token
-            ?? config('services.github.token');
+            // The environment fallback is a GitHub credential; handing it to
+            // another provider's API would only leak it.
+            ?? ($this->provider() === SourceProvider::Github ? config('services.github.token') : null);
     }
 
     /**
@@ -230,34 +270,61 @@ class Package extends Model
      */
     public function apiUrl(): string
     {
-        return $this->source?->apiUrl() ?? SourceProvider::Github->defaultApiUrl();
+        return $this->source?->apiUrl() ?? $this->provider()->defaultApiUrl();
     }
 
     /**
-     * The "owner/repo" path of the GitHub repository.
+     * The provider-side path of the repository: "owner/repo" on GitHub,
+     * the full (possibly nested) namespace path on GitLab.
      *
-     * Accepts a full GitHub URL (https or git@, with or without .git) as well
-     * as a bare "owner/repo" value.
+     * Accepts a full URL (https, ssh, or git@, with or without .git) from
+     * any provider, as well as a bare path.
      */
     public function repositoryPath(): string
     {
+        $parsed = $this->parsedRepository();
+
+        $path = $parsed['path'];
+
+        if ($path === null) {
+            throw new InvalidArgumentException(blank($this->repository)
+                ? 'This package has no VCS repository URL; it is published by artifact upload.'
+                : "Unable to determine the repository path from [{$this->repository}].");
+        }
+
+        // GitHub repositories are exactly owner/repo; anything after that in
+        // a pasted URL (/tree/main, /issues) is browser chrome, not path.
+        if ($this->provider() === SourceProvider::Github) {
+            return implode('/', array_slice(explode('/', $path), 0, 2));
+        }
+
+        return $path;
+    }
+
+    /**
+     * The host and repository path the stored URL names, each null when the
+     * URL does not yield one.
+     *
+     * @return array{host: ?string, path: ?string}
+     */
+    private function parsedRepository(): array
+    {
         $repository = trim((string) $this->repository);
 
-        if ($repository === '') {
-            throw new InvalidArgumentException(
-                'This package has no VCS repository URL; it is published by artifact upload.',
-            );
+        if (preg_match('#^(?:https?://|ssh://git@|git@)([^/:]+)[:/](.+?)(?:\.git)?/?$#i', $repository, $matches)) {
+            $path = trim($matches[2], '/');
+
+            return [
+                'host' => $matches[1],
+                'path' => str_contains($path, '/') ? $path : null,
+            ];
         }
 
-        if (preg_match('#github\.com[:/]+([^/]+)/([^/]+?)(?:\.git)?/?$#i', $repository, $matches)) {
-            return "{$matches[1]}/{$matches[2]}";
+        if (preg_match('#^[\w.-]+(?:/[\w.-]+)+$#', $repository)) {
+            return ['host' => null, 'path' => preg_replace('/\.git$/i', '', $repository)];
         }
 
-        if (preg_match('#^([\w.-]+)/([\w.-]+?)(?:\.git)?$#', $repository, $matches)) {
-            return "{$matches[1]}/{$matches[2]}";
-        }
-
-        throw new InvalidArgumentException("Unable to determine the GitHub repository from [{$repository}].");
+        return ['host' => null, 'path' => null];
     }
 
     /**
@@ -332,13 +399,15 @@ class Package extends Model
     }
 
     /**
-     * Where GitHub posts this package's own deliveries. Only meaningful for a
-     * package carrying a repository hook — an app-covered one is delivered to
-     * the account-wide URL instead.
+     * Where the provider posts this package's own deliveries. Only meaningful
+     * for a package carrying a repository hook — an app-covered one is
+     * delivered to the account-wide URL instead.
      */
     public function webhookUrl(): string
     {
-        return route('webhooks.github.package', $this);
+        return $this->provider() === SourceProvider::Gitlab
+            ? route('webhooks.gitlab.package', $this)
+            : route('webhooks.github.package', $this);
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -7,6 +7,8 @@ use App\Enums\WebhookCoverage;
 use App\Services\GitHub\GitHubApp;
 use App\Services\GitHub\WebhookRegistrar;
 use Database\Factories\PackageFactory;
+use Illuminate\Bus\Batch;
+use Illuminate\Bus\BatchRepository;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -71,6 +73,37 @@ class Package extends Model
     public function source(): BelongsTo
     {
         return $this->belongsTo(Source::class);
+    }
+
+    /**
+     * The job batch currently (or last) rebuilding this package's versions,
+     * or null when none has run or the batch has been pruned.
+     *
+     * Read through the repository rather than the Bus facade so it still
+     * answers from the real job_batches table when the dispatcher is faked.
+     */
+    public function syncBatch(): ?Batch
+    {
+        return $this->sync_batch_id === null
+            ? null
+            : app(BatchRepository::class)->find($this->sync_batch_id);
+    }
+
+    /**
+     * Whether a sync batch is still working through this package's versions.
+     *
+     * A batch that allows failures is never marked finished once a job has
+     * failed — only its pending count ever tells the truth. "Every job has
+     * run, some badly" is done, not in progress.
+     */
+    public function syncRunning(): bool
+    {
+        $batch = $this->syncBatch();
+
+        return $batch !== null
+            && ! $batch->finished()
+            && ! $batch->cancelled()
+            && $batch->pendingJobs > $batch->failedJobs;
     }
 
     /**

--- a/app/Models/PackageVersion.php
+++ b/app/Models/PackageVersion.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-#[Fillable(['version', 'reference', 'is_dev', 'released_at', 'metadata'])]
+#[Fillable(['version', 'reference', 'is_dev', 'released_at', 'metadata', 'archive_path', 'shasum'])]
 class PackageVersion extends Model
 {
     /** @use HasFactory<PackageVersionFactory> */

--- a/app/Models/PackageVersion.php
+++ b/app/Models/PackageVersion.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-#[Fillable(['version', 'reference', 'is_dev', 'released_at', 'metadata', 'archive_path', 'shasum'])]
+#[Fillable(['version', 'order', 'reference', 'is_dev', 'released_at', 'metadata', 'archive_path', 'shasum'])]
 class PackageVersion extends Model
 {
     /** @use HasFactory<PackageVersionFactory> */

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\RepositoryFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * A named Composer repository this registry serves.
+ *
+ * Every package belongs to exactly one repository. The default repository
+ * (path null) answers at the site root, exactly as the registry did before
+ * repositories existed; every other repository is mounted under /r/{path},
+ * so one installation can serve independent registries — a public one and an
+ * internal one, say — with independent access rules.
+ */
+#[Fillable(['name', 'path', 'description', 'public'])]
+class Repository extends Model
+{
+    /** @use HasFactory<RepositoryFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'public' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return HasMany<Package, $this>
+     */
+    public function packages(): HasMany
+    {
+        return $this->hasMany(Package::class);
+    }
+
+    /**
+     * The repository served at the site root, created on first use.
+     *
+     * Public by design: it stands in for the whole registry as it behaved
+     * before repositories (and token auth) existed, so its packages stay
+     * readable until an admin deliberately flips it private. Repositories
+     * created by hand start private instead.
+     */
+    public static function default(): self
+    {
+        $existing = static::query()->whereNull('path')->first();
+
+        if ($existing instanceof self) {
+            return $existing;
+        }
+
+        return static::create([
+            'name' => static::availableName('Default'),
+            'path' => null,
+            'description' => 'The repository served at the registry root.',
+            'public' => true,
+        ]);
+    }
+
+    /**
+     * The repository mounted at the given URL path, or null when nothing is.
+     * A null path names the default repository, creating it if need be.
+     */
+    public static function forPath(?string $path): ?self
+    {
+        return $path === null
+            ? static::default()
+            : static::query()->where('path', $path)->first();
+    }
+
+    /**
+     * Whether this is the default repository, the one answering at the root.
+     */
+    public function isDefault(): bool
+    {
+        return $this->path === null;
+    }
+
+    /**
+     * The URL path prefix this repository's Composer endpoints live under:
+     * empty for the default repository, "/r/{path}" for a named one.
+     */
+    public function pathPrefix(): string
+    {
+        return $this->isDefault() ? '' : "/r/{$this->path}";
+    }
+
+    /**
+     * An absolute URL inside this repository's mount.
+     */
+    public function url(string $suffix = ''): string
+    {
+        return url($this->pathPrefix().$suffix);
+    }
+
+    /**
+     * The preferred name, suffixed until it no longer collides. Names are
+     * unique, and default() must never fail because an admin happened to
+     * call their own repository "Default".
+     */
+    private static function availableName(string $preferred): string
+    {
+        $name = $preferred;
+
+        for ($suffix = 2; static::query()->where('name', $name)->exists(); $suffix++) {
+            $name = "{$preferred} ({$suffix})";
+        }
+
+        return $name;
+    }
+}

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Database\Factories\RepositoryFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -39,6 +40,29 @@ class Repository extends Model
     public function packages(): HasMany
     {
         return $this->hasMany(Package::class);
+    }
+
+    /**
+     * Narrow to the repositories a panel user may see: everything for a user
+     * holding Unscoped:Package, otherwise public repositories plus the ones
+     * their grants reach — granted wholesale, or holding a granted package.
+     *
+     * The repository-level counterpart of Package::scopeVisibleToUser().
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeVisibleToUser(Builder $query, User $user): Builder
+    {
+        if ($user->hasUnscopedAccess()) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $query) use ($user): void {
+            $query->where('public', true)
+                ->orWhereIn('repositories.id', $user->repositories()->select('repositories.id'))
+                ->orWhereIn('repositories.id', $user->packages()->select('packages.repository_id'));
+        });
     }
 
     /**

--- a/app/Models/Source.php
+++ b/app/Models/Source.php
@@ -4,6 +4,10 @@ namespace App\Models;
 
 use App\Enums\SourceProvider;
 use App\Services\GitHub\GitHubApp;
+use App\Services\GitHub\GitHubSourceClient;
+use App\Services\GitLab\GitLabSourceClient;
+use App\Sources\SourceClient;
+use App\Sources\StubClient;
 use Database\Factories\SourceFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -50,10 +54,10 @@ class Source extends Model
     }
 
     /**
-     * The source that owns a given "owner/repo" path, or null when that owner
-     * has not been connected.
+     * The source that owns a given "owner/repo" path on a provider, or null
+     * when that owner has not been connected.
      */
-    public static function forRepositoryPath(string $repositoryPath): ?self
+    public static function forRepositoryPath(string $repositoryPath, SourceProvider $provider = SourceProvider::Github): ?self
     {
         $owner = strtok($repositoryPath, '/');
 
@@ -62,9 +66,21 @@ class Source extends Model
         }
 
         return static::query()
-            ->where('provider', SourceProvider::Github)
+            ->where('provider', $provider)
             ->forAccount($owner)
             ->first();
+    }
+
+    /**
+     * The client that browses this source's projects, for onboarding.
+     */
+    public function client(): SourceClient
+    {
+        return match ($this->provider) {
+            SourceProvider::Github => new GitHubSourceClient($this),
+            SourceProvider::Gitlab => new GitLabSourceClient($this),
+            default => new StubClient($this->provider),
+        };
     }
 
     /**
@@ -354,6 +370,15 @@ class Source extends Model
             'This source has neither a GitHub App installation nor an access token.'
         ));
 
+        if ($this->provider === SourceProvider::Gitlab) {
+            // GitLab tokens are personal; membership is the account scope.
+            return count($this->get('/projects', ['membership' => 'true', 'per_page' => 100]));
+        }
+
+        throw_unless($this->provider === SourceProvider::Github, new RuntimeException(
+            "{$this->provider->getLabel()} sources are not supported yet."
+        ));
+
         throw_unless($this->account, new RuntimeException(
             'Set the account (the GitHub organisation or user) before testing a token-based source.'
         ));
@@ -375,7 +400,10 @@ class Source extends Model
     private function get(string $path, array $query = [], bool $allowMissing = false): ?array
     {
         $response = Http::baseUrl($this->apiUrl())
-            ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
+            ->when(
+                $this->provider === SourceProvider::Github,
+                fn ($request) => $request->withHeaders(['X-GitHub-Api-Version' => '2022-11-28']),
+            )
             ->withToken($this->accessToken())
             ->acceptJson()
             ->get($path, $query);

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\TokenAbility;
+use App\Support\NewToken;
+use Database\Factories\TokenFactory;
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+/**
+ * An access token a Composer client authenticates with.
+ *
+ * Consumers configure it as an HTTP Basic password (any username) or a
+ * bearer token:
+ *
+ *   composer config http-basic.<registry-host> token <plain-token>
+ *
+ * The plain token exists only at issue time; the row keeps its sha256.
+ * Revocation is a soft delete, which is also what findByPlainText() honours —
+ * a revoked token stops authenticating without its history disappearing.
+ */
+#[Fillable(['name', 'abilities', 'expires_at'])]
+class Token extends Model
+{
+    /** @use HasFactory<TokenFactory> */
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'access_tokens';
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'abilities' => 'array',
+            'last_used_at' => 'datetime',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * The principal this token acts as: a User, or a DeployToken.
+     *
+     * @return MorphTo<Model, $this>
+     */
+    public function tokenable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * Issue a token for a principal, returning the only copy of its plain
+     * text that will ever exist.
+     *
+     * @param  list<TokenAbility|string>  $abilities
+     */
+    public static function issue(
+        Model $tokenable,
+        string $name,
+        array $abilities,
+        ?DateTimeInterface $expiresAt = null,
+    ): NewToken {
+        $plain = 'pp_'.Str::random(40);
+
+        $token = new self;
+
+        $token->forceFill([
+            'tokenable_type' => $tokenable->getMorphClass(),
+            'tokenable_id' => $tokenable->getKey(),
+            'name' => $name,
+            'abilities' => array_map(
+                fn (TokenAbility|string $ability): string => $ability instanceof TokenAbility ? $ability->value : $ability,
+                $abilities,
+            ),
+            'token_prefix' => substr($plain, 0, 8),
+            'token' => hash('sha256', $plain),
+            'expires_at' => $expiresAt,
+        ])->save();
+
+        return new NewToken($token, $plain);
+    }
+
+    /**
+     * The live token a client presented, or null when it matches nothing —
+     * including anything revoked, which the soft delete keeps out of scope.
+     */
+    public static function findByPlainText(string $plain): ?self
+    {
+        return static::query()->where('token', hash('sha256', $plain))->first();
+    }
+
+    public function can(TokenAbility $ability): bool
+    {
+        return in_array($ability->value, $this->abilities ?? [], true);
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at !== null && $this->expires_at->isPast();
+    }
+
+    /**
+     * Record that the token was just used, at most once a minute — Composer
+     * fires a burst of requests per install, and one timestamp is the story.
+     */
+    public function markUsed(): void
+    {
+        if ($this->last_used_at?->gt(now()->subMinute())) {
+            return;
+        }
+
+        // last_used_at is bookkeeping, not an edit; updated_at keeps meaning
+        // "when the token itself last changed".
+        static::withoutTimestamps(fn () => $this->forceFill(['last_used_at' => now()])->saveQuietly());
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Filament\Panel;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -41,6 +42,40 @@ class User extends Authenticatable implements FilamentUser
     public function tokens(): MorphMany
     {
         return $this->morphMany(Token::class, 'tokenable');
+    }
+
+    /**
+     * Individual packages this user has been granted, over and above the
+     * public repositories everyone sees.
+     *
+     * @return BelongsToMany<Package, $this>
+     */
+    public function packages(): BelongsToMany
+    {
+        return $this->belongsToMany(Package::class);
+    }
+
+    /**
+     * Private repositories this user has been granted wholesale.
+     *
+     * @return BelongsToMany<Repository, $this>
+     */
+    public function repositories(): BelongsToMany
+    {
+        return $this->belongsToMany(Repository::class);
+    }
+
+    /**
+     * Whether row-level package scoping applies to this user at all.
+     *
+     * Packistry's `unscoped`: a permission any role can carry (the super
+     * admin's carries everything), checked wherever package visibility is
+     * narrowed — not a role name, so custom roles can be given full sight
+     * without inheriting administration.
+     */
+    public function hasUnscopedAccess(): bool
+    {
+        return $this->can('Unscoped:Package');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Filament\Panel;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
@@ -30,6 +31,16 @@ class User extends Authenticatable implements FilamentUser
     public function canAccessPanel(Panel $panel): bool
     {
         return $this->roles()->exists();
+    }
+
+    /**
+     * The personal access tokens this user authenticates Composer with.
+     *
+     * @return MorphMany<Token, $this>
+     */
+    public function tokens(): MorphMany
+    {
+        return $this->morphMany(Token::class, 'tokenable');
     }
 
     /**

--- a/app/Policies/AuthenticationSourcePolicy.php
+++ b/app/Policies/AuthenticationSourcePolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\AuthenticationSource;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class AuthenticationSourcePolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:AuthenticationSource');
+    }
+
+    public function view(AuthUser $authUser, AuthenticationSource $authenticationSource): bool
+    {
+        return $authUser->can('View:AuthenticationSource');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:AuthenticationSource');
+    }
+
+    public function update(AuthUser $authUser, AuthenticationSource $authenticationSource): bool
+    {
+        return $authUser->can('Update:AuthenticationSource');
+    }
+
+    public function delete(AuthUser $authUser, AuthenticationSource $authenticationSource): bool
+    {
+        return $authUser->can('Delete:AuthenticationSource');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:AuthenticationSource');
+    }
+
+    public function restore(AuthUser $authUser, AuthenticationSource $authenticationSource): bool
+    {
+        return $authUser->can('Restore:AuthenticationSource');
+    }
+
+    public function forceDelete(AuthUser $authUser, AuthenticationSource $authenticationSource): bool
+    {
+        return $authUser->can('ForceDelete:AuthenticationSource');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:AuthenticationSource');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:AuthenticationSource');
+    }
+
+    public function replicate(AuthUser $authUser, AuthenticationSource $authenticationSource): bool
+    {
+        return $authUser->can('Replicate:AuthenticationSource');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:AuthenticationSource');
+    }
+}

--- a/app/Policies/DeployTokenPolicy.php
+++ b/app/Policies/DeployTokenPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\DeployToken;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class DeployTokenPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:DeployToken');
+    }
+
+    public function view(AuthUser $authUser, DeployToken $deployToken): bool
+    {
+        return $authUser->can('View:DeployToken');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:DeployToken');
+    }
+
+    public function update(AuthUser $authUser, DeployToken $deployToken): bool
+    {
+        return $authUser->can('Update:DeployToken');
+    }
+
+    public function delete(AuthUser $authUser, DeployToken $deployToken): bool
+    {
+        return $authUser->can('Delete:DeployToken');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:DeployToken');
+    }
+
+    public function restore(AuthUser $authUser, DeployToken $deployToken): bool
+    {
+        return $authUser->can('Restore:DeployToken');
+    }
+
+    public function forceDelete(AuthUser $authUser, DeployToken $deployToken): bool
+    {
+        return $authUser->can('ForceDelete:DeployToken');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:DeployToken');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:DeployToken');
+    }
+
+    public function replicate(AuthUser $authUser, DeployToken $deployToken): bool
+    {
+        return $authUser->can('Replicate:DeployToken');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:DeployToken');
+    }
+}

--- a/app/Policies/RepositoryPolicy.php
+++ b/app/Policies/RepositoryPolicy.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Repository;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+class RepositoryPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Repository');
+    }
+
+    public function view(AuthUser $authUser, Repository $repository): bool
+    {
+        return $authUser->can('View:Repository');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:Repository');
+    }
+
+    public function update(AuthUser $authUser, Repository $repository): bool
+    {
+        return $authUser->can('Update:Repository');
+    }
+
+    public function delete(AuthUser $authUser, Repository $repository): bool
+    {
+        return $authUser->can('Delete:Repository');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:Repository');
+    }
+
+    public function restore(AuthUser $authUser, Repository $repository): bool
+    {
+        return $authUser->can('Restore:Repository');
+    }
+
+    public function forceDelete(AuthUser $authUser, Repository $repository): bool
+    {
+        return $authUser->can('ForceDelete:Repository');
+    }
+
+    public function forceDeleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ForceDeleteAny:Repository');
+    }
+
+    public function restoreAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('RestoreAny:Repository');
+    }
+
+    public function replicate(AuthUser $authUser, Repository $repository): bool
+    {
+        return $authUser->can('Replicate:Repository');
+    }
+
+    public function reorder(AuthUser $authUser): bool
+    {
+        return $authUser->can('Reorder:Repository');
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Filament\Pages\ApiTokens;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
@@ -63,6 +64,13 @@ class AdminPanelProvider extends PanelProvider
                     ->label(fn (): string => auth()->user()->name)
                     ->url(fn (): string => EditProfilePage::getUrl())
                     ->icon('heroicon-m-user-circle'),
+                // Personal Composer credentials, self-service for every
+                // panel user — which is why it lives here and not in the
+                // sidebar with the admin-managed resources.
+                'api-tokens' => MenuItem::make()
+                    ->label('API tokens')
+                    ->url(fn (): string => ApiTokens::getUrl())
+                    ->icon('heroicon-m-key'),
             ])
             // The bell, where a package's own releases and failed syncs land.
             // Syncing happens on a queue in response to a push, so there is

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -13,6 +13,8 @@ use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\View\PanelsRenderHook;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
@@ -31,6 +33,13 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
+            // One "Continue with …" button per active authentication source,
+            // under the password form. Rendered from a hook rather than a
+            // login page subclass, so the stock page stays stock.
+            ->renderHook(
+                PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
+                fn (): ViewContract => view('filament.auth.sso-buttons'),
+            )
             // Also the target of the link `php artisan admin:create` prints,
             // which is how the first account gets a password.
             ->passwordReset()

--- a/app/Services/ArchiveStore.php
+++ b/app/Services/ArchiveStore.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PackageVersion;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Keeps every package version's zip on the dist disk, so metadata and dist
+ * downloads are served from storage the app controls instead of being
+ * proxied from GitHub per request.
+ */
+class ArchiveStore
+{
+    /**
+     * The disk archives live on. The dist endpoint and archives:clean read
+     * from here too, so all three always agree on where archives are.
+     */
+    public function disk(): Filesystem
+    {
+        return Storage::disk(config('filesystems.dists'));
+    }
+
+    /**
+     * Store a local zip as the version's archive, recording where it went and
+     * the sha1 Composer verifies downloads against.
+     *
+     * The path is keyed by a fresh uuid rather than the git reference: a
+     * re-stored version never overwrites a file a concurrent download may be
+     * streaming — it writes a new one and leaves the old to archives:clean.
+     */
+    public function store(PackageVersion $version, string $zip): void
+    {
+        $path = "packages/{$version->package->name}/".Str::uuid7().'.zip';
+
+        $stream = fopen($zip, 'r');
+
+        throw_if($stream === false, new RuntimeException("Unable to read the downloaded archive at {$zip}."));
+
+        try {
+            throw_if(
+                $this->disk()->writeStream($path, $stream) === false,
+                new RuntimeException("Unable to write {$path} to the dist disk."),
+            );
+        } catch (Throwable $exception) {
+            // A write that fails part way through can leave a truncated object
+            // behind, which a later download would serve as the real archive.
+            $this->disk()->delete($path);
+
+            throw $exception;
+        } finally {
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+
+        $version->forceFill([
+            'archive_path' => $path,
+            'shasum' => sha1_file($zip),
+        ])->save();
+    }
+}

--- a/app/Services/CreateVersionFromZip.php
+++ b/app/Services/CreateVersionFromZip.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Models\Repository;
+use App\Support\VersionNormalizer;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use ZipArchive;
@@ -32,7 +33,10 @@ class CreateVersionFromZip
         'prefer-stable', 'scripts', 'extra',
     ];
 
-    public function __construct(private readonly ArchiveStore $archives) {}
+    public function __construct(
+        private readonly ArchiveStore $archives,
+        private readonly VersionNormalizer $normalizer = new VersionNormalizer,
+    ) {}
 
     /**
      * Create (or replace) the version the zip describes, inside the given
@@ -79,7 +83,8 @@ class CreateVersionFromZip
             // sha, so the file's own hash stands in — which also makes a
             // replaced upload a new URL, never a silently different file.
             'reference' => sha1_file($zip),
-            'is_dev' => str_starts_with($version, 'dev-') || str_ends_with($version, '-dev'),
+            'order' => $this->normalizer->order($version),
+            'is_dev' => $this->normalizer->isDev($version),
             'released_at' => now(),
             'metadata' => [
                 ...array_intersect_key($composerJson, array_flip(self::METADATA_KEYS)),

--- a/app/Services/CreateVersionFromZip.php
+++ b/app/Services/CreateVersionFromZip.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use ZipArchive;
+
+/**
+ * Publishes a version from an uploaded zip — the "build artifact → publish"
+ * path, where CI pushes what it built instead of the registry pulling from a
+ * VCS provider.
+ *
+ * The zip is the source of truth: its composer.json provides the metadata and
+ * the file itself becomes the served archive, so what Composer reads and what
+ * it downloads can never disagree.
+ */
+class CreateVersionFromZip
+{
+    /**
+     * The composer.json keys worth serving. Everything Composer needs to
+     * resolve and install, nothing that leaks build internals — and a bound
+     * on `/p2` payload size whatever a project stuffs into its manifest.
+     */
+    private const METADATA_KEYS = [
+        'description', 'type', 'license', 'authors', 'keywords', 'homepage',
+        'support', 'bin', 'autoload', 'autoload-dev', 'require', 'require-dev',
+        'conflict', 'provide', 'replace', 'suggest', 'minimum-stability',
+        'prefer-stable', 'scripts', 'extra',
+    ];
+
+    public function __construct(private readonly ArchiveStore $archives) {}
+
+    /**
+     * Create (or replace) the version the zip describes, inside the given
+     * repository, returning the stored row.
+     *
+     * @param  string  $name  the "vendor/package" the upload was addressed to
+     * @param  string  $zip  path to the uploaded zip on local disk
+     */
+    public function create(Repository $repository, string $name, string $zip, ?string $version = null): PackageVersion
+    {
+        $composerJson = $this->composerJson($zip);
+
+        // The URL names the package; a manifest naming something else is a
+        // publish to the wrong address, not a detail to reconcile silently.
+        if (isset($composerJson['name']) && strcasecmp((string) $composerJson['name'], $name) !== 0) {
+            throw ValidationException::withMessages([
+                'file' => "The zip's composer.json names \"{$composerJson['name']}\", but the upload is addressed to \"{$name}\".",
+            ]);
+        }
+
+        $version ??= $composerJson['version'] ?? null;
+
+        if (blank($version)) {
+            throw ValidationException::withMessages([
+                'version' => 'No version was given and the composer.json declares none.',
+            ]);
+        }
+
+        $version = (string) $version;
+
+        $package = Package::query()->firstOrCreate(
+            ['repository_id' => $repository->id, 'name' => $name],
+            [
+                'description' => $composerJson['description'] ?? null,
+                'type' => $composerJson['type'] ?? null,
+                // There is no VCS repository behind an uploaded package, so
+                // there is nothing for a webhook to hear about.
+                'webhook_enabled' => false,
+            ],
+        );
+
+        $data = [
+            // Dist URLs are keyed by reference; an artifact has no commit
+            // sha, so the file's own hash stands in — which also makes a
+            // replaced upload a new URL, never a silently different file.
+            'reference' => sha1_file($zip),
+            'is_dev' => str_starts_with($version, 'dev-') || str_ends_with($version, '-dev'),
+            'released_at' => now(),
+            'metadata' => [
+                ...array_intersect_key($composerJson, array_flip(self::METADATA_KEYS)),
+                'name' => $name,
+                'version' => $version,
+            ],
+        ];
+
+        $model = DB::transaction(function () use ($package, $version, $data, $zip): PackageVersion {
+            $model = $package->versions()->updateOrCreate(['version' => $version], $data);
+
+            $this->archives->store($model->setRelation('package', $package), $zip);
+
+            return $model;
+        });
+
+        $package->refreshLatestVersion();
+
+        // The latest release describes the package, exactly as a sync would
+        // have it.
+        if ($package->latest_version === $version || $package->wasRecentlyCreated) {
+            $package->forceFill([
+                'description' => $composerJson['description'] ?? $package->description,
+                'type' => $composerJson['type'] ?? $package->type,
+            ])->save();
+        }
+
+        return $model;
+    }
+
+    /**
+     * The decoded composer.json inside the zip, found at the top level or one
+     * folder deep — the shape both `git archive` and build tools produce.
+     *
+     * @return array<string, mixed>
+     */
+    private function composerJson(string $path): array
+    {
+        $zip = new ZipArchive;
+
+        if ($zip->open($path) !== true) {
+            throw ValidationException::withMessages(['file' => 'The upload is not a readable zip archive.']);
+        }
+
+        try {
+            $manifest = null;
+
+            for ($index = 0; $index < $zip->numFiles; $index++) {
+                $entry = (string) $zip->getNameIndex($index);
+
+                if (! preg_match('#^(?:[^/]+/)?composer\.json$#', $entry)) {
+                    continue;
+                }
+
+                // A top-level manifest beats one inside a folder, so a zip
+                // that carries both publishes the package it obviously is.
+                if ($manifest === null || substr_count($entry, '/') < substr_count($manifest, '/')) {
+                    $manifest = $entry;
+                }
+            }
+
+            if ($manifest === null) {
+                throw ValidationException::withMessages([
+                    'file' => 'The zip contains no composer.json at its top level or one folder deep.',
+                ]);
+            }
+
+            $decoded = json_decode((string) $zip->getFromName($manifest), true);
+
+            if (! is_array($decoded)) {
+                throw ValidationException::withMessages(['file' => 'The composer.json inside the zip is not valid JSON.']);
+            }
+
+            return $decoded;
+        } finally {
+            $zip->close();
+        }
+    }
+}

--- a/app/Services/GitHub/GitHubClient.php
+++ b/app/Services/GitHub/GitHubClient.php
@@ -3,13 +3,14 @@
 namespace App\Services\GitHub;
 
 use App\Models\Package;
+use App\Sources\RepositoryClient;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
 
-class GitHubClient
+class GitHubClient implements RepositoryClient
 {
     private const PER_PAGE = 100;
 

--- a/app/Services/GitHub/GitHubClient.php
+++ b/app/Services/GitHub/GitHubClient.php
@@ -114,10 +114,18 @@ class GitHubClient
      */
     public function downloadZipball(string $ref, string $destination): void
     {
-        $this->request()
+        $response = $this->request()
             ->sink($destination)
             ->get("/repos/{$this->repositoryPath}/zipball/{$ref}")
             ->throw();
+
+        // A 200 that is not a zip — a proxy's HTML error page, say — must not
+        // be stored and served to Composer as an archive.
+        $contentType = strtolower($response->header('Content-Type'));
+
+        throw_unless(str_contains($contentType, 'zip'), new RuntimeException(
+            "GitHub returned '{$contentType}' instead of a zip archive for {$this->repositoryPath}@{$ref}."
+        ));
     }
 
     /**

--- a/app/Services/GitHub/GitHubSourceClient.php
+++ b/app/Services/GitHub/GitHubSourceClient.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services\GitHub;
+
+use App\Models\Source;
+use App\Sources\Project;
+use App\Sources\SourceClient;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+/**
+ * Browses the repositories a GitHub source can reach, for onboarding.
+ *
+ * An installed app lists what the installation was granted; a token source
+ * lists the account's repositories. GitHub offers no search parameter on
+ * either endpoint, so the term filters the fetched list instead.
+ */
+class GitHubSourceClient implements SourceClient
+{
+    private const PER_PAGE = 100;
+
+    /**
+     * Browsing is for picking a handful of projects, not mirroring an estate;
+     * five pages covers 500 repositories before search has to narrow it.
+     */
+    private const MAX_PAGES = 5;
+
+    public function __construct(private readonly Source $source) {}
+
+    /**
+     * @return list<Project>
+     */
+    public function projects(?string $search = null): array
+    {
+        $repositories = $this->source->usesInstallation()
+            ? $this->paginate('/installation/repositories', 'repositories')
+            : $this->accountRepositories();
+
+        $projects = array_map(
+            fn (array $repository): Project => new Project(
+                id: (string) $repository['id'],
+                fullName: (string) $repository['full_name'],
+                webUrl: (string) ($repository['html_url'] ?? 'https://github.com/'.$repository['full_name']),
+            ),
+            $repositories,
+        );
+
+        if (filled($search)) {
+            $projects = array_filter(
+                $projects,
+                fn (Project $project): bool => Str::contains($project->fullName, $search, ignoreCase: true),
+            );
+        }
+
+        usort($projects, fn (Project $a, Project $b): int => strcasecmp($a->fullName, $b->fullName));
+
+        return array_values($projects);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function accountRepositories(): array
+    {
+        // Org repositories first; a source pointed at a personal account is
+        // not an org, and GitHub answers 404 there.
+        $response = $this->request()->get("/orgs/{$this->source->account}/repos", ['per_page' => self::PER_PAGE]);
+
+        if ($response->status() === 404) {
+            $response = $this->request()->get("/users/{$this->source->account}/repos", ['per_page' => self::PER_PAGE]);
+        }
+
+        return $response->throw()->json();
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function paginate(string $endpoint, string $key): array
+    {
+        $items = [];
+
+        for ($page = 1; $page <= self::MAX_PAGES; $page++) {
+            $response = $this->request()
+                ->get($endpoint, ['per_page' => self::PER_PAGE, 'page' => $page])
+                ->throw();
+
+            $batch = $response->json($key) ?? [];
+            $items = [...$items, ...$batch];
+
+            if (count($batch) < self::PER_PAGE) {
+                break;
+            }
+        }
+
+        return $items;
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl($this->source->apiUrl())
+            ->withHeaders(['X-GitHub-Api-Version' => '2022-11-28'])
+            ->withToken($this->source->accessToken())
+            ->acceptJson();
+    }
+}

--- a/app/Services/GitHub/WebhookRegistrar.php
+++ b/app/Services/GitHub/WebhookRegistrar.php
@@ -73,7 +73,7 @@ class WebhookRegistrar
         $secret = Str::random(40);
 
         try {
-            $id = GitHubClient::for($package)->createWebhook($package->webhookUrl(), $secret);
+            $id = $package->client()->createWebhook($package->webhookUrl(), $secret);
         } catch (Throwable $exception) {
             $package->forceFill(['webhook_error' => $this->reason($exception)])->save();
 
@@ -92,7 +92,7 @@ class WebhookRegistrar
             // and the secret for this one is lost with the save. Take it back
             // down before reporting the failure.
             try {
-                GitHubClient::for($package)->deleteWebhook($id);
+                $package->client()->deleteWebhook($id);
             } catch (Throwable $cleanup) {
                 Log::warning('Could not remove a GitHub webhook that failed to persist locally.', [
                     'package' => $package->name,
@@ -129,7 +129,7 @@ class WebhookRegistrar
         }
 
         try {
-            GitHubClient::for($package)->deleteWebhook($package->webhook_id);
+            $package->client()->deleteWebhook($package->webhook_id);
         } catch (Throwable $exception) {
             Log::warning('Could not remove the GitHub webhook for a deleted package.', [
                 'package' => $package->name,

--- a/app/Services/GitLab/GitLabClient.php
+++ b/app/Services/GitLab/GitLabClient.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Services\GitLab;
+
+use App\Models\Package;
+use App\Sources\RepositoryClient;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * GitLab's spelling of the repository contract (API v4). Projects are
+ * addressed by their URL-encoded namespace path, which is what a package's
+ * repository URL parses to.
+ */
+class GitLabClient implements RepositoryClient
+{
+    private const PER_PAGE = 100;
+
+    /**
+     * Safety bound on pagination, not an expected limit. Reaching it means
+     * GitLab was still advertising a next page, so stopping would silently
+     * drop refs — we fail loudly instead.
+     */
+    private const MAX_PAGES = 100;
+
+    public function __construct(
+        private readonly string $projectPath,
+        private readonly ?string $token,
+        private readonly string $apiUrl = 'https://gitlab.com/api/v4',
+    ) {}
+
+    /**
+     * A client for one package, authenticated with whatever credential the
+     * package resolves to — its connected source first of all.
+     */
+    public static function for(Package $package): self
+    {
+        return new self(
+            $package->repositoryPath(),
+            $package->accessToken(),
+            $package->apiUrl(),
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function tags(): array
+    {
+        return $this->paginateRefs('tags');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function branches(): array
+    {
+        return $this->paginateRefs('branches');
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function composerJson(?string $ref = null): ?array
+    {
+        // GitLab's raw-file endpoint requires a ref; "the default branch" has
+        // to be asked for by name first.
+        $ref ??= $this->defaultBranch();
+
+        if ($ref === null) {
+            return null;
+        }
+
+        $response = $this->request()->get(
+            "/projects/{$this->projectId()}/repository/files/composer.json/raw",
+            ['ref' => $ref],
+        );
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        $decoded = json_decode($response->throw()->body(), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    public function commitDate(string $ref): ?CarbonImmutable
+    {
+        $response = $this->request()->get("/projects/{$this->projectId()}/repository/commits/{$ref}");
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        $date = $response->throw()->json('committed_date');
+
+        return is_string($date) && $date !== '' ? CarbonImmutable::parse($date) : null;
+    }
+
+    public function downloadZipball(string $ref, string $destination): void
+    {
+        $response = $this->request()
+            ->sink($destination)
+            ->get("/projects/{$this->projectId()}/repository/archive.zip", ['sha' => $ref])
+            ->throw();
+
+        // A 200 that is not a zip — a proxy's HTML error page, say — must not
+        // be stored and served to Composer as an archive.
+        $contentType = strtolower($response->header('Content-Type'));
+
+        throw_unless(str_contains($contentType, 'zip'), new RuntimeException(
+            "GitLab returned '{$contentType}' instead of a zip archive for {$this->projectPath}@{$ref}."
+        ));
+    }
+
+    /**
+     * Push and tag-push events are the ones that can change what a version
+     * resolves to; the secret comes back on deliveries as X-Gitlab-Token.
+     */
+    public function createWebhook(string $url, string $secret): int
+    {
+        $id = $this->request()
+            ->post("/projects/{$this->projectId()}/hooks", [
+                'url' => $url,
+                'token' => $secret,
+                'push_events' => true,
+                'tag_push_events' => true,
+                'enable_ssl_verification' => true,
+            ])
+            ->throw()
+            ->json('id');
+
+        throw_unless(is_int($id), new RuntimeException(
+            "GitLab accepted the webhook on {$this->projectPath} but returned no id for it."
+        ));
+
+        return $id;
+    }
+
+    public function deleteWebhook(int $id): void
+    {
+        $response = $this->request()->delete("/projects/{$this->projectId()}/hooks/{$id}");
+
+        if ($response->status() === 404) {
+            return;
+        }
+
+        $response->throw();
+    }
+
+    /**
+     * The project's default branch, or null when the project is out of reach.
+     */
+    private function defaultBranch(): ?string
+    {
+        $response = $this->request()->get("/projects/{$this->projectId()}");
+
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        $branch = $response->throw()->json('default_branch');
+
+        return is_string($branch) && $branch !== '' ? $branch : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function paginateRefs(string $endpoint): array
+    {
+        $refs = [];
+        $page = 1;
+
+        do {
+            if ($page > self::MAX_PAGES) {
+                throw new RuntimeException(
+                    "{$this->projectPath} has more than ".self::MAX_PAGES * self::PER_PAGE
+                    ." {$endpoint}; refusing to sync from a partial list."
+                );
+            }
+
+            $response = $this->request()
+                ->get("/projects/{$this->projectId()}/repository/{$endpoint}", [
+                    'per_page' => self::PER_PAGE,
+                    'page' => $page,
+                ])
+                ->throw();
+
+            foreach ($response->json() as $item) {
+                $refs[$item['name']] = $item['commit']['id'];
+            }
+
+            $page++;
+        } while ($this->hasNextPage($response));
+
+        return $refs;
+    }
+
+    private function hasNextPage(Response $response): bool
+    {
+        return filled($response->header('X-Next-Page'));
+    }
+
+    private function projectId(): string
+    {
+        return rawurlencode($this->projectPath);
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl($this->apiUrl)
+            ->when($this->token, fn (PendingRequest $request) => $request->withHeaders([
+                'PRIVATE-TOKEN' => $this->token,
+            ]))
+            ->acceptJson();
+    }
+}

--- a/app/Services/GitLab/GitLabSourceClient.php
+++ b/app/Services/GitLab/GitLabSourceClient.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\GitLab;
+
+use App\Models\Source;
+use App\Sources\Project;
+use App\Sources\SourceClient;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Browses the projects a GitLab credential can reach, for onboarding.
+ */
+class GitLabSourceClient implements SourceClient
+{
+    public function __construct(private readonly Source $source) {}
+
+    /**
+     * @return list<Project>
+     */
+    public function projects(?string $search = null): array
+    {
+        $projects = Http::baseUrl($this->source->apiUrl())
+            ->withHeaders(['PRIVATE-TOKEN' => $this->source->accessToken()])
+            ->acceptJson()
+            ->get('/projects', array_filter([
+                'membership' => 'true',
+                'archived' => 'false',
+                'order_by' => 'path',
+                'sort' => 'asc',
+                'per_page' => 100,
+                'search' => $search,
+            ]))
+            ->throw()
+            ->json();
+
+        return array_values(array_map(
+            fn (array $project): Project => new Project(
+                id: (string) $project['id'],
+                fullName: (string) $project['path_with_namespace'],
+                webUrl: (string) $project['web_url'],
+            ),
+            $projects,
+        ));
+    }
+}

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -5,24 +5,63 @@ namespace App\Services;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Services\GitHub\GitHubClient;
-use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Throwable;
 
+/**
+ * Rebuilds a package's stored versions from its repository.
+ *
+ * The work is cut into steps — discover, prune, import one ref, finalize — so
+ * that the queued batch (app/Jobs/PackageSyncBatch.php) can run one ImportVersion
+ * job per ref while sync() composes the same steps inline for the console
+ * command and the tests. Either way there is exactly one implementation of
+ * version building.
+ */
 class PackageSynchronizer
 {
     public function __construct(private readonly ArchiveStore $archives) {}
 
     /**
      * Pull tags and branches from GitHub and rebuild the package's stored
-     * versions. The failure reason is recorded on the package before the
-     * exception bubbles up to the caller.
+     * versions, inline. The failure reason is recorded on the package before
+     * the exception bubbles up to the caller.
+     *
+     * A ref that fails to import does not fail the sync: the others still
+     * land, and finalize() notes the failures on the package. Only a sync
+     * that produces no versions at all throws.
      */
     public function sync(Package $package): SyncOutcome
     {
         try {
-            return $this->refresh($package, GitHubClient::for($package));
+            $known = array_map(strval(...), $package->versions()->pluck('version')->all());
+
+            $refs = $this->discover($package);
+
+            $this->resolveComposerName($package);
+            $this->prune($package, array_map(strval(...), array_keys($refs)));
+
+            $changed = $this->changed($package, $refs);
+
+            $failed = 0;
+            $lastError = null;
+
+            foreach ($changed as $version => $ref) {
+                try {
+                    $this->import($package, (string) $version, $ref);
+                } catch (Throwable $exception) {
+                    $failed++;
+                    $lastError = $exception;
+                }
+            }
+
+            // When nothing survived, the sync failed for whatever reason the
+            // last ref did — "no versions" would bury the actual error.
+            if ($lastError !== null && $package->versions()->count() === 0) {
+                throw $lastError;
+            }
+
+            return $this->finalize($package, $known, count($changed), $failed);
         } catch (Throwable $exception) {
             $package->forceFill(['sync_error' => $exception->getMessage()])->save();
 
@@ -30,8 +69,16 @@ class PackageSynchronizer
         }
     }
 
-    private function refresh(Package $package, GitHubClient $github): SyncOutcome
+    /**
+     * Every version the repository currently publishes, read from its tags and
+     * branches, as [version => ['reference' => sha, 'is_dev' => bool]].
+     *
+     * @return array<string, array{reference: string, is_dev: bool}>
+     */
+    public function discover(Package $package): array
     {
+        $github = GitHubClient::for($package);
+
         $versions = [];
 
         foreach ($github->tags() as $tag => $sha) {
@@ -46,75 +93,153 @@ class PackageSynchronizer
             $versions[$this->branchVersion($branch)] = ['reference' => $sha, 'is_dev' => true];
         }
 
-        $known = $package->versions()->get()->keyBy('version');
-        $synced = [];
-        $downloads = [];
+        return $versions;
+    }
 
-        try {
-            foreach ($versions as $version => $ref) {
-                $version = (string) $version;
-
-                if (($unchanged = $this->unchanged($known->get($version), $ref)) !== null) {
-                    $synced[$version] = $unchanged;
-
-                    continue;
-                }
-
-                $composerJson = $github->composerJson($ref['reference']);
-
-                // A ref without a composer.json (or without a package name) is not
-                // installable, so it is skipped rather than treated as an error.
-                if (! isset($composerJson['name'])) {
-                    continue;
-                }
-
-                $synced[$version] = [
-                    ...$ref,
-                    'released_at' => $github->commitDate($ref['reference']),
-                    'metadata' => [...$composerJson, 'version' => $version],
-                ];
-
-                $downloads[$version] = $this->downloadArchive($github, $ref['reference']);
-            }
-
-            if ($synced === []) {
-                throw new \RuntimeException('No installable versions found: no tag or branch contains a composer.json with a "name".');
-            }
-
-            // The most recently built ref wins; every synced ref of one repository
-            // should agree on the package name anyway.
-            $composerName = end($synced)['metadata']['name'];
-            $latest = $this->latestStableVersion(array_keys(array_filter($synced, fn (array $v): bool => ! $v['is_dev'])));
-            $newest = $synced[$latest ?? array_key_last($synced)]['metadata'];
-
-            DB::transaction(function () use ($package, $synced, $downloads, $composerName, $latest, $newest): void {
-                // The package is renamed before archives are stored, so their
-                // paths carry the composer name rather than the placeholder a
-                // first sync starts from.
-                $package->forceFill([
-                    'name' => $composerName,
-                    'description' => $newest['description'] ?? $package->description,
-                    'type' => $newest['type'] ?? $package->type,
-                    'latest_version' => $latest,
-                    'last_synced_at' => now(),
-                    'sync_error' => null,
-                ])->save();
-
-                $package->versions()->whereNotIn('version', array_keys($synced))->delete();
-
-                foreach ($synced as $version => $data) {
-                    $model = $package->versions()->updateOrCreate(['version' => (string) $version], $data);
-
-                    if (isset($downloads[$version])) {
-                        $this->archives->store($model->setRelation('package', $package), $downloads[$version]);
-                    }
-                }
-            });
-        } finally {
-            File::delete(array_values($downloads));
+    /**
+     * Give a never-synced package its composer name before any archive is
+     * stored, so archive paths carry the real name rather than the placeholder
+     * the create form started from. Read from the default branch because no
+     * ref has been imported yet; finalize() keeps the name current afterwards.
+     */
+    public function resolveComposerName(Package $package): void
+    {
+        if ($package->last_synced_at !== null) {
+            return;
         }
 
-        return $this->outcome($known->keys()->all(), $synced);
+        $name = GitHubClient::for($package)->composerJson()['name'] ?? null;
+
+        if (is_string($name) && $name !== '' && $name !== $package->name) {
+            $package->forceFill(['name' => $name])->save();
+        }
+    }
+
+    /**
+     * Delete stored versions the repository no longer publishes.
+     *
+     * Runs before the imports rather than after: the discovered ref list is
+     * the authority on what exists upstream, and a version already gone should
+     * not be served while the imports are still working through the batch.
+     *
+     * @param  list<string>  $versions  every version currently upstream
+     */
+    public function prune(Package $package, array $versions): void
+    {
+        $package->versions()->whereNotIn('version', $versions)->delete();
+    }
+
+    /**
+     * The subset of discovered refs that actually need an import: new ones,
+     * moved ones, and rows missing a piece a previous sync should have stored.
+     *
+     * @param  array<string, array{reference: string, is_dev: bool}>  $refs
+     * @return array<string, array{reference: string, is_dev: bool}>
+     */
+    public function changed(Package $package, array $refs): array
+    {
+        $known = $package->versions()->get()->keyBy('version');
+
+        return array_filter(
+            $refs,
+            fn (array $ref, string|int $version): bool => ! $this->unchanged($known->get((string) $version), $ref),
+            ARRAY_FILTER_USE_BOTH,
+        );
+    }
+
+    /**
+     * Import one ref: read its composer.json and commit date, store the row,
+     * and download and store its archive. Returns whether a version is now
+     * stored — a ref without an installable composer.json is not an error,
+     * but any row it used to have is removed rather than served stale.
+     *
+     * Safe to run twice: an already-imported, unmoved ref returns without
+     * touching GitHub, which is what makes duplicate jobs from overlapping
+     * syncs harmless.
+     *
+     * @param  array{reference: string, is_dev: bool}  $ref
+     */
+    public function import(Package $package, string $version, array $ref): bool
+    {
+        $existing = $package->versions()->where('version', $version)->first();
+
+        if ($this->unchanged($existing, $ref)) {
+            return true;
+        }
+
+        $github = GitHubClient::for($package);
+
+        $composerJson = $github->composerJson($ref['reference']);
+
+        if (! isset($composerJson['name'])) {
+            $existing?->delete();
+
+            return false;
+        }
+
+        $data = [
+            ...$ref,
+            'released_at' => $github->commitDate($ref['reference']),
+            'metadata' => [...$composerJson, 'version' => $version],
+        ];
+
+        $zip = $this->downloadArchive($github, $ref['reference']);
+
+        try {
+            // Row and archive columns land together, so a version is never
+            // visible without the archive Composer will ask for.
+            DB::transaction(function () use ($package, $version, $data, $zip): void {
+                $model = $package->versions()->updateOrCreate(['version' => $version], $data);
+
+                $this->archives->store($model->setRelation('package', $package), $zip);
+            });
+        } finally {
+            File::delete($zip);
+        }
+
+        return true;
+    }
+
+    /**
+     * Close out a sync: refresh the package's own columns from what is now
+     * stored and report what changed against what was known before.
+     *
+     * @param  list<string>  $known  the versions the package had before the sync
+     * @param  int  $attempted  how many refs the sync tried to import
+     * @param  int  $failed  how many of those imports failed
+     */
+    public function finalize(Package $package, array $known, int $attempted = 0, int $failed = 0): SyncOutcome
+    {
+        $versions = $package->versions()->orderBy('id')->get();
+
+        if ($versions->isEmpty()) {
+            throw new \RuntimeException($failed > 0
+                ? "All {$failed} version imports failed."
+                : 'No installable versions found: no tag or branch contains a composer.json with a "name".');
+        }
+
+        $latest = $this->latestStableVersion(
+            $versions->reject(fn (PackageVersion $v): bool => $v->is_dev)->pluck('version')->map(strval(...))->all(),
+        );
+
+        // The latest release describes the package; a repository without one
+        // is described by whatever version arrived last.
+        $newest = ($latest !== null ? $versions->firstWhere('version', $latest) : $versions->last())->metadata;
+
+        $package->forceFill([
+            'name' => $newest['name'] ?? $package->name,
+            'description' => $newest['description'] ?? $package->description,
+            'type' => $newest['type'] ?? $package->type,
+            'latest_version' => $latest,
+            'last_synced_at' => now(),
+            // A partial sync is not a silent one: the versions that failed are
+            // simply still missing, and this is the only place that says so.
+            'sync_error' => $failed > 0
+                ? "{$failed} of {$attempted} version imports failed; the next sync will retry them."
+                : null,
+        ])->save();
+
+        return $this->outcome($known, $versions->pluck('is_dev', 'version')->all());
     }
 
     /**
@@ -126,68 +251,59 @@ class PackageSynchronizer
      * Tuesday.
      *
      * @param  list<string>  $known  the versions the package had before
-     * @param  array<string, array{is_dev: bool, ...}>  $synced
+     * @param  array<string, bool>  $current  version => is_dev, as stored now
      */
-    private function outcome(array $known, array $synced): SyncOutcome
+    private function outcome(array $known, array $current): SyncOutcome
     {
         // A version like "1" is an integer once it is an array key, and every
         // comparison below reads better with the strings they started as.
-        $current = array_map(strval(...), array_keys($synced));
+        $isDev = array_combine(array_map(strval(...), array_keys($current)), array_values($current));
         $known = array_map(strval(...), $known);
 
-        $added = array_diff($current, $known);
+        $added = array_diff(array_keys($isDev), $known);
 
-        $releases = array_values(array_filter($added, fn (string $v): bool => ! $synced[$v]['is_dev']));
+        $releases = array_values(array_filter($added, fn (string $v): bool => ! $isDev[$v]));
 
         usort($releases, fn (string $a, string $b): int => version_compare(ltrim($a, 'vV'), ltrim($b, 'vV')));
 
         return new SyncOutcome(
             releases: $releases,
-            devVersions: array_values(array_filter($added, fn (string $v): bool => $synced[$v]['is_dev'])),
-            removed: array_values(array_diff($known, $current)),
+            devVersions: array_values(array_filter($added, fn (string $v): bool => $isDev[$v])),
+            removed: array_values(array_diff($known, array_keys($isDev))),
             initialImport: $known === [],
-            total: count($synced),
+            total: count($isDev),
         );
     }
 
     /**
-     * The stored row for a ref that has not moved since the last sync, in the
-     * shape the sync writes back — or null when the ref has to be re-read.
+     * Whether the stored row for a ref is complete and the ref has not moved,
+     * meaning the import can be skipped entirely.
      *
      * A commit sha names an immutable tree, so a version still pointing at the
      * same sha cannot have a different composer.json or commit date than the
-     * one already stored. Reusing it saves two API calls and an archive
+     * one already stored. Skipping it saves two API calls and an archive
      * download per version, which for a repository of any age is nearly the
      * whole sync. A row missing any piece — date, metadata, or archive — is
      * treated as changed so it is backfilled.
      *
      * @param  array{reference: string, is_dev: bool}  $ref
-     * @return array{reference: string, is_dev: bool, released_at: CarbonImmutable, metadata: array<string, mixed>}|null
      */
-    private function unchanged(?PackageVersion $known, array $ref): ?array
+    private function unchanged(?PackageVersion $known, array $ref): bool
     {
-        if (! $known instanceof PackageVersion
-            || $known->reference !== $ref['reference']
-            || $known->is_dev !== $ref['is_dev']
-            || $known->released_at === null
-            || $known->archive_path === null
-            || $known->shasum === null
-            || ! isset($known->metadata['name'])) {
-            return null;
-        }
-
-        return [
-            ...$ref,
-            'released_at' => $known->released_at,
-            'metadata' => $known->metadata,
-        ];
+        return $known instanceof PackageVersion
+            && $known->reference === $ref['reference']
+            && $known->is_dev === $ref['is_dev']
+            && $known->released_at !== null
+            && $known->archive_path !== null
+            && $known->shasum !== null
+            && isset($known->metadata['name']);
     }
 
     /**
      * Download the zipball for a ref to a temporary file, returning its path.
      *
-     * The caller owns the file's lifetime; refresh() deletes every download
-     * once the sync has stored or abandoned them.
+     * The caller owns the file's lifetime; import() deletes the download once
+     * the archive is stored or abandoned.
      */
     private function downloadArchive(GitHubClient $github, string $reference): string
     {

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -286,6 +286,11 @@ class PackageSynchronizer
      * whole sync. A row missing any piece — date, metadata, or archive — is
      * treated as changed so it is backfilled.
      *
+     * The archive check asks the dist disk, not just the columns: a row can
+     * outlive its file (storage loss, a deploy that wiped archives while the
+     * database survived), and trusting the columns alone would skip the
+     * re-download and leave dist serving 404s that no sync ever repairs.
+     *
      * @param  array{reference: string, is_dev: bool}  $ref
      */
     private function unchanged(?PackageVersion $known, array $ref): bool
@@ -296,7 +301,8 @@ class PackageSynchronizer
             && $known->released_at !== null
             && $known->archive_path !== null
             && $known->shasum !== null
-            && isset($known->metadata['name']);
+            && isset($known->metadata['name'])
+            && $this->archives->disk()->exists($known->archive_path);
     }
 
     /**

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use App\Models\Package;
 use App\Models\PackageVersion;
-use App\Services\GitHub\GitHubClient;
+use App\Sources\RepositoryClient;
 use App\Support\VersionNormalizer;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
@@ -81,11 +81,11 @@ class PackageSynchronizer
      */
     public function discover(Package $package): array
     {
-        $github = GitHubClient::for($package);
+        $client = $package->client();
 
         $versions = [];
 
-        foreach ($github->tags() as $tag => $sha) {
+        foreach ($client->tags() as $tag => $sha) {
             if (! $this->isVersionLikeTag($tag)) {
                 continue;
             }
@@ -95,7 +95,7 @@ class PackageSynchronizer
             $versions[$this->normalizer->version($tag)] = ['reference' => $sha, 'is_dev' => false];
         }
 
-        foreach ($github->branches() as $branch => $sha) {
+        foreach ($client->branches() as $branch => $sha) {
             $versions[$this->normalizer->devVersion($branch)] = ['reference' => $sha, 'is_dev' => true];
         }
 
@@ -114,7 +114,7 @@ class PackageSynchronizer
             return;
         }
 
-        $name = GitHubClient::for($package)->composerJson()['name'] ?? null;
+        $name = $package->client()->composerJson()['name'] ?? null;
 
         if (is_string($name) && $name !== '' && $name !== $package->name) {
             $package->forceFill(['name' => $name])->save();
@@ -173,9 +173,9 @@ class PackageSynchronizer
             return true;
         }
 
-        $github = GitHubClient::for($package);
+        $client = $package->client();
 
-        $composerJson = $github->composerJson($ref['reference']);
+        $composerJson = $client->composerJson($ref['reference']);
 
         if (! isset($composerJson['name'])) {
             $existing?->delete();
@@ -186,11 +186,11 @@ class PackageSynchronizer
         $data = [
             ...$ref,
             'order' => $this->normalizer->order($version),
-            'released_at' => $github->commitDate($ref['reference']),
+            'released_at' => $client->commitDate($ref['reference']),
             'metadata' => [...$composerJson, 'version' => $version],
         ];
 
-        $zip = $this->downloadArchive($github, $ref['reference']);
+        $zip = $this->downloadArchive($client, $ref['reference']);
 
         try {
             // Row and archive columns land together, so a version is never
@@ -318,14 +318,14 @@ class PackageSynchronizer
      * The caller owns the file's lifetime; import() deletes the download once
      * the archive is stored or abandoned.
      */
-    private function downloadArchive(GitHubClient $github, string $reference): string
+    private function downloadArchive(RepositoryClient $client, string $reference): string
     {
         $temporary = tempnam(sys_get_temp_dir(), 'package-archive-');
 
         throw_if($temporary === false, new \RuntimeException('Unable to create a temporary file for the archive.'));
 
         try {
-            $github->downloadZipball($reference, $temporary);
+            $client->downloadZipball($reference, $temporary);
         } catch (Throwable $exception) {
             File::delete($temporary);
 

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -35,7 +35,7 @@ class PackageSynchronizer
      * land, and finalize() notes the failures on the package. Only a sync
      * that produces no versions at all throws.
      */
-    public function sync(Package $package): SyncOutcome
+    public function sync(Package $package, bool $force = false): SyncOutcome
     {
         try {
             $known = array_map(strval(...), $package->versions()->pluck('version')->all());
@@ -45,14 +45,14 @@ class PackageSynchronizer
             $this->resolveComposerName($package);
             $this->prune($package, array_map(strval(...), array_keys($refs)));
 
-            $changed = $this->changed($package, $refs);
+            $changed = $this->changed($package, $refs, $force);
 
             $failed = 0;
             $lastError = null;
 
             foreach ($changed as $version => $ref) {
                 try {
-                    $this->import($package, (string) $version, $ref);
+                    $this->import($package, (string) $version, $ref, $force);
                 } catch (Throwable $exception) {
                     $failed++;
                     $lastError = $exception;
@@ -142,8 +142,14 @@ class PackageSynchronizer
      * @param  array<string, array{reference: string, is_dev: bool}>  $refs
      * @return array<string, array{reference: string, is_dev: bool}>
      */
-    public function changed(Package $package, array $refs): array
+    public function changed(Package $package, array $refs, bool $force = false): array
     {
+        // A rebuild trusts nothing stored: every ref imports fresh, which is
+        // the recovery hammer for corrupted archives and metadata drift.
+        if ($force) {
+            return $refs;
+        }
+
         $known = $package->versions()->get()->keyBy('version');
 
         return array_filter(
@@ -165,11 +171,11 @@ class PackageSynchronizer
      *
      * @param  array{reference: string, is_dev: bool}  $ref
      */
-    public function import(Package $package, string $version, array $ref): bool
+    public function import(Package $package, string $version, array $ref, bool $force = false): bool
     {
         $existing = $package->versions()->where('version', $version)->first();
 
-        if ($this->unchanged($existing, $ref)) {
+        if (! $force && $this->unchanged($existing, $ref)) {
             return true;
         }
 

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -7,10 +7,13 @@ use App\Models\PackageVersion;
 use App\Services\GitHub\GitHubClient;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Throwable;
 
 class PackageSynchronizer
 {
+    public function __construct(private readonly ArchiveStore $archives) {}
+
     /**
      * Pull tags and branches from GitHub and rebuild the package's stored
      * versions. The failure reason is recorded on the package before the
@@ -45,57 +48,71 @@ class PackageSynchronizer
 
         $known = $package->versions()->get()->keyBy('version');
         $synced = [];
+        $downloads = [];
 
-        foreach ($versions as $version => $ref) {
-            $version = (string) $version;
+        try {
+            foreach ($versions as $version => $ref) {
+                $version = (string) $version;
 
-            if (($unchanged = $this->unchanged($known->get($version), $ref)) !== null) {
-                $synced[$version] = $unchanged;
+                if (($unchanged = $this->unchanged($known->get($version), $ref)) !== null) {
+                    $synced[$version] = $unchanged;
 
-                continue;
+                    continue;
+                }
+
+                $composerJson = $github->composerJson($ref['reference']);
+
+                // A ref without a composer.json (or without a package name) is not
+                // installable, so it is skipped rather than treated as an error.
+                if (! isset($composerJson['name'])) {
+                    continue;
+                }
+
+                $synced[$version] = [
+                    ...$ref,
+                    'released_at' => $github->commitDate($ref['reference']),
+                    'metadata' => [...$composerJson, 'version' => $version],
+                ];
+
+                $downloads[$version] = $this->downloadArchive($github, $ref['reference']);
             }
 
-            $composerJson = $github->composerJson($ref['reference']);
-
-            // A ref without a composer.json (or without a package name) is not
-            // installable, so it is skipped rather than treated as an error.
-            if (! isset($composerJson['name'])) {
-                continue;
+            if ($synced === []) {
+                throw new \RuntimeException('No installable versions found: no tag or branch contains a composer.json with a "name".');
             }
 
-            $synced[$version] = [
-                ...$ref,
-                'released_at' => $github->commitDate($ref['reference']),
-                'metadata' => [...$composerJson, 'version' => $version],
-            ];
+            // The most recently built ref wins; every synced ref of one repository
+            // should agree on the package name anyway.
+            $composerName = end($synced)['metadata']['name'];
+            $latest = $this->latestStableVersion(array_keys(array_filter($synced, fn (array $v): bool => ! $v['is_dev'])));
+            $newest = $synced[$latest ?? array_key_last($synced)]['metadata'];
+
+            DB::transaction(function () use ($package, $synced, $downloads, $composerName, $latest, $newest): void {
+                // The package is renamed before archives are stored, so their
+                // paths carry the composer name rather than the placeholder a
+                // first sync starts from.
+                $package->forceFill([
+                    'name' => $composerName,
+                    'description' => $newest['description'] ?? $package->description,
+                    'type' => $newest['type'] ?? $package->type,
+                    'latest_version' => $latest,
+                    'last_synced_at' => now(),
+                    'sync_error' => null,
+                ])->save();
+
+                $package->versions()->whereNotIn('version', array_keys($synced))->delete();
+
+                foreach ($synced as $version => $data) {
+                    $model = $package->versions()->updateOrCreate(['version' => (string) $version], $data);
+
+                    if (isset($downloads[$version])) {
+                        $this->archives->store($model->setRelation('package', $package), $downloads[$version]);
+                    }
+                }
+            });
+        } finally {
+            File::delete(array_values($downloads));
         }
-
-        if ($synced === []) {
-            throw new \RuntimeException('No installable versions found: no tag or branch contains a composer.json with a "name".');
-        }
-
-        // The most recently built ref wins; every synced ref of one repository
-        // should agree on the package name anyway.
-        $composerName = end($synced)['metadata']['name'];
-        $latest = $this->latestStableVersion(array_keys(array_filter($synced, fn (array $v): bool => ! $v['is_dev'])));
-        $newest = $synced[$latest ?? array_key_last($synced)]['metadata'];
-
-        DB::transaction(function () use ($package, $synced, $composerName, $latest, $newest): void {
-            $package->versions()->whereNotIn('version', array_keys($synced))->delete();
-
-            foreach ($synced as $version => $data) {
-                $package->versions()->updateOrCreate(['version' => (string) $version], $data);
-            }
-
-            $package->forceFill([
-                'name' => $composerName,
-                'description' => $newest['description'] ?? $package->description,
-                'type' => $newest['type'] ?? $package->type,
-                'latest_version' => $latest,
-                'last_synced_at' => now(),
-                'sync_error' => null,
-            ])->save();
-        });
 
         return $this->outcome($known->keys()->all(), $synced);
     }
@@ -139,9 +156,10 @@ class PackageSynchronizer
      *
      * A commit sha names an immutable tree, so a version still pointing at the
      * same sha cannot have a different composer.json or commit date than the
-     * one already stored. Reusing it saves two API calls per version, which
-     * for a repository of any age is nearly the whole sync. A row missing
-     * either piece is treated as changed so it is backfilled.
+     * one already stored. Reusing it saves two API calls and an archive
+     * download per version, which for a repository of any age is nearly the
+     * whole sync. A row missing any piece — date, metadata, or archive — is
+     * treated as changed so it is backfilled.
      *
      * @param  array{reference: string, is_dev: bool}  $ref
      * @return array{reference: string, is_dev: bool, released_at: CarbonImmutable, metadata: array<string, mixed>}|null
@@ -152,6 +170,8 @@ class PackageSynchronizer
             || $known->reference !== $ref['reference']
             || $known->is_dev !== $ref['is_dev']
             || $known->released_at === null
+            || $known->archive_path === null
+            || $known->shasum === null
             || ! isset($known->metadata['name'])) {
             return null;
         }
@@ -161,6 +181,29 @@ class PackageSynchronizer
             'released_at' => $known->released_at,
             'metadata' => $known->metadata,
         ];
+    }
+
+    /**
+     * Download the zipball for a ref to a temporary file, returning its path.
+     *
+     * The caller owns the file's lifetime; refresh() deletes every download
+     * once the sync has stored or abandoned them.
+     */
+    private function downloadArchive(GitHubClient $github, string $reference): string
+    {
+        $temporary = tempnam(sys_get_temp_dir(), 'package-archive-');
+
+        throw_if($temporary === false, new \RuntimeException('Unable to create a temporary file for the archive.'));
+
+        try {
+            $github->downloadZipball($reference, $temporary);
+        } catch (Throwable $exception) {
+            File::delete($temporary);
+
+            throw $exception;
+        }
+
+        return $temporary;
     }
 
     /**

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -116,9 +116,26 @@ class PackageSynchronizer
 
         $name = $package->client()->composerJson()['name'] ?? null;
 
-        if (is_string($name) && $name !== '' && $name !== $package->name) {
-            $package->forceFill(['name' => $name])->save();
+        if (! is_string($name) || $name === '' || $name === $package->name) {
+            return;
         }
+
+        // The (repository_id, name) unique index would reject the rename with
+        // a bare query error; asked first, the conflict reads as what it is —
+        // one Composer repository cannot serve two packages under one name.
+        $taken = Package::query()
+            ->where('repository_id', $package->repository_id)
+            ->whereKeyNot($package->getKey())
+            ->where('name', $name)
+            ->exists();
+
+        throw_if($taken, new \RuntimeException(
+            "The repository's composer.json is named \"{$name}\", which another package"
+            .' in this Composer repository already publishes. Move one of them to a'
+            .' different repository, or fix the composer.json name.',
+        ));
+
+        $package->forceFill(['name' => $name])->save();
     }
 
     /**

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use App\Services\GitHub\GitHubClient;
+use App\Support\VersionNormalizer;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Throwable;
@@ -20,7 +21,10 @@ use Throwable;
  */
 class PackageSynchronizer
 {
-    public function __construct(private readonly ArchiveStore $archives) {}
+    public function __construct(
+        private readonly ArchiveStore $archives,
+        private readonly VersionNormalizer $normalizer = new VersionNormalizer,
+    ) {}
 
     /**
      * Pull tags and branches from GitHub and rebuild the package's stored
@@ -86,11 +90,13 @@ class PackageSynchronizer
                 continue;
             }
 
-            $versions[$tag] = ['reference' => $sha, 'is_dev' => false];
+            // Stored under its normalized spelling (v1.2.3 → 1.2.3), so the
+            // registry serves one vocabulary however maintainers tag.
+            $versions[$this->normalizer->version($tag)] = ['reference' => $sha, 'is_dev' => false];
         }
 
         foreach ($github->branches() as $branch => $sha) {
-            $versions[$this->branchVersion($branch)] = ['reference' => $sha, 'is_dev' => true];
+            $versions[$this->normalizer->devVersion($branch)] = ['reference' => $sha, 'is_dev' => true];
         }
 
         return $versions;
@@ -179,6 +185,7 @@ class PackageSynchronizer
 
         $data = [
             ...$ref,
+            'order' => $this->normalizer->order($version),
             'released_at' => $github->commitDate($ref['reference']),
             'metadata' => [...$composerJson, 'version' => $version],
         ];
@@ -334,23 +341,6 @@ class PackageSynchronizer
     private function isVersionLikeTag(string $tag): bool
     {
         return (bool) preg_match('/^v?\d+(\.\d+){0,3}([._-]?(alpha|beta|rc|dev|patch|pl|p)\.?\d*)?$/i', $tag);
-    }
-
-    /**
-     * The Composer dev version for a branch, following Packagist's naming:
-     * numeric branches become "2.0.x-dev" / "1.x-dev", others "dev-main".
-     */
-    private function branchVersion(string $branch): string
-    {
-        if (preg_match('/^v?\d+(\.\d+)*$/', $branch)) {
-            return "{$branch}.x-dev";
-        }
-
-        if (preg_match('/^v?\d+(\.(\d+|x))*$/i', $branch)) {
-            return "{$branch}-dev";
-        }
-
-        return "dev-{$branch}";
     }
 
     /**

--- a/app/Services/RebuildPackage.php
+++ b/app/Services/RebuildPackage.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+
+/**
+ * The recovery hammer: re-import every version from the source, trusting
+ * nothing stored — metadata re-read, archives re-downloaded, versions gone
+ * upstream pruned.
+ *
+ * It is a forced sync, so the package keeps serving its current versions
+ * while the rebuild replaces them row by row, and running it twice settles
+ * on the same result. For webhook drift, normalizer changes, corrupted
+ * archives — anything where "what is stored" can no longer be trusted.
+ */
+class RebuildPackage
+{
+    public function __construct(private readonly PackageSynchronizer $synchronizer) {}
+
+    /**
+     * Rebuild inline, for the console and tests.
+     */
+    public function rebuild(Package $package): SyncOutcome
+    {
+        return $this->synchronizer->sync($package, force: true);
+    }
+
+    /**
+     * Queue the rebuild through the ordinary sync pipeline — batch fan-out,
+     * uniqueness, overlap rules and all. Reports whether one was actually
+     * queued or a sync was already pending.
+     */
+    public function queue(Package $package): bool
+    {
+        return SyncPackageJob::dispatchUnlessPending($package, force: true);
+    }
+}

--- a/app/Sources/Project.php
+++ b/app/Sources/Project.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Sources;
+
+/**
+ * One project as a provider lists it — the identity needed to onboard it as
+ * a package, whatever the provider calls these things internally.
+ */
+final readonly class Project
+{
+    public function __construct(
+        public string $id,
+        public string $fullName,
+        public string $webUrl,
+    ) {}
+}

--- a/app/Sources/RepositoryClient.php
+++ b/app/Sources/RepositoryClient.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Sources;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * Everything syncing needs from a VCS provider, scoped to one repository.
+ *
+ * PackageSynchronizer, the webhook registrar and the create wizard depend on
+ * this contract alone; Package::client() resolves the implementation from
+ * the package's provider, which is what makes the rest of the app
+ * provider-agnostic.
+ */
+interface RepositoryClient
+{
+    /**
+     * All tags on the repository, as [name => commit sha].
+     *
+     * @return array<string, string>
+     */
+    public function tags(): array;
+
+    /**
+     * All branches on the repository, as [name => commit sha].
+     *
+     * @return array<string, string>
+     */
+    public function branches(): array;
+
+    /**
+     * The decoded composer.json at the given ref — or at the default branch
+     * when no ref is given. Null when the file is missing, out of reach, or
+     * not valid JSON.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function composerJson(?string $ref = null): ?array;
+
+    /**
+     * The commit date of the given ref, or null when the provider does not
+     * report one.
+     */
+    public function commitDate(string $ref): ?CarbonImmutable;
+
+    /**
+     * Download the zipball for the given ref to a local file.
+     */
+    public function downloadZipball(string $ref, string $destination): void;
+
+    /**
+     * Create a webhook on the repository, returning the provider's id for it.
+     */
+    public function createWebhook(string $url, string $secret): int;
+
+    /**
+     * Remove a webhook from the repository. A hook already gone is not an
+     * error — the desired state is the same either way.
+     */
+    public function deleteWebhook(int $id): void;
+}

--- a/app/Sources/SourceClient.php
+++ b/app/Sources/SourceClient.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Sources;
+
+/**
+ * What a connected source can answer about itself, independent of any one
+ * package — the browsing side of a provider, powering project search and
+ * one-click onboarding.
+ */
+interface SourceClient
+{
+    /**
+     * The projects the source's credential can reach, optionally narrowed by
+     * a search term.
+     *
+     * @return list<Project>
+     */
+    public function projects(?string $search = null): array;
+}

--- a/app/Sources/StubClient.php
+++ b/app/Sources/StubClient.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Sources;
+
+use App\Enums\SourceProvider;
+use Carbon\CarbonImmutable;
+
+/**
+ * The client for providers the enum names but nothing implements yet.
+ *
+ * Every method refuses with the same message, so wiring Gitea or Bitbucket
+ * in later is mechanical: write the real client, point the factories at it,
+ * and the contract-shaped hole closes.
+ */
+class StubClient implements RepositoryClient, SourceClient
+{
+    public function __construct(private readonly SourceProvider $provider) {}
+
+    public function projects(?string $search = null): array
+    {
+        throw $this->unsupported();
+    }
+
+    public function tags(): array
+    {
+        throw $this->unsupported();
+    }
+
+    public function branches(): array
+    {
+        throw $this->unsupported();
+    }
+
+    public function composerJson(?string $ref = null): ?array
+    {
+        throw $this->unsupported();
+    }
+
+    public function commitDate(string $ref): ?CarbonImmutable
+    {
+        throw $this->unsupported();
+    }
+
+    public function downloadZipball(string $ref, string $destination): void
+    {
+        throw $this->unsupported();
+    }
+
+    public function createWebhook(string $url, string $secret): int
+    {
+        throw $this->unsupported();
+    }
+
+    public function deleteWebhook(int $id): void
+    {
+        throw $this->unsupported();
+    }
+
+    private function unsupported(): UnsupportedProviderException
+    {
+        return new UnsupportedProviderException(
+            "{$this->provider->getLabel()} sources are not supported yet: the provider is declared, but no client implements it."
+        );
+    }
+}

--- a/app/Sources/UnsupportedProviderException.php
+++ b/app/Sources/UnsupportedProviderException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Sources;
+
+use RuntimeException;
+
+/**
+ * Raised by the stub clients for providers the enum names but nothing
+ * implements yet. The message is the roadmap: implement the client, the
+ * rest of the app already speaks the contract.
+ */
+class UnsupportedProviderException extends RuntimeException {}

--- a/app/Support/NewToken.php
+++ b/app/Support/NewToken.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Token;
+
+/**
+ * A freshly issued access token, carrying the one and only copy of its
+ * plain text. The caller shows it once; only the hash survives.
+ */
+final readonly class NewToken
+{
+    public function __construct(
+        public Token $token,
+        public string $plainText,
+    ) {}
+}

--- a/app/Support/VersionNormalizer.php
+++ b/app/Support/VersionNormalizer.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Support;
+
+use Composer\Semver\VersionParser;
+use UnexpectedValueException;
+
+/**
+ * One spelling for every version this registry stores.
+ *
+ * Tags arrive as whatever a maintainer typed — v1.2.3, 1.0.0-beta.2 — and
+ * are normalized once at import, so equality checks and metadata all agree.
+ * Alongside the display version, order() produces a string whose *lexical*
+ * order matches semantic version order, which is what lets the database sort
+ * versions correctly (a plain string sort puts 1.10.0 below 1.9.0).
+ */
+class VersionNormalizer
+{
+    /**
+     * Lexically ordered stability weights: a stable release outranks its own
+     * release candidates, and a rare post-release patch outranks stable.
+     *
+     * @var array<string, string>
+     */
+    private const STABILITY_WEIGHTS = [
+        'dev' => '1',
+        'alpha' => '2',
+        'beta' => '3',
+        'rc' => '4',
+        'stable' => '5',
+        'patch' => '6',
+        'pl' => '6',
+        'p' => '6',
+    ];
+
+    public function __construct(private readonly VersionParser $parser = new VersionParser) {}
+
+    /**
+     * The version a tag publishes as: the leading "v" dropped and pre-release
+     * suffixes tidied (1.0.0-beta.2 → 1.0.0-beta2). Dev versions pass through
+     * untouched — they are branch names, not tags.
+     */
+    public function version(string $tag): string
+    {
+        $tag = trim($tag);
+
+        if ($this->isDev($tag)) {
+            return $tag;
+        }
+
+        $version = preg_replace('/^v/i', '', $tag) ?? $tag;
+
+        return preg_replace('/[-._]?(alpha|beta|rc|patch|pl|p)[-._]?(\d*)$/i', '-$1$2', $version) ?? $version;
+    }
+
+    /**
+     * The Composer dev version a branch publishes as, following Packagist's
+     * naming: numeric branches become "2.x-dev" / "2.0.x-dev", version-like
+     * ones keep their shape with "-dev" appended, and everything else is
+     * "dev-{branch}".
+     */
+    public function devVersion(string $branch): string
+    {
+        if (preg_match('/^v?\d+(\.\d+)*$/', $branch)) {
+            return "{$branch}.x-dev";
+        }
+
+        if (preg_match('/^v?\d+(\.(\d+|x))*$/i', $branch)) {
+            return "{$branch}-dev";
+        }
+
+        return "dev-{$branch}";
+    }
+
+    /**
+     * A string whose lexical order is the version's semantic order.
+     *
+     * Built from composer/semver's canonical four-segment normal form, with
+     * each segment zero-padded and the stability suffix mapped to a weighted
+     * tail — so `order by` in SQL ranks 1.10.0 above 1.9.0, and 1.0.0 above
+     * its own RCs. Dev versions return as themselves: branches have no
+     * position on a release line, and the endpoints sort them by name.
+     */
+    public function order(string $version): string
+    {
+        if ($this->isDev($version)) {
+            return $version;
+        }
+
+        try {
+            $normalized = $this->parser->normalize($version);
+        } catch (UnexpectedValueException) {
+            // Unparseable input sorts beneath every real version rather than
+            // failing the import that carried it.
+            return sprintf('%08d.%08d.%08d.%08d-0.0000', 0, 0, 0, 0);
+        }
+
+        preg_match(
+            '/^(\d+)\.(\d+)\.(\d+)\.(\d+)(?:-(dev|alpha|beta|RC|patch|pl|p)(\d*))?$/i',
+            $normalized,
+            $matches,
+        );
+
+        $weight = self::STABILITY_WEIGHTS[strtolower($matches[5] ?? 'stable')] ?? '5';
+
+        return sprintf(
+            '%08d.%08d.%08d.%08d-%s.%04d',
+            (int) $matches[1],
+            (int) $matches[2],
+            (int) $matches[3],
+            (int) $matches[4],
+            $weight,
+            (int) ($matches[6] ?? 0),
+        );
+    }
+
+    /**
+     * Whether a version string names a branch rather than a release.
+     */
+    public function isDev(string $version): bool
+    {
+        return str_starts_with($version, 'dev-') || str_ends_with($version, '-dev');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,11 +20,18 @@ return Application::configure(basePath: dirname(__DIR__))
 
         // GitHub posts deliveries with no session and no token; they carry a
         // signature instead, which the webhook controller checks before doing
-        // anything with the payload.
-        $middleware->validateCsrfTokens(except: ['incoming/*']);
+        // anything with the payload. Artifact uploads are likewise stateless:
+        // CI authenticates with an access token, not a session.
+        $middleware->validateCsrfTokens(except: ['incoming/*', 'upload/*', 'r/*/upload/*']);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
+        // The upload endpoint is driven by curl in CI scripts, which rarely
+        // send an Accept header; a validation failure must still answer 422
+        // JSON, never a redirect to a login page.
         $exceptions->shouldRenderJsonWhen(
-            fn (Request $request) => $request->is('api/*') || $request->expectsJson(),
+            fn (Request $request) => $request->is('api/*')
+                || $request->is('upload/*')
+                || $request->is('r/*/upload/*')
+                || $request->expectsJson(),
         );
     })->create();

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "joaopaulolndev/filament-edit-profile": "^3.0",
         "laravel/framework": "^13.17",
         "laravel/slack-notification-channel": "^3.10",
+        "laravel/socialite": "^5.29",
         "laravel/tinker": "^3.0",
         "league/flysystem-aws-s3-v3": "^3.35"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.3",
         "bezhansalleh/filament-shield": "^4.3",
+        "composer/semver": "^3.4",
         "filament/filament": "^5.0",
         "joaopaulolndev/filament-edit-profile": "^3.0",
         "laravel/framework": "^13.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31369479e77cf0cc480c525ebb908aac",
+    "content-hash": "11d574579e410a0e4b9b5d5bab7d9044",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -1801,6 +1801,72 @@
             "time": "2026-07-29T13:14:03+00:00"
         },
         {
+            "name": "firebase/php-jwt",
+            "version": "v7.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/php-jwt.git",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "reference": "b374a5d1a4f1f67fadc2165cdb284645945e2fc0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpfastcache/phpfastcache": "^9.2",
+                "phpseclib/phpseclib": "~3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present",
+                "phpseclib/phpseclib": "Support PS256 (RSASSA-PSS) signatures"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/googleapis/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/php-jwt/issues",
+                "source": "https://github.com/googleapis/php-jwt/tree/v7.1.0"
+            },
+            "time": "2026-06-11T17:54:14+00:00"
+        },
+        {
             "name": "fruitcake/php-cors",
             "version": "v1.4.0",
             "source": {
@@ -3035,6 +3101,78 @@
             "time": "2026-07-24T20:53:54+00:00"
         },
         {
+            "name": "laravel/socialite",
+            "version": "v5.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/socialite.git",
+                "reference": "cd343a5841f02292af119ee607edc71300c9ae4f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/cd343a5841f02292af119ee607edc71300c9ae4f",
+                "reference": "cd343a5841f02292af119ee607edc71300c9ae4f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.4|^7.0",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/http": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "league/oauth1-client": "^1.11",
+                "php": "^7.2|^8.0",
+                "phpseclib/phpseclib": "^3.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^4.18|^5.20|^6.47|^7.55|^8.36|^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.12.23",
+                "phpunit/phpunit": "^8.0|^9.3|^10.4|^11.5|^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Socialite": "Laravel\\Socialite\\Facades\\Socialite"
+                    },
+                    "providers": [
+                        "Laravel\\Socialite\\SocialiteServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Socialite\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel wrapper around OAuth 1 & OAuth 2 libraries.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "laravel",
+                "oauth"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/socialite/issues",
+                "source": "https://github.com/laravel/socialite"
+            },
+            "time": "2026-07-01T13:50:23+00:00"
+        },
+        {
             "name": "laravel/tinker",
             "version": "v3.0.2",
             "source": {
@@ -3625,6 +3763,82 @@
                 }
             ],
             "time": "2026-07-09T11:49:27+00:00"
+        },
+        {
+            "name": "league/oauth1-client",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth1-client.git",
+                "reference": "f9c94b088837eb1aae1ad7c4f23eb65cc6993055"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth1-client/zipball/f9c94b088837eb1aae1ad7c4f23eb65cc6993055",
+                "reference": "f9c94b088837eb1aae1ad7c4f23eb65cc6993055",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "guzzlehttp/guzzle": "^6.0|^7.0",
+                "guzzlehttp/psr7": "^1.7|^2.0",
+                "php": ">=7.1||>=8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "friendsofphp/php-cs-fixer": "^2.17",
+                "mockery/mockery": "^1.3.3",
+                "phpstan/phpstan": "^0.12.42",
+                "phpunit/phpunit": "^7.5||9.5"
+            },
+            "suggest": {
+                "ext-simplexml": "For decoding XML-based responses."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev",
+                    "dev-develop": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth1\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Corlett",
+                    "email": "bencorlett@me.com",
+                    "homepage": "http://www.webcomm.com.au",
+                    "role": "Developer"
+                }
+            ],
+            "description": "OAuth 1.0 Client Library",
+            "keywords": [
+                "Authentication",
+                "SSO",
+                "authorization",
+                "bitbucket",
+                "identity",
+                "idp",
+                "oauth",
+                "oauth1",
+                "single sign on",
+                "trello",
+                "tumblr",
+                "twitter"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth1-client/issues",
+                "source": "https://github.com/thephpleague/oauth1-client/tree/v1.11.0"
+            },
+            "time": "2024-12-10T19:59:05+00:00"
         },
         {
             "name": "league/uri",
@@ -4843,6 +5057,56 @@
             "time": "2025-09-24T15:06:41+00:00"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
             "name": "phpoption/phpoption",
             "version": "1.9.5",
             "source": {
@@ -4916,6 +5180,116 @@
                 }
             ],
             "time": "2025-12-27T19:41:33+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.56",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7adbbe38cde25e2df2116dbf2673c407e24fa305",
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.56"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-08-03T04:36:50+00:00"
         },
         {
             "name": "pragmarx/google2fa",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11d574579e410a0e4b9b5d5bab7d9044",
+    "content-hash": "8826e370158239066288e011a306abf2",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -834,6 +834,83 @@
                 }
             ],
             "time": "2026-03-20T21:10:52+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "danharrin/date-format-converter",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
-            "version": "1.3.10",
+            "version": "1.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AnourValar/eloquent-serialize.git",
-                "reference": "2be26f176b764a2d6f20118bfa4b125f71fa88f8"
+                "reference": "abd890c4d1ad8e90dd454d01283fbf342f80f1e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AnourValar/eloquent-serialize/zipball/2be26f176b764a2d6f20118bfa4b125f71fa88f8",
-                "reference": "2be26f176b764a2d6f20118bfa4b125f71fa88f8",
+                "url": "https://api.github.com/repos/AnourValar/eloquent-serialize/zipball/abd890c4d1ad8e90dd454d01283fbf342f80f1e5",
+                "reference": "abd890c4d1ad8e90dd454d01283fbf342f80f1e5",
                 "shasum": ""
             },
             "require": {
@@ -67,9 +67,9 @@
             ],
             "support": {
                 "issues": "https://github.com/AnourValar/eloquent-serialize/issues",
-                "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.10"
+                "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.11"
             },
-            "time": "2026-06-20T14:30:25+00:00"
+            "time": "2026-08-07T06:14:19+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -127,16 +127,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.391.0",
+            "version": "3.391.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "7dbeb8684ae8c1388f0d5f26e803259299ae59eb"
+                "reference": "90920ce5518aa864e04da0224bb0ba0ee9e31d7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/7dbeb8684ae8c1388f0d5f26e803259299ae59eb",
-                "reference": "7dbeb8684ae8c1388f0d5f26e803259299ae59eb",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/90920ce5518aa864e04da0224bb0ba0ee9e31d7f",
+                "reference": "90920ce5518aa864e04da0224bb0ba0ee9e31d7f",
                 "shasum": ""
             },
             "require": {
@@ -218,9 +218,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.391.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.391.1"
             },
-            "time": "2026-08-06T18:26:00+00:00"
+            "time": "2026-08-07T20:18:18+00:00"
         },
         {
             "name": "bezhansalleh/filament-plugin-essentials",
@@ -965,16 +965,16 @@
         },
         {
             "name": "danharrin/livewire-rate-limiting",
-            "version": "v2.2.0",
+            "version": "v2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/danharrin/livewire-rate-limiting.git",
-                "reference": "c03e649220089f6e5a52d422e24e3f98c73e456d"
+                "reference": "69436717dc70e30f80d7f8fd02504c22992a9ad5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/danharrin/livewire-rate-limiting/zipball/c03e649220089f6e5a52d422e24e3f98c73e456d",
-                "reference": "c03e649220089f6e5a52d422e24e3f98c73e456d",
+                "url": "https://api.github.com/repos/danharrin/livewire-rate-limiting/zipball/69436717dc70e30f80d7f8fd02504c22992a9ad5",
+                "reference": "69436717dc70e30f80d7f8fd02504c22992a9ad5",
                 "shasum": ""
             },
             "require": {
@@ -982,7 +982,7 @@
                 "php": "^8.0"
             },
             "require-dev": {
-                "livewire/livewire": "^3.0",
+                "livewire/livewire": "^3.0|^4.0",
                 "livewire/volt": "^1.3",
                 "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0|^11.0",
                 "phpunit/phpunit": "^9.0|^10.0|^11.5.3|^12.5.12"
@@ -1015,7 +1015,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-16T11:29:23+00:00"
+            "time": "2026-08-06T08:41:51+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1392,16 +1392,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "995b58bf41f26bad5d457fca0246fbb07820c3b4"
+                "reference": "da3ed6cc03bd604b8b875ea03d4e9ef02c279eb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/995b58bf41f26bad5d457fca0246fbb07820c3b4",
-                "reference": "995b58bf41f26bad5d457fca0246fbb07820c3b4",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/da3ed6cc03bd604b8b875ea03d4e9ef02c279eb2",
+                "reference": "da3ed6cc03bd604b8b875ea03d4e9ef02c279eb2",
                 "shasum": ""
             },
             "require": {
@@ -1437,20 +1437,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:13:50+00:00"
+            "time": "2026-08-05T20:45:04+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "81100c0692e684fc1950173dd60d7947f4d235f5"
+                "reference": "7e75d8da9b907ead7d618ce8237228316d08ae43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/81100c0692e684fc1950173dd60d7947f4d235f5",
-                "reference": "81100c0692e684fc1950173dd60d7947f4d235f5",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/7e75d8da9b907ead7d618ce8237228316d08ae43",
+                "reference": "7e75d8da9b907ead7d618ce8237228316d08ae43",
                 "shasum": ""
             },
             "require": {
@@ -1494,20 +1494,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-31T03:39:19+00:00"
+            "time": "2026-08-05T20:52:57+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "5b4e193bf6b4e86a51e20db3db33a734d0a28f11"
+                "reference": "3295b3acfe81dc75faa3a6dbbfea551e4df10887"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/5b4e193bf6b4e86a51e20db3db33a734d0a28f11",
-                "reference": "5b4e193bf6b4e86a51e20db3db33a734d0a28f11",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/3295b3acfe81dc75faa3a6dbbfea551e4df10887",
+                "reference": "3295b3acfe81dc75faa3a6dbbfea551e4df10887",
                 "shasum": ""
             },
             "require": {
@@ -1544,20 +1544,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-31T03:39:08+00:00"
+            "time": "2026-08-05T20:51:04+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "fba46bc691a120a3251326b77cdafe758b41386a"
+                "reference": "dca2f115006b716f2293e29042f9c9b410fc3548"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/fba46bc691a120a3251326b77cdafe758b41386a",
-                "reference": "fba46bc691a120a3251326b77cdafe758b41386a",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/dca2f115006b716f2293e29042f9c9b410fc3548",
+                "reference": "dca2f115006b716f2293e29042f9c9b410fc3548",
                 "shasum": ""
             },
             "require": {
@@ -1589,20 +1589,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:09:16+00:00"
+            "time": "2026-08-05T20:44:03+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
-                "reference": "c0c90201667a2fa64293be8af4a4baf565c00879"
+                "reference": "f188823f2e681883e1fa419af7e2f2a17d4c63c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/c0c90201667a2fa64293be8af4a4baf565c00879",
-                "reference": "c0c90201667a2fa64293be8af4a4baf565c00879",
+                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/f188823f2e681883e1fa419af7e2f2a17d4c63c5",
+                "reference": "f188823f2e681883e1fa419af7e2f2a17d4c63c5",
                 "shasum": ""
             },
             "require": {
@@ -1636,20 +1636,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:13:39+00:00"
+            "time": "2026-08-05T20:49:13+00:00"
         },
         {
             "name": "filament/query-builder",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/query-builder.git",
-                "reference": "30ecea7c77c0066ee09c5902e820c62f816f8837"
+                "reference": "d658205b135ef364c992f5d5d518e9463099aab4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/30ecea7c77c0066ee09c5902e820c62f816f8837",
-                "reference": "30ecea7c77c0066ee09c5902e820c62f816f8837",
+                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/d658205b135ef364c992f5d5d518e9463099aab4",
+                "reference": "d658205b135ef364c992f5d5d518e9463099aab4",
                 "shasum": ""
             },
             "require": {
@@ -1682,20 +1682,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:13:35+00:00"
+            "time": "2026-08-05T20:44:12+00:00"
         },
         {
             "name": "filament/schemas",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/schemas.git",
-                "reference": "53d4346cf0d7abbfc5f7157c761365766153a080"
+                "reference": "3e191f49090645685a34560f5a3e1ba28ed3e7bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/53d4346cf0d7abbfc5f7157c761365766153a080",
-                "reference": "53d4346cf0d7abbfc5f7157c761365766153a080",
+                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/3e191f49090645685a34560f5a3e1ba28ed3e7bc",
+                "reference": "3e191f49090645685a34560f5a3e1ba28ed3e7bc",
                 "shasum": ""
             },
             "require": {
@@ -1727,20 +1727,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-31T03:39:26+00:00"
+            "time": "2026-08-05T20:51:01+00:00"
         },
         {
             "name": "filament/support",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "37aee7759b9ef434c246c28aef87d0f17bb88fd7"
+                "reference": "b6a33dd2af46160abe73226d671b1bc490a84a27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/37aee7759b9ef434c246c28aef87d0f17bb88fd7",
-                "reference": "37aee7759b9ef434c246c28aef87d0f17bb88fd7",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/b6a33dd2af46160abe73226d671b1bc490a84a27",
+                "reference": "b6a33dd2af46160abe73226d671b1bc490a84a27",
                 "shasum": ""
             },
             "require": {
@@ -1785,20 +1785,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:09:20+00:00"
+            "time": "2026-08-05T20:51:57+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "c412d9ab38c0e77bbd6be0527b8c6dd026bea082"
+                "reference": "be471ed4a9f2e7dcbbb134db622a03d4e89f7a21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/c412d9ab38c0e77bbd6be0527b8c6dd026bea082",
-                "reference": "c412d9ab38c0e77bbd6be0527b8c6dd026bea082",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/be471ed4a9f2e7dcbbb134db622a03d4e89f7a21",
+                "reference": "be471ed4a9f2e7dcbbb134db622a03d4e89f7a21",
                 "shasum": ""
             },
             "require": {
@@ -1831,20 +1831,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:11:13+00:00"
+            "time": "2026-08-05T20:51:25+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v5.7.5",
+            "version": "v5.7.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
-                "reference": "917a6fd81577512bb1e586664e6e40bc0c668d58"
+                "reference": "e500c98debe26112008398933fcf3ed50ee103f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/917a6fd81577512bb1e586664e6e40bc0c668d58",
-                "reference": "917a6fd81577512bb1e586664e6e40bc0c668d58",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/e500c98debe26112008398933fcf3ed50ee103f7",
+                "reference": "e500c98debe26112008398933fcf3ed50ee103f7",
                 "shasum": ""
             },
             "require": {
@@ -1875,7 +1875,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-29T13:14:03+00:00"
+            "time": "2026-08-05T20:49:46+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -2078,21 +2078,21 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.2",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "744101956d78b7c1384d0cbf379db13e859167bf"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/744101956d78b7c1384d0cbf379db13e859167bf",
-                "reference": "744101956d78b7c1384d0cbf379db13e859167bf",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/promises": "^2.5.2",
                 "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
@@ -2186,7 +2186,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -2202,20 +2202,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-26T23:23:20+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
@@ -2270,7 +2270,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -2286,7 +2286,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -2767,16 +2767,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.23.0",
+            "version": "v13.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "92a707229148e57f08a249211c8a5a194159c619"
+                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/92a707229148e57f08a249211c8a5a194159c619",
-                "reference": "92a707229148e57f08a249211c8a5a194159c619",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/6d481710375d2aa67656922ef760cdd2b18bcfe0",
+                "reference": "6d481710375d2aa67656922ef760cdd2b18bcfe0",
                 "shasum": ""
             },
             "require": {
@@ -2796,7 +2796,7 @@
                 "guzzlehttp/guzzle": "^7.8.2",
                 "guzzlehttp/promises": "^2.0.3",
                 "guzzlehttp/uri-template": "^1.0",
-                "laravel/prompts": "^0.3.0",
+                "laravel/prompts": "^0.3.11",
                 "laravel/serializable-closure": "^2.0.10",
                 "league/commonmark": "^2.8.1",
                 "league/flysystem": "^3.25.1",
@@ -2990,20 +2990,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-07-27T14:48:58+00:00"
+            "time": "2026-08-04T15:54:59+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.21",
+            "version": "v0.3.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
+                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
-                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/02b89b39e8972a998db4d5d4ad4719239dd4aee4",
+                "reference": "02b89b39e8972a998db4d5d4ad4719239dd4aee4",
                 "shasum": ""
             },
             "require": {
@@ -3047,9 +3047,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.22"
             },
-            "time": "2026-06-26T00:11:25+00:00"
+            "time": "2026-08-04T14:50:50+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -6685,16 +6685,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v8.1.2",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "535e18a1b8925f6c01a55b171d157ab66c2ace15"
+                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/535e18a1b8925f6c01a55b171d157ab66c2ace15",
-                "reference": "535e18a1b8925f6c01a55b171d157ab66c2ace15",
+                "url": "https://api.github.com/repos/symfony/console/zipball/68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
                 "shasum": ""
             },
             "require": {
@@ -6761,7 +6761,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.1.2"
+                "source": "https://github.com/symfony/console/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -6781,7 +6781,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-27T13:58:19+00:00"
+            "time": "2026-07-31T12:43:13+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -7383,16 +7383,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v8.1.2",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9943adbf5a64e2951a8d9eb0485310d55624f0e8"
+                "reference": "57e712b75f2d0bc8844edbdb18a81dab6f9d55c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9943adbf5a64e2951a8d9eb0485310d55624f0e8",
-                "reference": "9943adbf5a64e2951a8d9eb0485310d55624f0e8",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/57e712b75f2d0bc8844edbdb18a81dab6f9d55c2",
+                "reference": "57e712b75f2d0bc8844edbdb18a81dab6f9d55c2",
                 "shasum": ""
             },
             "require": {
@@ -7440,7 +7440,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v8.1.2"
+                "source": "https://github.com/symfony/http-foundation/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -7460,20 +7460,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-29T07:22:54+00:00"
+            "time": "2026-08-07T15:02:39+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v8.1.2",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "c7bb08dc26a7a7da68fb7ac1ce9de925e6464dbc"
+                "reference": "69d81d8a5dac32a5d94e4eb063b7d97dc42c792a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c7bb08dc26a7a7da68fb7ac1ce9de925e6464dbc",
-                "reference": "c7bb08dc26a7a7da68fb7ac1ce9de925e6464dbc",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/69d81d8a5dac32a5d94e4eb063b7d97dc42c792a",
+                "reference": "69d81d8a5dac32a5d94e4eb063b7d97dc42c792a",
                 "shasum": ""
             },
             "require": {
@@ -7550,7 +7550,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v8.1.2"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -7570,7 +7570,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-29T11:54:54+00:00"
+            "time": "2026-08-07T18:04:54+00:00"
         },
         {
             "name": "symfony/mailer",
@@ -7654,16 +7654,16 @@
         },
         {
             "name": "symfony/mime",
-            "version": "v8.1.2",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "75f4779d4ec2e13f24a3a7e5d0347c340c7ca627"
+                "reference": "8f8ac859d369fe3d18e3837998b1c992bbee92c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/75f4779d4ec2e13f24a3a7e5d0347c340c7ca627",
-                "reference": "75f4779d4ec2e13f24a3a7e5d0347c340c7ca627",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/8f8ac859d369fe3d18e3837998b1c992bbee92c9",
+                "reference": "8f8ac859d369fe3d18e3837998b1c992bbee92c9",
                 "shasum": ""
             },
             "require": {
@@ -7716,7 +7716,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v8.1.2"
+                "source": "https://github.com/symfony/mime/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -7736,7 +7736,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-29T08:00:47+00:00"
+            "time": "2026-08-07T15:02:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -8891,16 +8891,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.1",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
+                "reference": "c0955eb4aa417a110e65c8162237b8a5c7d910bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
-                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/c0955eb4aa417a110e65c8162237b8a5c7d910bf",
+                "reference": "c0955eb4aa417a110e65c8162237b8a5c7d910bf",
                 "shasum": ""
             },
             "require": {
@@ -8960,7 +8960,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.1"
+                "source": "https://github.com/symfony/translation/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -8980,7 +8980,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-06T11:11:44+00:00"
+            "time": "2026-07-30T12:40:56+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -9066,16 +9066,16 @@
         },
         {
             "name": "symfony/uid",
-            "version": "v8.1.0",
+            "version": "v8.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "7393f157a55f7e70a4de0334435c55a5a8fe749a"
+                "reference": "50e98f8bc4c3fcdaf925545a65150fb42cf0caf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/7393f157a55f7e70a4de0334435c55a5a8fe749a",
-                "reference": "7393f157a55f7e70a4de0334435c55a5a8fe749a",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/50e98f8bc4c3fcdaf925545a65150fb42cf0caf2",
+                "reference": "50e98f8bc4c3fcdaf925545a65150fb42cf0caf2",
                 "shasum": ""
             },
             "require": {
@@ -9120,7 +9120,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v8.1.0"
+                "source": "https://github.com/symfony/uid/tree/v8.1.4"
             },
             "funding": [
                 {
@@ -9140,7 +9140,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-08-02T11:29:46+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -9762,16 +9762,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.4.13",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "f55e08f5afa89ac72f23f574175005b67878f466"
+                "reference": "f5f9297225aba9857d014b3140f55a7c50cb1a92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/f55e08f5afa89ac72f23f574175005b67878f466",
-                "reference": "f55e08f5afa89ac72f23f574175005b67878f466",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/f5f9297225aba9857d014b3140f55a7c50cb1a92",
+                "reference": "f5f9297225aba9857d014b3140f55a7c50cb1a92",
                 "shasum": ""
             },
             "require": {
@@ -9782,7 +9782,7 @@
                 "illuminate/support": "^11.45.3|^12.41.1|^13.0",
                 "laravel/mcp": "^0.7.1|^0.8.0|^0.9.0",
                 "laravel/prompts": "^0.3.10",
-                "laravel/roster": "^0.5.0",
+                "laravel/roster": "^1.0.0",
                 "php": "^8.2"
             },
             "require-dev": {
@@ -9824,20 +9824,20 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-07-17T14:28:57+00:00"
+            "time": "2026-08-07T05:46:02+00:00"
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.9.1",
+            "version": "v0.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "a08884d79a95c5143498507aec5badf751cdbec4"
+                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/a08884d79a95c5143498507aec5badf751cdbec4",
-                "reference": "a08884d79a95c5143498507aec5badf751cdbec4",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
+                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
                 "shasum": ""
             },
             "require": {
@@ -9898,7 +9898,7 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2026-07-21T13:23:52+00:00"
+            "time": "2026-08-06T15:59:47+00:00"
         },
         {
             "name": "laravel/pail",
@@ -10067,16 +10067,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.30.3",
+            "version": "v1.30.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "19ca6de4ce07869f61f09863e37e81562ebc0a9b"
+                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/19ca6de4ce07869f61f09863e37e81562ebc0a9b",
-                "reference": "19ca6de4ce07869f61f09863e37e81562ebc0a9b",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/a96cb6eee2961905d2fce7207aefb80945bf6b28",
+                "reference": "a96cb6eee2961905d2fce7207aefb80945bf6b28",
                 "shasum": ""
             },
             "require": {
@@ -10089,11 +10089,11 @@
             "require-dev": {
                 "composer/semver": "^3.4.4",
                 "friendsofphp/php-cs-fixer": "^3.95.18",
-                "illuminate/view": "^12.64.0",
+                "illuminate/view": "^12.65.0",
                 "larastan/larastan": "^3.10.0",
                 "laravel-zero/framework": "^12.1.0",
                 "laravel/agent-detector": "^2.0.2",
-                "laravel/prompts": "^0.3.21",
+                "laravel/prompts": "^0.3.22",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest": "^3.8.7"
@@ -10133,36 +10133,37 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-08-02T01:28:21+00:00"
+            "time": "2026-08-05T16:47:22+00:00"
         },
         {
             "name": "laravel/roster",
-            "version": "v0.5.1",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/roster.git",
-                "reference": "5089de7615f72f78e831590ff9d0435fed0102bb"
+                "reference": "89e518bd88ae98ff50f6082f6b517c8d8e8245fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/roster/zipball/5089de7615f72f78e831590ff9d0435fed0102bb",
-                "reference": "5089de7615f72f78e831590ff9d0435fed0102bb",
+                "url": "https://api.github.com/repos/laravel/roster/zipball/89e518bd88ae98ff50f6082f6b517c8d8e8245fa",
+                "reference": "89e518bd88ae98ff50f6082f6b517c8d8e8245fa",
                 "shasum": ""
             },
             "require": {
+                "composer/semver": "^3.0",
                 "illuminate/console": "^11.0|^12.0|^13.0",
                 "illuminate/contracts": "^11.0|^12.0|^13.0",
-                "illuminate/routing": "^11.0|^12.0|^13.0",
                 "illuminate/support": "^11.0|^12.0|^13.0",
                 "php": "^8.2",
                 "symfony/yaml": "^7.2|^8.0"
             },
             "require-dev": {
-                "laravel/pint": "^1.14",
+                "laravel/pint": "^1.29",
                 "mockery/mockery": "^1.6",
                 "orchestra/testbench": "^9.0|^10.0|^11.0",
                 "pestphp/pest": "^3.0|^4.1",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.0",
+                "rector/rector": "^2.0"
             },
             "type": "library",
             "extra": {
@@ -10194,7 +10195,7 @@
                 "issues": "https://github.com/laravel/roster/issues",
                 "source": "https://github.com/laravel/roster"
             },
-            "time": "2026-03-05T07:58:43+00:00"
+            "time": "2026-07-18T17:53:15+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -27,7 +27,9 @@ return [
             'pages' => true,
             'widgets' => true,
             'resources' => true,
-            'custom_permissions' => false,
+            // Surfaces hand-declared permissions — Unscoped:Package, seeded
+            // by ShieldPermissionSeeder — so any role can be granted them.
+            'custom_permissions' => true,
         ],
     ],
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -17,12 +17,13 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Composer Dist Cache Disk
+    | Composer Dist Disk
     |--------------------------------------------------------------------------
     |
-    | The disk that cached package zipballs are written to. Application
-    | containers have ephemeral local storage, so any deployment with
-    | more than one container must point this at an "s3" bucket.
+    | The disk that version archives (Composer dist zipballs) are stored on
+    | at sync time and served from. Application containers have ephemeral
+    | local storage, so any deployment with more than one container — or
+    | that redeploys at all — must point this at an "s3" bucket.
     |
     */
 

--- a/database/factories/AuthenticationSourceFactory.php
+++ b/database/factories/AuthenticationSourceFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AuthProvider;
+use App\Models\AuthenticationSource;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AuthenticationSource>
+ */
+class AuthenticationSourceFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->company(),
+            'provider' => AuthProvider::Github,
+            'client_id' => fake()->uuid(),
+            'client_secret' => fake()->sha256(),
+            'active' => true,
+            'allow_registration' => true,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes): array => ['active' => false]);
+    }
+}

--- a/database/factories/DeployTokenFactory.php
+++ b/database/factories/DeployTokenFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DeployToken;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DeployToken>
+ */
+class DeployTokenFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->words(2, true).' deploy',
+        ];
+    }
+}

--- a/database/factories/RepositoryFactory.php
+++ b/database/factories/RepositoryFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Repository;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Repository>
+ */
+class RepositoryFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $path = fake()->unique()->slug(2);
+
+        return [
+            'name' => ucfirst(str_replace('-', ' ', $path)),
+            'path' => $path,
+            'description' => fake()->sentence(),
+            'public' => false,
+        ];
+    }
+
+    /**
+     * Indicate that the repository is readable without a token.
+     */
+    public function public(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'public' => true,
+        ]);
+    }
+}

--- a/database/factories/TokenFactory.php
+++ b/database/factories/TokenFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\TokenAbility;
+use App\Models\Token;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Token>
+ */
+class TokenFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $plain = 'pp_'.Str::random(40);
+
+        return [
+            'tokenable_type' => User::class,
+            'tokenable_id' => User::factory(),
+            'name' => fake()->words(2, true),
+            'token_prefix' => substr($plain, 0, 8),
+            'token' => hash('sha256', $plain),
+            'abilities' => [TokenAbility::RepositoryRead->value],
+        ];
+    }
+}

--- a/database/migrations/2026_08_03_193135_create_repositories_table.php
+++ b/database/migrations/2026_08_03_193135_create_repositories_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('repositories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+
+            // The URL slug the repository's Composer endpoints are mounted
+            // under (/r/{path}/...). Null only for the default repository,
+            // which is served at the site root; Repository::default() is the
+            // one place that creates that row.
+            $table->string('path')->nullable()->unique();
+
+            $table->text('description')->nullable();
+
+            // Whether unauthenticated Composer clients may read from this
+            // repository. Reads on a private repository require a token with
+            // access to it.
+            $table->boolean('public')->default(false);
+
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('repositories');
+    }
+};

--- a/database/migrations/2026_08_03_193145_create_packages_table.php
+++ b/database/migrations/2026_08_03_193145_create_packages_table.php
@@ -23,7 +23,9 @@ return new class extends Migration
             // to their own token or GITHUB_TOKEN until relinked.
             $table->foreignId('source_id')->nullable()->constrained()->nullOnDelete();
 
-            $table->string('repository');
+            // Null for packages published by artifact upload, which have no
+            // VCS repository behind them.
+            $table->string('repository')->nullable();
             $table->string('latest_version')->nullable();
 
             // Composer resolves packages by name, so it must be unique — per

--- a/database/migrations/2026_08_03_193145_create_packages_table.php
+++ b/database/migrations/2026_08_03_193145_create_packages_table.php
@@ -14,15 +14,22 @@ return new class extends Migration
         Schema::create('packages', function (Blueprint $table) {
             $table->id();
 
+            // The Composer repository this package is served from. Deleting a
+            // repository is refused while it still holds packages — an admin
+            // moves or deletes them first, deliberately.
+            $table->foreignId('repository_id')->constrained()->restrictOnDelete();
+
             // Deleting a source leaves its packages in place; they fall back
             // to their own token or GITHUB_TOKEN until relinked.
             $table->foreignId('source_id')->nullable()->constrained()->nullOnDelete();
 
-            $table->string('repository')->unique();
+            $table->string('repository');
             $table->string('latest_version')->nullable();
 
-            // Composer resolves packages by name, so it must be unique.
-            $table->string('name')->unique();
+            // Composer resolves packages by name, so it must be unique — per
+            // repository, since each repository is its own registry. The same
+            // goes for the VCS repository URL.
+            $table->string('name');
             $table->text('description')->nullable();
             $table->string('type')->nullable()->index();
             $table->text('token')->nullable();
@@ -52,6 +59,9 @@ return new class extends Migration
             $table->timestamp('webhook_received_at')->nullable();
 
             $table->timestamps();
+
+            $table->unique(['repository_id', 'name']);
+            $table->unique(['repository_id', 'repository']);
         });
     }
 

--- a/database/migrations/2026_08_03_193145_create_packages_table.php
+++ b/database/migrations/2026_08_03_193145_create_packages_table.php
@@ -38,6 +38,11 @@ return new class extends Migration
             $table->timestamp('last_synced_at')->nullable();
             $table->text('sync_error')->nullable();
 
+            // Denormalized from the downloads table so search results and
+            // sortable listings never need a count over it;
+            // `downloads:recalculate` rebuilds it from the source of truth.
+            $table->unsignedBigInteger('total_downloads')->default(0);
+
             // The job batch currently (or last) rebuilding this package's
             // versions, so the panel can show the imports' progress.
             $table->string('sync_batch_id')->nullable();

--- a/database/migrations/2026_08_03_193145_create_packages_table.php
+++ b/database/migrations/2026_08_03_193145_create_packages_table.php
@@ -29,6 +29,10 @@ return new class extends Migration
             $table->timestamp('last_synced_at')->nullable();
             $table->text('sync_error')->nullable();
 
+            // The job batch currently (or last) rebuilding this package's
+            // versions, so the panel can show the imports' progress.
+            $table->string('sync_batch_id')->nullable();
+
             // The repository webhook created for this package, which only
             // exists as the fallback for repositories the GitHub App's own
             // webhook does not deliver for. Packages under an installed app

--- a/database/migrations/2026_08_03_193150_create_package_versions_table.php
+++ b/database/migrations/2026_08_03_193150_create_package_versions_table.php
@@ -18,6 +18,12 @@ return new class extends Migration
             $table->string('reference');
             $table->boolean('is_dev')->default(false);
 
+            // Where this version's zip lives on the dist disk, and the sha1
+            // Composer verifies downloads against. Null only for a row whose
+            // archive has not been stored yet; the next sync backfills it.
+            $table->string('archive_path')->nullable();
+            $table->string('shasum', 40)->nullable();
+
             // Nullable because a ref may resolve before its date is known; the
             // next sync backfills it, since a null date is what looks stale.
             $table->timestamp('released_at')->nullable()->index();

--- a/database/migrations/2026_08_03_193150_create_package_versions_table.php
+++ b/database/migrations/2026_08_03_193150_create_package_versions_table.php
@@ -15,6 +15,13 @@ return new class extends Migration
             $table->id();
             $table->foreignId('package_id')->constrained()->cascadeOnDelete();
             $table->string('version');
+
+            // A string whose lexical order matches semantic version order
+            // (see App\Support\VersionNormalizer::order), which is what
+            // "latest" and the /p2 response ordering sort by. Null only on
+            // rows predating it; the next sync backfills.
+            $table->string('order')->nullable()->index();
+
             $table->string('reference');
             $table->boolean('is_dev')->default(false);
 

--- a/database/migrations/2026_08_03_193150_create_package_versions_table.php
+++ b/database/migrations/2026_08_03_193150_create_package_versions_table.php
@@ -24,6 +24,10 @@ return new class extends Migration
             $table->string('archive_path')->nullable();
             $table->string('shasum', 40)->nullable();
 
+            // Denormalized from the downloads table, kept by the download
+            // listener and downloads:recalculate.
+            $table->unsignedBigInteger('total_downloads')->default(0);
+
             // Nullable because a ref may resolve before its date is known; the
             // next sync backfills it, since a null date is what looks stale.
             $table->timestamp('released_at')->nullable()->index();

--- a/database/migrations/2026_08_07_235500_create_access_tokens_table.php
+++ b/database/migrations/2026_08_07_235500_create_access_tokens_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('access_tokens', function (Blueprint $table) {
+            $table->id();
+
+            // The principal the token acts as: a user's personal token, or a
+            // deploy token standing in for a CI system.
+            $table->morphs('tokenable');
+
+            $table->string('name');
+
+            // Only the sha256 of the plain token is stored — the secret is
+            // shown once at creation and never again. The prefix is what
+            // listings show, so a token can be recognised without it.
+            $table->string('token_prefix', 16);
+            $table->string('token', 64)->unique();
+
+            $table->json('abilities');
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+
+            // Revoking is a soft delete, so "what was that token and when was
+            // it last used" stays answerable after the fact.
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('access_tokens');
+    }
+};

--- a/database/migrations/2026_08_07_235510_create_deploy_tokens_table.php
+++ b/database/migrations/2026_08_07_235510_create_deploy_tokens_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // A deploy token is a machine principal — a CI system, a build box —
+        // that owns an access token without owning a user account. Its reach
+        // is the union of the pivots below; holding no grants at all means
+        // "every package".
+        Schema::create('deploy_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+
+        Schema::create('deploy_token_package', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('deploy_token_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('package_id')->constrained()->cascadeOnDelete();
+
+            $table->unique(['deploy_token_id', 'package_id']);
+        });
+
+        Schema::create('deploy_token_repository', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('deploy_token_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('repository_id')->constrained()->cascadeOnDelete();
+
+            $table->unique(['deploy_token_id', 'repository_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('deploy_token_repository');
+        Schema::dropIfExists('deploy_token_package');
+        Schema::dropIfExists('deploy_tokens');
+    }
+};

--- a/database/migrations/2026_08_07_235520_create_user_access_grant_tables.php
+++ b/database/migrations/2026_08_07_235520_create_user_access_grant_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Row-level access for panel users without Unscoped:Package — the
+        // union of these grants plus every public repository is what such a
+        // user (and their personal tokens) can see.
+        Schema::create('package_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('package_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+            $table->unique(['package_id', 'user_id']);
+        });
+
+        Schema::create('repository_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('repository_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+
+            $table->unique(['repository_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('repository_user');
+        Schema::dropIfExists('package_user');
+    }
+};

--- a/database/migrations/2026_08_07_235530_create_downloads_table.php
+++ b/database/migrations/2026_08_07_235530_create_downloads_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // One row per dist download — the raw feed behind the dashboard's
+        // chart and the denormalized total_downloads counters.
+        Schema::create('downloads', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('package_id')->constrained()->cascadeOnDelete();
+
+            // The row outlives the version: pruned branches and replaced tags
+            // null the FK while the version string keeps history readable.
+            $table->foreignId('package_version_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('version');
+
+            $table->string('ip', 45)->nullable();
+
+            // Which credential fetched it — the prefix, since that is what
+            // token listings show and it stays meaningful after revocation.
+            $table->string('token_prefix', 16)->nullable();
+
+            $table->timestamp('created_at')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('downloads');
+    }
+};

--- a/database/migrations/2026_08_07_235540_create_authentication_sources_table.php
+++ b/database/migrations/2026_08_07_235540_create_authentication_sources_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Login providers configured at runtime — an OIDC issuer, GitHub,
+        // Google, GitLab — each carrying its own OAuth client and rules for
+        // who may register through it.
+        Schema::create('authentication_sources', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('provider');
+            $table->string('client_id');
+            $table->text('client_secret');
+
+            // Only OIDC needs one; the named providers know their endpoints.
+            $table->string('discovery_url')->nullable();
+
+            $table->boolean('active')->default(true);
+
+            // Whether an unknown identity may create an account, and if so,
+            // which email domains qualify (empty = any) and what role the
+            // fresh account starts with.
+            $table->boolean('allow_registration')->default(true);
+            $table->json('allowed_domains')->nullable();
+            $table->string('default_role')->nullable();
+
+            $table->timestamps();
+        });
+
+        // The external identity a user signs in as. Lives here rather than in
+        // the users create migration because the FK needs this table first.
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('authentication_source_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('external_id')->nullable();
+
+            $table->unique(['authentication_source_id', 'external_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('authentication_source_id');
+            $table->dropColumn('external_id');
+        });
+
+        Schema::dropIfExists('authentication_sources');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Repository;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -20,5 +21,10 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(ShieldPermissionSeeder::class);
+
+        // The repository served at the registry root. Created lazily wherever
+        // it is first needed, but seeding it means a fresh install shows it in
+        // the panel before any package or Composer request exists.
+        Repository::default();
     }
 }

--- a/database/seeders/ShieldPermissionSeeder.php
+++ b/database/seeders/ShieldPermissionSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use BezhanSalleh\FilamentShield\Support\Utils;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\PermissionRegistrar;
@@ -35,6 +36,15 @@ class ShieldPermissionSeeder extends Seeder
             '--all' => true,
             '--option' => 'permissions',
             '--panel' => 'admin',
+        ]);
+
+        // Packistry's `unscoped`, spelled in Shield's permission grammar: the
+        // row-level visibility bypass Package::visibleToUser() checks. Shield
+        // only derives entity CRUD permissions, so it is declared here; any
+        // role can be granted it on the Roles screen's custom permissions tab.
+        Utils::getPermissionModel()::firstOrCreate([
+            'name' => 'Unscoped:Package',
+            'guard_name' => 'web',
         ]);
 
         app(PermissionRegistrar::class)->forgetCachedPermissions();

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -22,7 +22,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | # | Feature | Status | Depends on |
 |---|---------|--------|------------|
 | 1 | Composer v2 API completeness (search.json, list.json, stable/dev split) | ✅ | — |
-| 2 | Local archive storage + dist serving (zips, sha1, cleanup) | 🟡 | — |
+| 2 | Local archive storage + dist serving (zips, sha1, cleanup) | ✅ | — |
 | 3 | Version normalization & ordering (composer/semver) | ❌ | — |
 | 4 | Artifact upload endpoint (CI pushes a zip) | ❌ | 2 |
 | 5 | Multiple named repositories (`/r/{path}`, public/private) | ❌ | — |
@@ -72,24 +72,21 @@ records `shasum` (sha1 of the file), and serves downloads via `Storage::download
 archive is missing. `archives:clean` command prunes orphaned files. Dist URLs in metadata point at the
 app, never at GitHub, so consumers never need GitHub credentials.
 
-**Gap**: package-pipeline builds dist zips at request time by proxying GitHub (check
-`ComposerRepositoryController::dist()`); no shasum, no persistent archives, no pruning.
-
-```text
-In this Laravel app, make package version archives first-class:
-1. Migration: add nullable `archive_path` (string) and `shasum` (string, sha1) to package_versions.
-2. Create app/Services/ArchiveStore.php: given a PackageVersion and a local zip path, store it on the
-   default Storage disk at "packages/{vendor}/{name}/{uuid}.zip", record archive_path + sha1 shasum.
-3. During sync (app/Services/PackageSynchronizer.php), download the GitHub zipball for each new
-   reference (reuse app/Services/GitHub/GitHubClient.php; validate content-type is zip), pass it
-   through ArchiveStore, and skip re-downloading versions whose reference is unchanged.
-4. Update ComposerRepositoryController::dist() to stream the stored archive
-   (Storage::download) and 404 when archive_path is null/missing; update metadata() to include
-   dist.shasum. Keep dist URL shape unchanged.
-5. Add artisan command archives:clean {--dry-run} that deletes stored files not referenced by any
-   PackageVersion, printing each removal.
-6. Feature tests with Storage::fake and Http::fake covering store, serve, 404, and clean. Run tests.
-```
+**Implemented**: `package_versions` carries nullable `archive_path` + `shasum` (folded into the
+create migration, pre-v1). `PackageSynchronizer` downloads the zipball for every new or moved
+reference during sync — `GitHubClient::downloadZipball()` rejects a 200 whose content-type is not a
+zip — and `app/Services/ArchiveStore.php` stores it at `packages/{vendor}/{name}/{uuid7}.zip`,
+recording the path and the file's sha1. Unchanged refs skip the download entirely, and a row missing
+its archive (synced before this feature, or a file gone missing) is treated as changed so the next
+sync backfills it. `ComposerRepositoryController::dist()` streams the stored archive and 404s when
+none is stored — it never reaches for GitHub — and `metadata()` advertises `dist.shasum` so Composer
+verifies downloads. `archives:clean {--dry-run}` prunes files no version references (replaced
+archives get a fresh uuid path rather than an overwrite, so orphans are expected between cleans).
+Two deliberate departures from the prompt: archives live on the existing configurable dist disk
+(`filesystems.dists`, `DIST_DISK`) rather than the default disk, since that knob already existed for
+the request-time cache this replaces; and the columns were folded into the create migration per the
+pre-v1 convention above. Covered in `tests/Feature/ComposerRepositoryTest.php`,
+`tests/Feature/PackageSyncTest.php`, and `tests/Feature/CleanArchivesCommandTest.php`.
 
 ## 3. Version normalization & ordering
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -30,10 +30,10 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 6 | Token authentication for Composer clients (http-basic) | ❌ | — |
 | 7 | Deploy tokens (machine access, repo/package scoped) | ❌ | 6 |
 | 8 | Personal access tokens (per-user) | ❌ | 6 |
-| 9 | Roles + granular permissions | ❌ | — |
+| 9 | Roles + granular permissions | ✅ | — |
 | 10 | Per-user repository/package access scoping | ❌ | 5, 9 |
 | 11 | Provider webhooks (auto-sync on push/tag/delete) | ✅ | — |
-| 12 | Queued batch imports with progress | 🟡 | — |
+| 12 | Queued batch imports with progress | ✅ | — |
 | 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | 🟡 | — |
 | 13a | Sources with GitHub App auth + package bridging | ✅ | — |
 | 14 | Source project browser + one-click package onboarding | ❌ | 13 |
@@ -242,21 +242,16 @@ two roles (admin, user) mapped in config to a flat permission enum covering CRUD
 batch_*) plus `dashboard` and `unscoped` (bypasses row-level scoping). A `Gate::before`-style check
 resolves `$user->can(Permission::X)` from the role → permission map. Simple, no DB permission tables.
 
-```text
-In this Laravel + Filament app, add config-driven role authorization:
-1. app/Enums/Role.php (Admin, User) and app/Enums/Permission.php (string-backed cases:
-   package_create/read/update/delete, version_read, token_manage, user_manage, source_manage,
-   dashboard, unscoped — adjust to the domains that exist in app/Filament/Resources).
-2. Migration: role string column on users defaulting to 'user'; the existing super admin seeder
-   gets role admin.
-3. config/authorization.php maps each role to a permission array; register a Gate::before or
-   per-permission Gate definitions reading that map; add User::can support via a hasPermission()
-   helper.
-4. Enforce in Filament: each Resource's canViewAny/canCreate/canEdit/canDelete checks the matching
-   permission; hide navigation items the user can't access; keep Filament login open to both roles.
-5. Tests: role map resolves correctly; a 'user' role cannot access an admin-only resource page
-   (HTTP test against the Filament route). Run tests.
-```
+**Implemented**, as one deliberate departure: roles and permissions are database-backed via
+`bezhansalleh/filament-shield` (spatie/laravel-permission underneath) rather than Packistry's
+config-enum map. Shield derives one permission per panel entity action (`ViewAny:Package`,
+`Create:Source`, …) from the panel itself (`ShieldPermissionSeeder` regenerates them every seed, so
+they cannot drift as resources are added), generated policies in `app/Policies` enforce them on every
+resource, and `User::canAccessPanel()` requires holding at least one role — a stray user row is never
+a way in. Roles are managed in the panel's own Roles resource, so an admin can shape any number of
+roles at runtime instead of the two the config file would freeze; `admin:create` grants the
+super-admin role with every permission. Row-level visibility (Packistry's `unscoped`) is item 10's
+concern, not a permission flag here.
 
 ## 10. Per-user repository/package access scoping
 
@@ -322,23 +317,41 @@ and fans out one `ImportImportable` job per ref (batch `allowFailures()`). The U
 show progress (total/processed/failed) and can prune finished batches. Result: importing a package with
 hundreds of tags doesn't block a request and failures are per-version, not all-or-nothing.
 
-**Gap**: `PackageSynchronizer::sync()` runs inline and one bad ref can fail the whole sync.
+**Implemented**, with the batch layered under the existing entry point rather than replacing it.
+`PackageSynchronizer` is decomposed into steps — `discover()`, `resolveComposerName()`, `prune()`,
+`changed()`, `import()` (one ref: composer.json, commit date, row + archive in one transaction),
+`finalize()` — so there is exactly one implementation of version building with two drivers:
+`sync()` composes the steps inline for `packages:sync` and the tests, and the batch
+(`App\Jobs\PackageSyncBatch::dispatchFor`) runs them as a named `Bus::batch` with
+`allowFailures()`: `DiscoverVersions` lists refs, prunes, and fans out one `ImportVersion` job per
+ref whose sha moved (unchanged refs add no job at all, so a routine sync is a batch of one), and a
+`FinalizePackageSync` `finally` callback recomputes the package's columns, sets
+`last_synced_at`/`sync_error`, and sends the item-11 notifications. The batch id is stored on the
+package (`sync_batch_id`, folded into the create migration pre-v1) and a polling widget on the
+package view page renders imported/total/failed with a progress bar while
+`Package::syncRunning()` — which knows that a batch with failures never gets `finished_at` — says
+the imports are still going.
 
-```text
-In this Laravel app, move package syncing onto queued job batches:
-1. Refactor app/Services/PackageSynchronizer.php so the per-reference work (fetch composer.json,
-   normalize version, upsert PackageVersion, store archive) lives in a dedicated
-   app/Jobs/ImportVersion.php job (Batchable, Queueable) that takes package id + ref data.
-2. Add app/Jobs/DiscoverVersions.php that lists tags+branches via GitHubClient and adds one
-   ImportVersion per ref to its batch; expose PackageSyncBatch::dispatchFor(Package) that creates a
-   named Bus::batch([DiscoverVersions]) with allowFailures(), storing batch id on the package.
-3. After the batch finishes, prune versions no longer present upstream (finally callback) and set
-   last_synced_at / sync_error.
-4. Wire the Filament "sync" action (or create one on PackageResource) to dispatch the batch and show
-   batch progress on the package view (poll job_batches by stored id: processed/total/failed).
-5. Ensure queue + batches tables exist (php artisan queue:batches-table if needed). Tests with
-   Bus::fake and a small fake ref set exercising fan-out and failure isolation. Run tests.
-```
+Deliberate departures from the prompt:
+
+- **`SyncPackageJob` stays the single entry point** and now only starts the batch: the webhook
+  debounce, uniqueness lock, and "sync already queued" panel affordance all hang off that job, and
+  a sync arriving while a batch is still importing re-queues itself for after it finishes (with a
+  2-hour staleness override) instead of racing it — two rebuilds pruning concurrently was the bug
+  the old `WithoutOverlapping` prevented, and the batch inherits that guarantee here.
+- **Pruning happens at discovery, not in the finally callback.** The discovered ref list is the
+  authority on what exists upstream; waiting for the imports would keep serving versions already
+  deleted. The finally callback instead recomputes package metadata from what the imports stored.
+- **Partial failure is a recorded state, not an error**: the batch finishes, `last_synced_at` is
+  set, and `sync_error` reads "N of M version imports failed; the next sync will retry them" —
+  which the next sync does, because an incomplete row is treated as changed.
+- Inline `sync()` keeps the same per-ref isolation (a lone bad ref costs its version, not the
+  sync), throwing only when nothing at all could be imported.
+
+The `job_batches` table already existed in the default jobs migration. Covered in
+`tests/Feature/PackageSyncBatchTest.php` (fan-out, no-op re-sync, failure isolation on a real
+database queue, discovery-failure cancellation, deferral while a batch runs, widget states) plus
+the reworked `tests/Feature/PackageSyncTest.php` / `SyncPackageJobTest.php`.
 
 ## 13a. Sources with GitHub App auth — implemented
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -34,7 +34,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 10 | Per-user repository/package access scoping | ✅ | 5, 9 |
 | 11 | Provider webhooks (auto-sync on push/tag/delete) | ✅ | — |
 | 12 | Queued batch imports with progress | ✅ | — |
-| 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | 🟡 | — |
+| 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | ✅ | — |
 | 13a | Sources with GitHub App auth + package bridging | ✅ | — |
 | 14 | Source project browser + one-click package onboarding | ❌ | 13 |
 | 15 | Download statistics + dashboard | ✅ | 2 |
@@ -349,26 +349,24 @@ token (+ metadata). The abstract client exposes `projects(search)`, `project(id)
 download; the rest of the app is provider-agnostic (webhook event classes per provider adapt payloads
 to shared `Importable`/`Deletable` interfaces). Supports self-hosted instances via custom base URLs.
 
-```text
-In this Laravel app (GitHub-only sync via app/Services/GitHub/GitHubClient.php), introduce a
-provider-agnostic source layer:
-1. Model + migration: sources table (name, provider enum string [github, gitlab, gitea, bitbucket],
-   base_url, token encrypted cast, metadata json nullable). Add nullable source_id +
-   provider_id (external project id) on packages; keep the per-package token column working as a
-   legacy fallback during transition.
-2. Contract app/Sources/SourceClient.php: projects(?string search): array{id, fullName, webUrl},
-   tags(project) and branches(project) as lazy iterables of {name, sha, zipUrl}, composerJson(ref),
-   downloadZip(url), createWebhook(package), validateToken(). Port GitHubClient to implement it;
-   add GitLabClient (API v4: /projects, /repository/tags, /repository/branches, archive.zip
-   endpoints, PRIVATE-TOKEN header). Stub Gitea/Bitbucket classes behind the same contract (throw
-   UnsupportedProviderException until implemented) so adding them later is mechanical.
-3. Source::client() factory resolves the right implementation; PackageSynchronizer (and jobs, if
-   batch sync exists) depend only on the contract.
-4. Filament: SourceResource (provider select, base_url, token, "validate token" action calling
-   validateToken()).
-5. Tests with Http::fake per provider fixture covering tags/branches pagination and composer.json
-   fetch. Run tests.
-```
+**Implemented**, shaped to fit what 13a already built: the contract splits in two rather than
+Packistry's one-class-does-both. `App\Sources\RepositoryClient` (tags, branches, composerJson,
+commitDate, downloadZipball, create/deleteWebhook) is what syncing, the webhook registrar and the
+create wizard depend on — resolved by `Package::client()` from the package's provider (the source's
+word for it, else the URL's host) — and `App\Sources\SourceClient` (`projects(?search)` returning
+`Project` DTOs) is the browsing side behind `Source::client()`, ready for item 14.
+`GitLabClient`/`GitLabSourceClient` implement both against API v4 (URL-encoded namespace paths,
+PRIVATE-TOKEN, X-Next-Page pagination with the same loud upper bound as GitHub, archive.zip with
+the content-type guard); Gitea/Bitbucket resolve to a shared `StubClient` throwing
+`UnsupportedProviderException`. `Package::repositoryPath()` now parses any provider's URL (nested
+GitLab namespaces included, GitHub paths truncated to owner/repo so pasted /tree/main URLs still
+work), the `GITHUB_TOKEN` env fallback is deliberately withheld from non-GitHub hosts, and GitLab
+gets its own per-repository webhook leg — `POST /incoming/gitlab/{package}`, verified by
+constant-time comparison of `X-Gitlab-Token` since GitLab replays the secret rather than signing
+the body; there is no GitLab equivalent of the GitHub App's account-wide webhook. `Source::verify()`
+speaks GitLab (`/projects?membership`). No `provider_id` column: packages here are keyed by
+repository URL, which webhook resolution already handles. Covered in
+`tests/Feature/GitLabProviderTest.php`.
 
 ## 14. Source project browser + one-click onboarding
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -39,7 +39,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 14 | Source project browser + one-click package onboarding | ❌ | 13 |
 | 15 | Download statistics + dashboard | ✅ | 2 |
 | 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ❌ | 9 |
-| 17 | Operational CLI commands | 🟡 | varies |
+| 17 | Operational CLI commands | ✅ | varies |
 | 18 | Package rebuild & maintenance jobs | 🟡 | 2, 12 |
 
 Suggested independent tracks: **Core registry** (1–4), **Access control** (5–10), **Sync pipeline**
@@ -451,16 +451,18 @@ repository, package, source, deploy-token; `reset:password`; `rebuild:package`;
 `downloads:recalculate`; `archives:clean`. Everything the UI does is scriptable for provisioning and
 recovery (their Docker quickstart creates the first user this way).
 
-```text
-In this Laravel app (private Composer registry, Filament admin), add operational artisan commands
-mirroring the admin UI, using laravel/prompts for interactive input with non-interactive option
-flags for scripting: user:add (name, email, password, role) and user:reset-password;
-package:add (name/repo URL/token) dispatching the existing sync; package:delete (with confirmation,
-also deleting stored archives); token:add / token:revoke for Composer access tokens if that feature
-exists; package:sync {name?} to trigger sync for one or all packages. Reuse existing
-services/actions rather than duplicating logic, register in routes/console.php or via attributes,
-and add a smoke test per command with artisan() test helpers. Run tests.
-```
+**Implemented**: `user:add` (roles validated against what exists, prompts interactively, prints the
+same short-lived signed reset link `admin:create` uses — extracted into the shared
+`IssuesPasswordResetLinks` concern, so a password still never travels through the environment) and
+`user:reset-password`; `package:add` (URL → guessed composer name, `--repo` targets a named
+Composer repository, webhook registration and the first queued sync exactly like the wizard,
+`--no-webhook`/`--no-sync` to opt out) and `package:delete` (confirmation, `--repo` disambiguation
+when a name is served twice, and the stored archives go with the rows); `token:add` (`--user` email
+or `--deploy` name — created on demand as an unscoped principal — abilities `read`/`write`,
+optional expiry, plain text printed once with the `composer config` line) and `token:revoke` by the
+prefix listings show. Syncing was already scriptable as `packages:sync {name?} {--source=}
+{--queue}`, alongside `archives:clean` and `downloads:recalculate`. Covered in
+`tests/Feature/OperationalCommandsTest.php`.
 
 ## 18. Package rebuild & maintenance
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -25,7 +25,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 1 | Composer v2 API completeness (search.json, list.json, stable/dev split) | ✅ | — |
 | 2 | Local archive storage + dist serving (zips, sha1, cleanup) | ✅ | — |
 | 3 | Version normalization & ordering (composer/semver) | ❌ | — |
-| 4 | Artifact upload endpoint (CI pushes a zip) | ❌ | 2 |
+| 4 | Artifact upload endpoint (CI pushes a zip) | ✅ | 2 |
 | 5 | Multiple named repositories (`/r/{path}`, public/private) | ✅ | — |
 | 6 | Token authentication for Composer clients (http-basic) | ✅ | — |
 | 7 | Deploy tokens (machine access, repo/package scoped) | ✅ | 6 |
@@ -124,23 +124,20 @@ fly and a version from the zip's `composer.json` (name/description/type extracte
 composer.json keys — require, autoload, scripts, license, authors, etc. — stored as version metadata).
 Requires a write-ability token. This enables "build artifact → publish" pipelines with no VCS source.
 
-```text
-In this Laravel app (private Composer repository, Filament admin), add an artifact upload endpoint:
-1. Route: POST /{vendor}/{package} (name it composer.upload) accepting multipart `file` (required,
-   zip) and optional `version` string. Guard it with the app's Composer token auth if present,
-   otherwise a config('services.composer.upload_token') bearer check as a stopgap.
-2. Create app/Services/CreateVersionFromZip.php: open the zip (ZipArchive), locate composer.json at
-   any top-level folder depth, decode it; resolve version from input or composer.json version key
-   (error 422 if neither); firstOrCreate the Package by "{vendor}/{package}"; upsert a
-   PackageVersion with metadata limited to keys Composer needs (description, license, authors,
-   keywords, homepage, support, bin, autoload, autoload-dev, require, require-dev, conflict,
-   provide, replace, suggest, minimum-stability, prefer-stable, scripts, extra); store the zip via
-   the archive storage service if present (app/Services/ArchiveStore.php), else under
-   storage/app/packages, recording sha1.
-3. Return 201 with the version JSON; 422 with validation-style errors for bad zip / missing name.
-4. Feature tests: successful upload creates package+version+archive; re-upload same version
-   overwrites; missing composer.json rejected. Run tests.
-```
+**Implemented**: `POST /upload/{vendor}/{package}` (and `/r/{path}/upload/...` per repository) —
+one deliberate departure from Packistry's bare `POST /{vendor}/{package}`, which would collide with
+the `/incoming` webhook paths and force a wildcard CSRF exemption; the `/upload` segment gets its
+own narrow exemption and always renders errors as JSON, since CI curls rarely send an Accept
+header. Requires `repository:write`, and the principal's *scope* must reach the addressed
+repository — a scoped deploy token publishes only into granted repositories (or onto its granted
+packages); public means readable, never writable. `CreateVersionFromZip` finds composer.json at the
+top level or one folder deep, 422s a manifest naming a different package than the URL, resolves the
+version from input else manifest (422 when neither), stores the curated metadata subset, and stores
+the zip through `ArchiveStore` in one transaction; the version's dist reference is the file's own
+sha1, so a re-published version is a new URL rather than a silently different file. Uploaded
+packages carry a null VCS `repository` (column made nullable, pre-v1), webhooks off, and no sync
+action; `Package::refreshLatestVersion()` keeps `latest_version` honest. Covered in
+`tests/Feature/ArtifactUploadTest.php`.
 
 ## 5. Multiple named repositories
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -36,7 +36,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 12 | Queued batch imports with progress | ✅ | — |
 | 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | ✅ | — |
 | 13a | Sources with GitHub App auth + package bridging | ✅ | — |
-| 14 | Source project browser + one-click package onboarding | ❌ | 13 |
+| 14 | Source project browser + one-click package onboarding | ✅ | 13 |
 | 15 | Download statistics + dashboard | ✅ | 2 |
 | 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ✅ | 9 |
 | 17 | Operational CLI commands | ✅ | varies |
@@ -375,16 +375,15 @@ projects available to a source token (`GET /sources/{id}/projects?search=`), let
 optionally auto-creates the provider webhook per project, creates each package linked by
 `(source_id, provider_id)`, and kicks off the import batch — packages onboard in one step.
 
-```text
-In this Laravel + Filament app (sources table + SourceClient contract + batch sync exist), build
-package onboarding from a source: a Filament page or PackageResource "Import from source" action
-where the user picks a Source, searches its projects live (SourceClient::projects), multi-selects
-projects, and toggles "create webhook". On submit: for each project, firstOrCreate the Package
-(source_id + provider_id + name from project fullName), optionally call createWebhook (surface
-per-project failures as validation errors without aborting the rest), and dispatch the sync batch.
-Show created packages with links. Tests: onboarding two fake projects creates packages and
-dispatches batches (Bus::fake, Http::fake). Run tests.
-```
+**Implemented**: an "Import from source" header action on the package list (visible once a source
+exists). Pick a source, live-search its projects through `SourceClient::projects()` (the select's
+options *are* the provider listing, keyed by web URL — exactly what the `repository` column
+stores), choose the target Composer repository, and toggle auto-sync. On submit each project is
+`firstOrCreate`d by `(repository_id, repository URL)` with the source attached and a name guessed
+from the URL (the first sync replaces it with composer.json's word); already-onboarded projects are
+counted and skipped, a refused project (name collision, webhook failure) lands in a persistent
+warning without aborting the rest, and every new package gets the same webhook registration and
+queued first sync the create wizard arranges. Covered in `tests/Feature/ImportFromSourceTest.php`.
 
 ## 15. Download statistics + dashboard
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -31,7 +31,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 7 | Deploy tokens (machine access, repo/package scoped) | ✅ | 6 |
 | 8 | Personal access tokens (per-user) | ✅ | 6 |
 | 9 | Roles + granular permissions | ✅ | — |
-| 10 | Per-user repository/package access scoping | ❌ | 5, 9 |
+| 10 | Per-user repository/package access scoping | ✅ | 5, 9 |
 | 11 | Provider webhooks (auto-sync on push/tag/delete) | ✅ | — |
 | 12 | Queued batch imports with progress | ✅ | — |
 | 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | 🟡 | — |
@@ -248,17 +248,17 @@ dashboard counts, download stats) funnels through `userScoped()`: public repos �
 granted packages, with `unscoped` permission bypassing. Authentication sources can also auto-grant
 package access (`authentication_source_package`).
 
-```text
-In this Laravel + Filament app (roles already exist), add row-level access for non-admin users:
-1. Pivot migrations package_user (and repository_user if repositories exist) with unique indexes.
-2. Package::visibleToUser(User) query scope: admins/unscoped see all; others see packages in public
-   repositories plus explicitly granted packages/repositories.
-3. Apply the scope in the Filament PackageResource table query, any version listings, and (if
-   present) dashboard counts and download stats.
-4. Filament: on the User form, multi-selects for granted packages/repositories; on the Package
-   form, an inverse users multi-select.
-5. Tests: granted user sees only their packages in the Filament table query; admin sees all. Run tests.
-```
+**Implemented**: `package_user` / `repository_user` pivots; `Package::visibleToUser(User)` returns
+everything for holders of the **`Unscoped:Package`** permission (Packistry's `unscoped`, declared in
+`ShieldPermissionSeeder` since Shield only derives CRUD permissions, and grantable to any role on
+the Roles screen's custom-permissions tab — the super admin holds it like everything else) and
+public repositories ∪ granted packages ∪ granted repositories for everyone else. Applied on
+`PackageResource::getEloquentQuery()` — so the table *and* record pages 404 out-of-reach packages —
+on the release heatmap widget, and, through `visibleTo()`, on the user's personal access tokens:
+a token reaches exactly what its owner can see. Grants are edited as two multi-selects on the User
+form; the inverse users-select on the Package form was skipped deliberately — grants are a
+user-management concern and one place to edit them keeps the story straight. Covered in
+`tests/Feature/UserAccessScopingTest.php`.
 
 ## 11. Provider webhooks (auto-sync on push)
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -11,7 +11,8 @@ independently in package-pipeline (Laravel 13 + Filament v5). Prompts assume the
 - `Package` / `PackageVersion` models, `app/Services/PackageSynchronizer.php`, `app/Services/GitHub/GitHubClient.php`
 - Admin is Filament (`app/Filament/Resources`), no public SPA
 - Migrations `2026_08_03_193140_create_sources_table.php`, `..._193145_create_packages_table.php`,
-  `..._193150_create_package_versions_table.php` define the whole schema (pre-v1: folded in, never altered)
+  `..._193150_create_package_versions_table.php` define the whole schema (pre-v1: folded in, never
+  altered — deployed databases are rebuilt with `migrate:fresh` when the schema moves)
 
 Legend: ✅ already have · 🟡 partial · ❌ missing
 
@@ -82,10 +83,9 @@ sync backfills it. `ComposerRepositoryController::dist()` streams the stored arc
 none is stored — it never reaches for GitHub — and `metadata()` advertises `dist.shasum` so Composer
 verifies downloads. `archives:clean {--dry-run}` prunes files no version references (replaced
 archives get a fresh uuid path rather than an overwrite, so orphans are expected between cleans).
-Two deliberate departures from the prompt: archives live on the existing configurable dist disk
+One deliberate departure from the prompt: archives live on the existing configurable dist disk
 (`filesystems.dists`, `DIST_DISK`) rather than the default disk, since that knob already existed for
-the request-time cache this replaces; and the columns were folded into the create migration per the
-pre-v1 convention above. Covered in `tests/Feature/ComposerRepositoryTest.php`,
+the request-time cache this replaces. Covered in `tests/Feature/ComposerRepositoryTest.php`,
 `tests/Feature/PackageSyncTest.php`, and `tests/Feature/CleanArchivesCommandTest.php`.
 
 ## 3. Version normalization & ordering

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -27,9 +27,9 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 3 | Version normalization & ordering (composer/semver) | ❌ | — |
 | 4 | Artifact upload endpoint (CI pushes a zip) | ❌ | 2 |
 | 5 | Multiple named repositories (`/r/{path}`, public/private) | ✅ | — |
-| 6 | Token authentication for Composer clients (http-basic) | ❌ | — |
+| 6 | Token authentication for Composer clients (http-basic) | ✅ | — |
 | 7 | Deploy tokens (machine access, repo/package scoped) | ❌ | 6 |
-| 8 | Personal access tokens (per-user) | ❌ | 6 |
+| 8 | Personal access tokens (per-user) | ✅ | 6 |
 | 9 | Roles + granular permissions | ✅ | — |
 | 10 | Per-user repository/package access scoping | ❌ | 5, 9 |
 | 11 | Provider webhooks (auto-sync on push/tag/delete) | ✅ | — |
@@ -174,24 +174,18 @@ soft-delete for revocation, and `last_used_at`. Every Composer query runs throug
 which limits visible packages to public repositories plus whatever the token grants. Consumers
 configure `composer config http-basic.<host> token <plain-token>`.
 
-```text
-In this Laravel app, protect the Composer endpoints with token auth:
-1. Migration: access_tokens table (name, token_prefix, token hash sha256, abilities json,
-   last_used_at, expires_at nullable, soft deletes) with a Token model; generate plain tokens once
-   ("pp_" + 40 random chars), store only the hash, expose plaintext only at creation.
-2. Middleware app/Http/Middleware/AuthenticateComposer.php: accept the token from HTTP Basic
-   password (any username) or Authorization: Bearer; look up by hash; reject 401 with a JSON body
-   telling the user to run `composer config http-basic.<host> token <token>`; touch last_used_at
-   (throttled to once a minute). Read endpoints require ability repository:read, upload requires
-   repository:write.
-3. Apply to all composer.* routes. If a repositories table with a `public` flag exists, let
-   unauthenticated requests through for public repositories only.
-4. Filament: TokenResource — create (shows plaintext once in a modal), list with prefix,
-   abilities, last_used_at, revoke (soft delete) action.
-5. Feature tests: 401 without token, 200 with valid basic auth, revoked/expired tokens rejected,
-   write ability enforced on upload. Verify a real `composer install` flow works against the test
-   server if practical. Run tests.
-```
+**Implemented** as specified: `access_tokens` (morphs to its owning principal, name, prefix, sha256
+hash unique, abilities json, last_used_at, expires_at, soft-deletes) with `Token::issue()` returning
+a `NewToken` value object carrying the only copy of the plain text (`pp_` + 40 chars);
+`AuthenticateComposer` middleware accepts the token as the HTTP Basic password (any username) or a
+bearer token, 401s with the exact `composer config http-basic.<host> token <token>` fix (plus a
+`WWW-Authenticate: Basic` challenge so interactive installs prompt), 403s a token without the
+required ability (`TokenAbility` enum: `repository:read` / `repository:write`), and touches
+`last_used_at` at most once a minute without bumping `updated_at`. Reads on a public repository
+pass without a token, but a *presented* credential is always verified — a CI box with a revoked
+token hears about it as a 401 immediately. One departure: there is no admin-wide TokenResource —
+personal tokens are self-service on the user-menu page (item 8), and machine tokens are item 7's
+DeployTokenResource, matching Packistry's own split. Covered in `tests/Feature/ComposerAuthTest.php`.
 
 ## 7. Deploy tokens (machine access)
 
@@ -221,16 +215,14 @@ AuthenticateComposer middleware), add machine deploy tokens with scoped access:
 (name + abilities + optional expiry) from their profile; the token inherits the *user's* repository and
 package access. Listing shows prefix + last used; delete revokes.
 
-```text
-In this Laravel app with Filament admin and Composer token auth, let each admin user issue personal
-access tokens: tokens table rows are polymorphically owned (tokenable) by User or DeployToken if the
-deploy-token feature exists — otherwise add a user_id owner to the existing tokens table. Build a
-Filament page under the user menu ("API Tokens") where a user creates a token (name, read/write
-abilities, optional expiry), sees it in plaintext once, lists their tokens with prefix/last_used_at,
-and revokes them. Composer endpoints authenticate these tokens through the existing middleware and,
-if per-user access scoping exists, restrict visibility to the owner's accessible packages. Feature
-tests for issue/list/revoke and auth flow. Run tests.
-```
+**Implemented**: `access_tokens.tokenable` is polymorphic from the start, so User and DeployToken
+principals share one issuing/hashing/lookup mechanism. The "API tokens" page hangs off the user
+menu (`app/Filament/Pages/ApiTokens.php`) — create with name, read/write abilities and optional
+expiry (valid through the whole chosen day), the plain text rendered once on the page alongside the
+ready-to-paste `composer config http-basic...` line, a listing showing prefix / abilities /
+last-used / expiry, and revoke (soft delete). The page pins every query to the signed-in user, so
+it needs no Shield permission and every panel user gets it. Per-user package visibility is item
+10's concern. Covered in `tests/Feature/ApiTokensPageTest.php`.
 
 ## 9. Roles + granular permissions
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -28,7 +28,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 4 | Artifact upload endpoint (CI pushes a zip) | ❌ | 2 |
 | 5 | Multiple named repositories (`/r/{path}`, public/private) | ✅ | — |
 | 6 | Token authentication for Composer clients (http-basic) | ✅ | — |
-| 7 | Deploy tokens (machine access, repo/package scoped) | ❌ | 6 |
+| 7 | Deploy tokens (machine access, repo/package scoped) | ✅ | 6 |
 | 8 | Personal access tokens (per-user) | ✅ | 6 |
 | 9 | Roles + granular permissions | ✅ | — |
 | 10 | Per-user repository/package access scoping | ❌ | 5, 9 |
@@ -194,20 +194,17 @@ DeployTokenResource, matching Packistry's own split. Covered in `tests/Feature/C
 repositories and/or individual packages (or unscoped = everything); `tokenScoped()` unions those
 grants. They authenticate exactly like user tokens and appear in download stats.
 
-```text
-In this Laravel app (which already has Composer token auth — see the Token model and
-AuthenticateComposer middleware), add machine deploy tokens with scoped access:
-1. Model + migration: deploy_tokens (name, timestamps) with one access token each (reuse the
-   token issuing/hashing mechanics), plus pivots deploy_token_package (and deploy_token_repository
-   if a repositories table exists). An empty scope set means "all packages".
-2. Extend the Composer auth layer: when the authenticated principal is a deploy token, scope every
-   package query (root/search/list/metadata/dist) to its granted packages/repositories. Extract a
-   query scope like Package::visibleTo($principal) used by all endpoints.
-3. Filament: DeployTokenResource — create with multi-select of packages (and repositories),
-   plaintext token shown once, revoke action, last_used_at column.
-4. Feature tests: scoped token sees only granted packages in list/search/metadata and gets 404 on
-   others' dist; unscoped token sees all. Run tests.
-```
+**Implemented** as specified: `deploy_tokens` (name) with `deploy_token_package` /
+`deploy_token_repository` pivots, its access token issued through the shared polymorphic `Token`
+mechanics (deleting the deploy token soft-deletes — revokes — its tokens; the pivots cascade).
+`Package::visibleTo(?Token)` is the single access-control scope every Composer endpoint
+(search/list/metadata/dist) runs through: no token → public repositories only; user token → the
+owner's reach; scoped deploy token → public repositories ∪ granted packages ∪ packages in granted
+repositories; unscoped deploy token → everything. `DeployTokenResource` sits in the Access
+Management group — create shows the plain text once (persistent notification with the ready-made
+`composer config` line) and issues **read** ability only; write is granted deliberately through the
+edit page's "Regenerate token" action, which also serves as rotation (old token dies the moment the
+new one exists). Covered in `tests/Feature/DeployTokenTest.php`.
 
 ## 8. Personal access tokens (per-user)
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -40,7 +40,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 15 | Download statistics + dashboard | ✅ | 2 |
 | 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ✅ | 9 |
 | 17 | Operational CLI commands | ✅ | varies |
-| 18 | Package rebuild & maintenance jobs | 🟡 | 2, 12 |
+| 18 | Package rebuild & maintenance jobs | ✅ | 2, 12 |
 
 Suggested independent tracks: **Core registry** (1–4), **Access control** (5–10), **Sync pipeline**
 (11–14), **Observability/ops** (15, 17, 18), **Auth UX** (16).
@@ -459,15 +459,19 @@ prefix listings show. Syncing was already scriptable as `packages:sync {name?} {
 batch from its source — the recovery hammer for webhook drift, normalizer changes, or corrupted
 archives. Also `renormalize_version_order` migration/job pattern for retroactive fixes.
 
-```text
-In this Laravel + Filament app, add package rebuild: a RebuildPackage service that, for a given
-Package, re-runs a full sync from its source (reusing PackageSynchronizer / the sync batch if
-present), re-downloading archives for versions whose stored file is missing and pruning versions
-that no longer exist upstream; expose it as a Filament table+page action ("Rebuild") with
-confirmation and as artisan package:rebuild {name?} (all packages when omitted, with progress bar).
-Ensure rebuild is idempotent (running twice yields identical rows/files). Feature test: mutate a
-version row and delete an archive file, rebuild, assert both restored. Run tests.
-```
+**Implemented** as a `force` flag threaded through the one sync implementation rather than a second
+import path: `PackageSynchronizer::sync($package, force: true)` makes `changed()` return every ref
+and `import()` skip its `unchanged()` fast-path, so a rebuild re-reads metadata, re-downloads every
+archive and prunes what is gone upstream — while the package keeps serving its current rows, since
+each is replaced in place rather than wiped first. The flag rides the whole queued pipeline too
+(`SyncPackageJob` → `PackageSyncBatch` → `DiscoverVersions` → `ImportVersion`, batches named
+"Rebuild {name}"), so the panel's Rebuild action (table + view page, confirmed, hidden for uploaded
+artifacts) inherits the debounce/uniqueness/overlap rules for free. `RebuildPackage` wraps both
+drivers; `package:rebuild {name?} {--repo=}` sweeps one or all synced packages inline with a
+progress bar. Idempotent by construction — a second rebuild settles on identical rows (archive
+*paths* are fresh uuids by ArchiveStore's design; `archives:clean` collects the replaced files).
+Packistry's `NormalizeVersionOrder` job is subsumed: a rebuild re-normalizes every version. Covered
+in `tests/Feature/PackageRebuildTest.php`.
 
 ---
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -38,7 +38,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 13a | Sources with GitHub App auth + package bridging | ✅ | — |
 | 14 | Source project browser + one-click package onboarding | ❌ | 13 |
 | 15 | Download statistics + dashboard | ✅ | 2 |
-| 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ❌ | 9 |
+| 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ✅ | 9 |
 | 17 | Operational CLI commands | ✅ | varies |
 | 18 | Package rebuild & maintenance jobs | 🟡 | 2, 12 |
 
@@ -426,23 +426,20 @@ domain allowlist), and a `default_user_role` for just-in-time provisioned users.
 active sources; callback matches users by `external_id`/email. Optionally maps an auth source to
 package grants (`authentication_source_package`).
 
-```text
-In this Laravel + Filament v5 app (Filament handles login; users have a role column), add runtime-
-configurable SSO:
-1. composer require laravel/socialite (+ socialiteproviders/manager for generic OIDC).
-2. Model + migration: authentication_sources (name, provider enum [oidc, github, google, gitlab],
-   client_id, client_secret encrypted cast, discovery_url nullable for oidc, active boolean,
-   allow_registration boolean default true, allowed_domains json nullable, default_user_role
-   string default 'user') and users.external_id nullable string with (provider, external_id) unique.
-3. Routes /auth/{source}/redirect and /auth/{source}/callback driving Socialite with credentials
-   loaded from the row (for oidc, resolve endpoints from the discovery document, cached). Callback:
-   match user by external_id, else by email; if none and allow_registration and email domain passes
-   allowed_domains, create the user with default_user_role; then Filament::auth()->login().
-4. Extend the Filament login page to render one "Continue with {name}" button per active source.
-5. Filament resource for authentication_sources (admins only).
-6. Tests with Socialite mocked: existing-user login, JIT registration, domain rejection,
-   registration disabled. Run tests.
-```
+**Implemented** with `laravel/socialite` alone — Socialite ships GitHub/Google/GitLab drivers, and
+generic OIDC is a slim in-house provider (`app/Auth/OidcProvider.php`) whose endpoints come from
+the issuer's discovery document (fetched by `SsoProviderFactory`, cached an hour), so no
+socialiteproviders/manager. `authentication_sources` rows carry provider, OAuth client (secret
+encrypted), discovery URL, active, allow_registration, allowed_domains, and `default_role` — a
+select of the *actual* Shield roles rather than Packistry's hardcoded 'user', since roles here are
+runtime-shaped. The identity binding is `(authentication_source_id, external_id)` unique on users;
+the callback matches by binding, then by email (binding the identity only when the account is
+unbound — one provider must never quietly take over another's users), then JIT-registers when
+allowed and the domain passes, marking the email verified because the IdP vouched for it. A matched
+account with no role is refused with an explanation rather than a Filament 403. The login page
+gains "Continue with {name}" buttons per active source through a `AUTH_LOGIN_FORM_AFTER` render
+hook — the stock login page stays stock — and a Login providers resource sits in Access Management.
+Covered in `tests/Feature/SsoTest.php` with the provider factory swapped out.
 
 ## 17. Operational CLI commands
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -26,7 +26,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 2 | Local archive storage + dist serving (zips, sha1, cleanup) | ✅ | — |
 | 3 | Version normalization & ordering (composer/semver) | ❌ | — |
 | 4 | Artifact upload endpoint (CI pushes a zip) | ❌ | 2 |
-| 5 | Multiple named repositories (`/r/{path}`, public/private) | ❌ | — |
+| 5 | Multiple named repositories (`/r/{path}`, public/private) | ✅ | — |
 | 6 | Token authentication for Composer clients (http-basic) | ❌ | — |
 | 7 | Deploy tokens (machine access, repo/package scoped) | ❌ | 6 |
 | 8 | Personal access tokens (per-user) | ❌ | 6 |
@@ -150,22 +150,20 @@ root (default repository, `path = null`) and under `/r/{path}`. Packages belong 
 repository; archives are stored under the repository's path. Public repositories skip auth for reads;
 private ones require a token.
 
-```text
-In this Laravel app, introduce multiple Composer repositories:
-1. Model + migration: repositories table (name unique, path unique nullable slug, description
-   nullable, public boolean default false). Add repository_id FK on packages (nullable during
-   migration; backfill by creating a default repository with path null and assigning all packages
-   to it, then make it non-nullable). Package name uniqueness becomes unique per (repository_id, name).
-2. Routing: extract the composer routes in routes/web.php into a reusable group and mount them both
-   at root (resolving the default repository) and under prefix /r/{repositoryPath}. Resolve the
-   Repository in ComposerRepositoryController via a shared method that 404s on unknown path. All
-   queries (root/search/list/metadata/dist) must scope by the resolved repository, and metadata/list
-   URLs must be generated with the repository prefix.
-3. Filament: a RepositoryResource (list/create/edit; fields name, path, description, public toggle)
-   and a repository select on the existing Package resource form + table filter.
-4. Feature tests: same package name in two repositories resolves independently at / and /r/{path};
-   unknown path 404s. Run tests.
-```
+**Implemented**: a `repositories` table (name unique, path unique nullable slug, description,
+`public` boolean) with the FK folded into the packages create migration (pre-v1); package names and
+VCS URLs are unique per `(repository_id, …)`. The Composer routes are one group mounted twice — at
+the root and under `/r/{path}` — with `ResolveComposerRepository` middleware resolving which
+repository a request addresses (404 on unknown paths) and every controller query scoped to it;
+metadata/search/list/dist URLs are generated inside the resolved mount, and a package's install
+commands point at it (with the path suffixed onto the composer.json config key so two repositories
+never fight over one entry). Departures from Packistry: the model relation is `composerRepository()`
+because `Package::$repository` already means the VCS URL; and the default repository (path null,
+served at the root) is system-owned — created lazily by `Repository::default()`, seeded for fresh
+installs, its path not editable and the row not deletable — and is created **public** so existing
+deployments keep serving openly, while admin-created repositories start **private**. `public` is
+enforced by token auth (item 6). Covered in `tests/Feature/ComposerRepositoryScopingTest.php` and
+`tests/Feature/RepositoryResourceTest.php`.
 
 ## 6. Token authentication for Composer clients
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -24,7 +24,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 |---|---------|--------|------------|
 | 1 | Composer v2 API completeness (search.json, list.json, stable/dev split) | ✅ | — |
 | 2 | Local archive storage + dist serving (zips, sha1, cleanup) | ✅ | — |
-| 3 | Version normalization & ordering (composer/semver) | ❌ | — |
+| 3 | Version normalization & ordering (composer/semver) | ✅ | — |
 | 4 | Artifact upload endpoint (CI pushes a zip) | ✅ | 2 |
 | 5 | Multiple named repositories (`/r/{path}`, public/private) | ✅ | — |
 | 6 | Token authentication for Composer clients (http-basic) | ✅ | — |
@@ -97,24 +97,18 @@ pre-release suffixes like `-beta.2` → `1.2.3-beta2`), maps branches to dev ver
 (e.g. which version's composer.json updates the package name/description/type) compare `order`, and
 `/p2` responses sort by it. A `NormalizeVersionOrder` job re-normalizes after algorithm changes.
 
-**Gap**: package-pipeline sorts with `orderByDesc('version')` (string sort — `1.10.0` < `1.9.0`) and
-has ad-hoc tag/branch mapping in `PackageSynchronizer`.
-
-```text
-In this Laravel app, add proper Composer version normalization:
-1. composer require composer/semver.
-2. Create app/Support/VersionNormalizer.php with: version(string): string (strip leading v, normalize
-   pre-release suffixes; pass through dev-* and *-dev), devVersion(string branch): string
-   (main -> dev-main, 2.x -> 2.x-dev, numeric 2 -> 2.x-dev), and order(string): string using
-   Composer\Semver\VersionParser::normalize (dev-* returns as-is).
-3. Migration: add `order` (string, indexed) to package_versions; backfill existing rows in the
-   migration using the normalizer.
-4. Use it in app/Services/PackageSynchronizer.php when creating versions, and replace
-   orderByDesc('version') in ComposerRepositoryController with orderByDesc('order') for stable
-   versions (dev versions keep name ordering).
-5. Unit-test the normalizer against edge cases: v1.2.3, 1.2, 1.2.3.4, 1.0.0-beta.2, RC tags,
-   branches main/develop/2.x/2, and verify 1.10.0 sorts above 1.9.0. Run tests.
-```
+**Implemented**: `app/Support/VersionNormalizer.php` with `version()` (v1.2.3 → 1.2.3,
+1.0.0-beta.2 → 1.0.0-beta2, dev versions pass through), `devVersion()` (main → dev-main,
+2 → 2.x-dev, 2.0 → 2.0.x-dev, 2.x → 2.x-dev), and `order()`. One refinement over the prompt:
+`VersionParser::normalize()` output alone is *not* lexically sortable (`'1.10.0.0' < '1.9.0.0'` as
+strings), so `order()` builds on the parser's canonical four-segment form but zero-pads every
+segment and maps the stability suffix to a weighted tail (dev < alpha < beta < RC < stable <
+patch, pre-release numbers padded too) — an `order by` in any database then ranks 1.10.0 above
+1.9.0 and 1.0.0 above its own RCs. The indexed `order` column is folded into the create migration
+(pre-v1; a rebuild re-normalizes everything, standing in for Packistry's `NormalizeVersionOrder`
+job). Tags are now *stored* under their normalized spelling, the synchronizer and the upload
+service both stamp `order`, and `/p2` sorts releases by it while dev versions keep name order.
+Covered in `tests/Unit/VersionNormalizerTest.php` and `tests/Feature/VersionOrderingTest.php`.
 
 ## 4. Artifact upload endpoint (push from CI)
 

--- a/docs/packistry-feature-analysis.md
+++ b/docs/packistry-feature-analysis.md
@@ -37,7 +37,7 @@ Legend: ✅ already have · 🟡 partial · ❌ missing
 | 13 | Multi-provider source abstraction (GitLab, Gitea, Bitbucket) | 🟡 | — |
 | 13a | Sources with GitHub App auth + package bridging | ✅ | — |
 | 14 | Source project browser + one-click package onboarding | ❌ | 13 |
-| 15 | Download statistics + dashboard | ❌ | 2 |
+| 15 | Download statistics + dashboard | ✅ | 2 |
 | 16 | SSO / authentication sources (OIDC, GitHub, Google…) | ❌ | 9 |
 | 17 | Operational CLI commands | 🟡 | varies |
 | 18 | Package rebuild & maintenance jobs | 🟡 | 2, 12 |
@@ -403,19 +403,19 @@ a 90-day per-day chart; denormalized `total_downloads` on packages/versions feed
 lists. The dashboard shows permission-gated counts (packages, repos, users, tokens, sources) plus the
 chart.
 
-```text
-In this Laravel + Filament app, add download analytics:
-1. Migration: downloads table (package_id FK, package_version_id FK nullable, ip string nullable,
-   token identifier nullable, created_at indexed) + total_downloads unsignedBigInteger default 0 on
-   packages and package_versions.
-2. Fire an event from ComposerRepositoryController::dist() after a successful archive response; a
-   queued listener inserts the Download row and increments both counters.
-3. Artisan command downloads:recalculate to rebuild counters from the table.
-4. Filament dashboard widgets: StatsOverview (package count, version count, downloads last 30 days)
-   and a per-day downloads chart for the last 90 days (single grouped query on created_at date).
-   Add a total_downloads column to the PackageResource table, sortable.
-5. Tests: downloading dist creates a row and bumps counters; chart query groups correctly. Run tests.
-```
+**Implemented** as specified: a `downloads` table (package FK, nullable version FK *plus* the
+version string so history survives pruned branches, ip, the fetching token's prefix, indexed
+created_at) and `total_downloads` counters folded into the packages/package_versions create
+migrations (pre-v1). `dist()` dispatches `PackageDownloaded` — scalars, not models, so the queued
+`RecordDownload` listener still counts a download whose version row was pruned before the job ran —
+only after every 404 check has passed; the listener writes the row and bumps both counters.
+`downloads:recalculate` rebuilds the counters with two correlated-subquery updates (portable across
+SQLite/MySQL/Postgres). Dashboard: `RegistryStatsOverview` (packages, versions, downloads over 30
+days / all time) and a 90-day per-day `DownloadsChart`, both scoped through `visibleToUser()` like
+the release heatmap — a granted user reads a dashboard about *their* packages; `search.json` serves
+the real counter, and the package table gains a sortable Downloads column. Grouping happens in PHP
+(same reasoning as the heatmap: date truncation has no portable SQL spelling). Covered in
+`tests/Feature/DownloadStatsTest.php`.
 
 ## 16. SSO / authentication sources
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1739 @@
+{
+    "name": "package-pipeline",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "devDependencies": {
+                "@tailwindcss/vite": "^4.0.0",
+                "concurrently": "^10.0.3",
+                "laravel-vite-plugin": "^3.1",
+                "tailwindcss": "^4.0.0",
+                "vite": "^8.0.0"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/remapping": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.143.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+            "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+            "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+            "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+            "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+            "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+            "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+            "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+            "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+            "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+            "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+            "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+            "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+            "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+            "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@tailwindcss/node": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+            "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "enhanced-resolve": "^5.24.1",
+                "jiti": "^2.7.0",
+                "lightningcss": "1.32.0",
+                "magic-string": "^0.30.21",
+                "source-map-js": "^1.2.1",
+                "tailwindcss": "4.3.3"
+            }
+        },
+        "node_modules/@tailwindcss/oxide": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+            "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "optionalDependencies": {
+                "@tailwindcss/oxide-android-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-x64": "4.3.3",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-android-arm64": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+            "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-arm64": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+            "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-darwin-x64": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+            "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-freebsd-x64": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+            "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+            "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+            "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+            "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+            "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+            "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+            "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+            "bundleDependencies": [
+                "@napi-rs/wasm-runtime",
+                "@emnapi/core",
+                "@emnapi/runtime",
+                "@tybys/wasm-util",
+                "@emnapi/wasi-threads",
+                "tslib"
+            ],
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.11.1",
+                "@emnapi/runtime": "^1.11.1",
+                "@emnapi/wasi-threads": "^1.2.2",
+                "@napi-rs/wasm-runtime": "^1.1.4",
+                "@tybys/wasm-util": "^0.10.2",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+            "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+            "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@tailwindcss/vite": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+            "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "tailwindcss": "4.3.3"
+            },
+            "peerDependencies": {
+                "vite": "^5.2.0 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+            "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^7.2.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/concurrently": {
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+            "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "5.6.2",
+                "rxjs": "7.8.2",
+                "shell-quote": "1.9.0",
+                "supports-color": "10.2.2",
+                "tree-kill": "1.2.2",
+                "yargs": "18.0.0"
+            },
+            "bin": {
+                "conc": "dist/bin/index.js",
+                "concurrently": "dist/bin/index.js"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+            }
+        },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/enhanced-resolve": {
+            "version": "5.24.5",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+            "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.3.3"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jiti": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
+            }
+        },
+        "node_modules/laravel-vite-plugin": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.3.tgz",
+            "integrity": "sha512-cI5Anw4QHY+UzvZczFaj+j8NhwT2FtyEN8aqS/hOdt6DpEFBsn6x3GENxALem3cc+TsGvd9MacneimEvShvKMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "tinyglobby": "^0.2.12",
+                "vite-plugin-full-reload": "^1.1.0"
+            },
+            "bin": {
+                "clean-orphaned-assets": "bin/clean.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "fontaine": "^0.8.0",
+                "vite": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "fontaine": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/picocolors": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/postcss": {
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "nanoid": "^3.3.17",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            }
+        },
+        "node_modules/rolldown": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+            "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.143.0",
+                "@rolldown/pluginutils": "^1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.2.3",
+                "@rolldown/binding-darwin-arm64": "1.2.3",
+                "@rolldown/binding-darwin-x64": "1.2.3",
+                "@rolldown/binding-freebsd-x64": "1.2.3",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+                "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+                "@rolldown/binding-linux-arm64-musl": "1.2.3",
+                "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+                "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-gnu": "1.2.3",
+                "@rolldown/binding-linux-x64-musl": "1.2.3",
+                "@rolldown/binding-openharmony-arm64": "1.2.3",
+                "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+                "@rolldown/binding-win32-x64-msvc": "1.2.3"
+            }
+        },
+        "node_modules/rxjs": {
+            "version": "7.8.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+            "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+            "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/source-map-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+            "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/tailwindcss": {
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+            "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tapable": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+            "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD"
+        },
+        "node_modules/vite": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+            "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.33.0",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.25",
+                "rolldown": "~1.2.1",
+                "tinyglobby": "^0.2.17"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.4.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-full-reload": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-full-reload/-/vite-plugin-full-reload-1.2.0.tgz",
+            "integrity": "sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picocolors": "^1.0.0",
+                "picomatch": "^2.3.1"
+            }
+        },
+        "node_modules/vite-plugin-full-reload/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-android-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "18.0.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+            "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^9.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "string-width": "^7.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^22.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        }
+    }
+}

--- a/resources/views/filament/auth/sso-buttons.blade.php
+++ b/resources/views/filament/auth/sso-buttons.blade.php
@@ -1,0 +1,27 @@
+@php
+    $ssoSources = \App\Models\AuthenticationSource::query()
+        ->where('active', true)
+        ->orderBy('name')
+        ->get();
+@endphp
+
+@if (session('sso_error'))
+    <p class="text-center text-sm text-danger-600 dark:text-danger-400">
+        {{ session('sso_error') }}
+    </p>
+@endif
+
+@if ($ssoSources->isNotEmpty())
+    <div class="grid gap-2">
+        @foreach ($ssoSources as $ssoSource)
+            <x-filament::button
+                tag="a"
+                color="gray"
+                outlined
+                href="{{ route('sso.redirect', $ssoSource) }}"
+            >
+                Continue with {{ $ssoSource->name }}
+            </x-filament::button>
+        @endforeach
+    </div>
+@endif

--- a/resources/views/filament/pages/api-tokens.blade.php
+++ b/resources/views/filament/pages/api-tokens.blade.php
@@ -1,0 +1,14 @@
+<x-filament-panels::page>
+    @if ($plainTextToken)
+        <x-filament::section
+            icon="heroicon-o-key"
+            icon-color="success"
+            heading="Copy your new token now"
+            description="This is the only time it is shown. Configure Composer on the consuming machine with:"
+        >
+            <pre class="overflow-x-auto rounded-lg bg-gray-950 p-4 text-sm text-gray-100"><code>composer config http-basic.{{ request()->getHost() }} token {{ $plainTextToken }}</code></pre>
+        </x-filament::section>
+    @endif
+
+    {{ $this->table }}
+</x-filament-panels::page>

--- a/resources/views/filament/resources/packages/widgets/package-sync-progress.blade.php
+++ b/resources/views/filament/resources/packages/widgets/package-sync-progress.blade.php
@@ -1,0 +1,80 @@
+{{--
+    Styled with a scoped <style> block and Filament's colour custom properties
+    rather than utility classes, for the same reason as the release heatmap:
+    app-level Tailwind never reaches the panel's pre-built stylesheet.
+
+    The poll is on the widget itself so the panel notices a sync starting or
+    finishing without anyone reloading the page.
+--}}
+<x-filament-widgets::widget class="fi-wi-package-sync-progress">
+    <div wire:poll.5s>
+        @if ($running)
+            <x-filament::section>
+                <style>
+                    .pp-sync-progress-row {
+                        display: flex;
+                        align-items: baseline;
+                        justify-content: space-between;
+                        gap: 1rem;
+                    }
+
+                    .pp-sync-progress-title {
+                        font-size: 0.875rem;
+                        font-weight: 600;
+                    }
+
+                    .pp-sync-progress-detail {
+                        font-size: 0.875rem;
+                        color: var(--gray-500);
+                    }
+
+                    .dark .pp-sync-progress-detail {
+                        color: var(--gray-400);
+                    }
+
+                    .pp-sync-progress-failed {
+                        color: var(--danger-600);
+                    }
+
+                    .pp-sync-progress-track {
+                        margin-top: 0.75rem;
+                        height: 0.5rem;
+                        border-radius: 9999px;
+                        overflow: hidden;
+                        background-color: var(--gray-100);
+                    }
+
+                    .dark .pp-sync-progress-track {
+                        background-color: rgba(255, 255, 255, 0.1);
+                    }
+
+                    .pp-sync-progress-bar {
+                        height: 100%;
+                        border-radius: 9999px;
+                        background-color: var(--primary-600);
+                        transition: width 0.5s ease;
+                    }
+                </style>
+
+                <div class="pp-sync-progress-row">
+                    <span class="pp-sync-progress-title">Sync in progress</span>
+
+                    <span class="pp-sync-progress-detail">
+                        @if ($discovering)
+                            Fetching the list of versions from the repository…
+                        @else
+                            {{ $imported }} of {{ $total }} {{ str('version')->plural($total) }} imported
+                            @if ($failed > 0)
+                                · <span class="pp-sync-progress-failed">{{ $failed }} failed</span>
+                            @endif
+                        @endif
+                    </span>
+                </div>
+
+                <div class="pp-sync-progress-track">
+                    <div class="pp-sync-progress-bar" style="width: {{ $progress }}%"></div>
+                </div>
+            </x-filament::section>
+        @endif
+    </div>
+</x-filament-widgets::widget>

--- a/resources/views/filament/widgets/registry-totals.blade.php
+++ b/resources/views/filament/widgets/registry-totals.blade.php
@@ -1,0 +1,118 @@
+{{--
+    Styled with a scoped <style> block and Filament's colour custom properties
+    for the same reason as the release heatmap: the panel ships Filament's
+    pre-built stylesheet, so app-level Tailwind never reaches this view.
+--}}
+<x-filament-widgets::widget class="fi-wi-registry-totals">
+    <x-filament::section heading="Registry totals">
+        <x-slot name="afterHeader">
+            <x-filament::icon icon="heroicon-o-squares-2x2" class="pp-quad-icon" />
+        </x-slot>
+
+        <style>
+            .fi-wi-registry-totals {
+                --pp-divider: var(--gray-200);
+                --pp-label-color: var(--gray-500);
+            }
+
+            .dark .fi-wi-registry-totals {
+                --pp-divider: var(--gray-800);
+                --pp-label-color: var(--gray-400);
+            }
+
+            .pp-quad-icon {
+                width: 1.25rem;
+                height: 1.25rem;
+                color: var(--pp-label-color);
+            }
+
+            .pp-quad-grid {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                margin: 0;
+            }
+
+            .pp-quad-cell {
+                display: grid;
+                gap: 0.375rem;
+                justify-items: center;
+                padding: 1.25rem 1rem;
+                text-align: center;
+            }
+
+            .pp-quad-cell:nth-child(odd) {
+                border-inline-end: 1px solid var(--pp-divider);
+            }
+
+            .pp-quad-cell:nth-child(-n + 2) {
+                border-block-end: 1px solid var(--pp-divider);
+            }
+
+            .pp-quad-label {
+                font-size: 0.875rem;
+                line-height: 1.25rem;
+                color: var(--pp-label-color);
+            }
+
+            .pp-quad-value {
+                margin: 0;
+                font-size: 1.875rem;
+                line-height: 2.25rem;
+                font-weight: 600;
+            }
+
+            .pp-quad-value[data-tone='info'] { color: var(--info-600); }
+            .pp-quad-value[data-tone='success'] { color: var(--success-600); }
+
+            /* The 600 steps vanish against a dark surface; step up to the
+               shades that keep large-text contrast there. */
+            .dark .pp-quad-value[data-tone='info'] { color: var(--info-400); }
+            .dark .pp-quad-value[data-tone='success'] { color: var(--success-400); }
+
+            .pp-quad-updated {
+                margin: 0.25rem 0 0;
+                padding-top: 0.75rem;
+                border-top: 1px solid var(--pp-divider);
+                font-size: 0.75rem;
+                line-height: 1rem;
+                color: var(--pp-label-color);
+            }
+        </style>
+
+        <div
+            class="pp-quad"
+            @if ($pollingInterval)
+                wire:poll.{{ $pollingInterval }}
+            @endif
+        >
+            <dl class="pp-quad-grid">
+                @foreach ($stats as $stat)
+                    <div class="pp-quad-cell">
+                        <dt class="pp-quad-label">{{ $stat['label'] }}</dt>
+                        <dd class="pp-quad-value" data-tone="{{ $stat['tone'] }}">{{ $stat['value'] }}</dd>
+                    </div>
+                @endforeach
+            </dl>
+
+            {{--
+                Counts up from the last render. The timestamp lives in an
+                attribute rather than Alpine state because each poll morphs the
+                attribute in place, restarting the counter — Alpine state would
+                survive the morph and keep counting from the first page load.
+            --}}
+            <p
+                class="pp-quad-updated"
+                data-rendered-at="{{ now()->getTimestampMs() }}"
+                x-data="{ tick: 0 }"
+                x-init="setInterval(() => tick++, 1000)"
+                x-text="(() => {
+                    tick;
+                    const seconds = Math.max(0, Math.floor((Date.now() - Number($el.dataset.renderedAt)) / 1000));
+                    if (seconds < 60) return `Updated ${seconds} ${seconds === 1 ? 'second' : 'seconds'} ago`;
+                    const minutes = Math.floor(seconds / 60);
+                    return `Updated ${minutes} ${minutes === 1 ? 'minute' : 'minutes'} ago`;
+                })()"
+            >Updated 0 seconds ago</p>
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ComposerRepositoryController;
 use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\SourceConnectionController;
+use App\Http\Controllers\SsoController;
 use App\Http\Middleware\AuthenticateComposer;
 use App\Http\Middleware\ResolveComposerRepository;
 use Illuminate\Support\Facades\Route;
@@ -67,6 +68,14 @@ Route::post('/incoming/github', [GitHubWebhookController::class, 'app'])
     ->name('webhooks.github');
 Route::post('/incoming/github/{package}', [GitHubWebhookController::class, 'repository'])
     ->name('webhooks.github.package');
+
+// The SSO round trip for runtime-configured login providers. The login page
+// renders one button per active authentication source; the callback signs
+// the resolved user into the Filament panel.
+Route::get('/auth/{source}/redirect', [SsoController::class, 'redirect'])
+    ->name('sso.redirect');
+Route::get('/auth/{source}/callback', [SsoController::class, 'callback'])
+    ->name('sso.callback');
 
 // The GitHub App install handshake for connecting a source. Both legs are
 // admin-only: the callback attaches an installation to a source, so it must

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ComposerRepositoryController;
 use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\SourceConnectionController;
+use App\Http\Middleware\AuthenticateComposer;
 use App\Http\Middleware\ResolveComposerRepository;
 use Illuminate\Support\Facades\Route;
 
@@ -33,11 +34,11 @@ $composer = function (): void {
         ->name('dist');
 };
 
-Route::middleware(ResolveComposerRepository::class)
+Route::middleware([ResolveComposerRepository::class, AuthenticateComposer::class])
     ->name('composer.')
     ->group($composer);
 
-Route::middleware(ResolveComposerRepository::class)
+Route::middleware([ResolveComposerRepository::class, AuthenticateComposer::class])
     ->prefix('r/{repositoryPath}')
     ->where(['repositoryPath' => '[a-z0-9-]+'])
     ->name('composer.repository.')

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ComposerRepositoryController;
 use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\SourceConnectionController;
+use App\Http\Middleware\ResolveComposerRepository;
 use Illuminate\Support\Facades\Route;
 
 // The app is administered entirely through Filament, so the root URL lands on
@@ -12,18 +13,35 @@ Route::redirect('/', '/admin/login')->name('home');
 
 // The Composer v2 repository API. A consuming project opts in with:
 //   composer config repositories.private composer <this-app's-url>
-Route::get('/packages.json', [ComposerRepositoryController::class, 'root'])
-    ->name('composer.root');
-Route::get('/search.json', [ComposerRepositoryController::class, 'search'])
-    ->name('composer.search');
-Route::get('/list.json', [ComposerRepositoryController::class, 'list'])
-    ->name('composer.list');
-Route::get('/p2/{vendor}/{package}.json', [ComposerRepositoryController::class, 'metadata'])
-    // Greedy segment so package names containing dots still match.
-    ->where('package', '[^/]+')
-    ->name('composer.metadata');
-Route::get('/dist/{vendor}/{package}/{reference}.zip', [ComposerRepositoryController::class, 'dist'])
-    ->name('composer.dist');
+//
+// The same endpoints are mounted twice: at the root, serving the default
+// repository, and under /r/{path} for every named repository. The middleware
+// resolves which repository a request addresses; the controller scopes every
+// query to it.
+$composer = function (): void {
+    Route::get('/packages.json', [ComposerRepositoryController::class, 'root'])
+        ->name('root');
+    Route::get('/search.json', [ComposerRepositoryController::class, 'search'])
+        ->name('search');
+    Route::get('/list.json', [ComposerRepositoryController::class, 'list'])
+        ->name('list');
+    Route::get('/p2/{vendor}/{package}.json', [ComposerRepositoryController::class, 'metadata'])
+        // Greedy segment so package names containing dots still match.
+        ->where('package', '[^/]+')
+        ->name('metadata');
+    Route::get('/dist/{vendor}/{package}/{reference}.zip', [ComposerRepositoryController::class, 'dist'])
+        ->name('dist');
+};
+
+Route::middleware(ResolveComposerRepository::class)
+    ->name('composer.')
+    ->group($composer);
+
+Route::middleware(ResolveComposerRepository::class)
+    ->prefix('r/{repositoryPath}')
+    ->where(['repositoryPath' => '[a-z0-9-]+'])
+    ->name('composer.repository.')
+    ->group($composer);
 
 // Incoming provider deliveries, which sync a package as soon as a tag or
 // branch moves. Both are unauthenticated by design and verify GitHub's

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,25 +20,36 @@ Route::redirect('/', '/admin/login')->name('home');
 // resolves which repository a request addresses; the controller scopes every
 // query to it.
 $composer = function (): void {
-    Route::get('/packages.json', [ComposerRepositoryController::class, 'root'])
-        ->name('root');
-    Route::get('/search.json', [ComposerRepositoryController::class, 'search'])
-        ->name('search');
-    Route::get('/list.json', [ComposerRepositoryController::class, 'list'])
-        ->name('list');
-    Route::get('/p2/{vendor}/{package}.json', [ComposerRepositoryController::class, 'metadata'])
-        // Greedy segment so package names containing dots still match.
+    Route::middleware(AuthenticateComposer::class)->group(function (): void {
+        Route::get('/packages.json', [ComposerRepositoryController::class, 'root'])
+            ->name('root');
+        Route::get('/search.json', [ComposerRepositoryController::class, 'search'])
+            ->name('search');
+        Route::get('/list.json', [ComposerRepositoryController::class, 'list'])
+            ->name('list');
+        Route::get('/p2/{vendor}/{package}.json', [ComposerRepositoryController::class, 'metadata'])
+            // Greedy segment so package names containing dots still match.
+            ->where('package', '[^/]+')
+            ->name('metadata');
+        Route::get('/dist/{vendor}/{package}/{reference}.zip', [ComposerRepositoryController::class, 'dist'])
+            ->name('dist');
+    });
+
+    // CI publishing a built artifact: multipart `file` (zip) and optional
+    // `version`. Under its own /upload segment rather than Packistry's bare
+    // POST /{vendor}/{package}, which would collide with the /incoming
+    // webhook paths and force a wildcard CSRF exemption.
+    Route::post('/upload/{vendor}/{package}', [ComposerRepositoryController::class, 'upload'])
         ->where('package', '[^/]+')
-        ->name('metadata');
-    Route::get('/dist/{vendor}/{package}/{reference}.zip', [ComposerRepositoryController::class, 'dist'])
-        ->name('dist');
+        ->middleware(AuthenticateComposer::class.':write')
+        ->name('upload');
 };
 
-Route::middleware([ResolveComposerRepository::class, AuthenticateComposer::class])
+Route::middleware(ResolveComposerRepository::class)
     ->name('composer.')
     ->group($composer);
 
-Route::middleware([ResolveComposerRepository::class, AuthenticateComposer::class])
+Route::middleware(ResolveComposerRepository::class)
     ->prefix('r/{repositoryPath}')
     ->where(['repositoryPath' => '[a-z0-9-]+'])
     ->name('composer.repository.')

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ComposerRepositoryController;
 use App\Http\Controllers\GitHubWebhookController;
+use App\Http\Controllers\GitLabWebhookController;
 use App\Http\Controllers\SourceConnectionController;
 use App\Http\Controllers\SsoController;
 use App\Http\Middleware\AuthenticateComposer;
@@ -68,6 +69,12 @@ Route::post('/incoming/github', [GitHubWebhookController::class, 'app'])
     ->name('webhooks.github');
 Route::post('/incoming/github/{package}', [GitHubWebhookController::class, 'repository'])
     ->name('webhooks.github.package');
+
+// GitLab's per-repository leg. GitLab has no account-wide webhook to mirror
+// the GitHub App's, and it authenticates by replaying the hook's secret in a
+// header rather than signing the body.
+Route::post('/incoming/gitlab/{package}', [GitLabWebhookController::class, 'repository'])
+    ->name('webhooks.gitlab.package');
 
 // The SSO round trip for runtime-configured login providers. The login page
 // renders one button per active authentication source; the callback signs

--- a/tests/Feature/ApiTokensPageTest.php
+++ b/tests/Feature/ApiTokensPageTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Pages\ApiTokens;
+use App\Models\Token;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ApiTokensPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->superAdmin()->create();
+
+        $this->actingAs($this->user);
+    }
+
+    public function test_a_token_is_created_and_its_plain_text_shown_once(): void
+    {
+        $component = Livewire::test(ApiTokens::class)
+            ->callAction('create', [
+                'name' => 'CI deploy',
+                'abilities' => ['repository:read'],
+            ])
+            ->assertHasNoActionErrors();
+
+        $plain = $component->get('plainTextToken');
+
+        $this->assertIsString($plain);
+        $this->assertStringStartsWith('pp_', $plain);
+        $component->assertSee($plain);
+
+        $token = Token::findByPlainText($plain);
+
+        $this->assertNotNull($token);
+        $this->assertSame('CI deploy', $token->name);
+        $this->assertSame(['repository:read'], $token->abilities);
+        $this->assertTrue($token->tokenable->is($this->user));
+
+        // Only the hash is stored.
+        $this->assertNotSame($plain, $token->token);
+        $this->assertSame(substr($plain, 0, 8), $token->token_prefix);
+    }
+
+    public function test_the_table_lists_only_the_users_own_tokens(): void
+    {
+        $mine = Token::factory()->for($this->user, 'tokenable')->create();
+        $theirs = Token::factory()->create();
+
+        Livewire::test(ApiTokens::class)
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$theirs]);
+    }
+
+    public function test_revoking_a_token_soft_deletes_it_and_stops_authentication(): void
+    {
+        $plain = 'pp_'.str_repeat('x', 40);
+
+        $token = Token::factory()->for($this->user, 'tokenable')->create([
+            'token' => hash('sha256', $plain),
+        ]);
+
+        $this->assertNotNull(Token::findByPlainText($plain));
+
+        Livewire::test(ApiTokens::class)
+            ->callAction(TestAction::make('delete')->table($token));
+
+        $this->assertSoftDeleted('access_tokens', ['id' => $token->id]);
+        $this->assertNull(Token::findByPlainText($plain));
+    }
+}

--- a/tests/Feature/ArtifactUploadTest.php
+++ b/tests/Feature/ArtifactUploadTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TokenAbility;
+use App\Models\DeployToken;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Token;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use ZipArchive;
+
+/**
+ * POST /upload/{vendor}/{package}: CI publishing a built zip, no VCS source
+ * behind it. The zip's composer.json is the metadata, the zip itself the
+ * served archive.
+ */
+class ArtifactUploadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.dists' => 's3']);
+        Storage::fake('s3');
+    }
+
+    /**
+     * @param  array<string, mixed>  $composerJson
+     */
+    private function makeZip(array $composerJson, string $folder = 'build-output/'): UploadedFile
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'upload-zip-');
+
+        $zip = new ZipArchive;
+        $zip->open($path, ZipArchive::OVERWRITE);
+        $zip->addFromString($folder.'composer.json', (string) json_encode($composerJson));
+        $zip->addFromString($folder.'src/Widget.php', '<?php // built');
+        $zip->close();
+
+        return new UploadedFile($path, 'package.zip', 'application/zip', test: true);
+    }
+
+    private function writeToken(): string
+    {
+        return Token::issue(
+            User::factory()->superAdmin()->create(),
+            'ci',
+            [TokenAbility::RepositoryRead, TokenAbility::RepositoryWrite],
+        )->plainText;
+    }
+
+    public function test_uploading_requires_authentication_even_on_a_public_repository(): void
+    {
+        $this->post('/upload/acme/widgets', ['file' => $this->makeZip(['name' => 'acme/widgets'])])
+            ->assertUnauthorized();
+    }
+
+    public function test_uploading_requires_the_write_ability(): void
+    {
+        $read = Token::issue(User::factory()->superAdmin()->create(), 'ro', [TokenAbility::RepositoryRead]);
+
+        $this->withToken($read->plainText)
+            ->post('/upload/acme/widgets', ['file' => $this->makeZip(['name' => 'acme/widgets'])])
+            ->assertForbidden();
+    }
+
+    public function test_an_upload_creates_the_package_its_version_and_the_served_archive(): void
+    {
+        $zip = $this->makeZip([
+            'name' => 'acme/widgets',
+            'description' => 'Built by CI.',
+            'type' => 'library',
+            'version' => '1.2.3',
+            'require' => ['php' => '^8.3'],
+            'scripts' => ['post-install-cmd' => 'echo done'],
+            // Not part of the curated subset; must not be served.
+            'repositories' => [['type' => 'vcs', 'url' => 'https://internal.example']],
+        ]);
+
+        $expectedShasum = sha1_file($zip->getRealPath());
+
+        $this->withToken($this->writeToken())
+            ->post('/upload/acme/widgets', ['file' => $zip])
+            ->assertCreated()
+            ->assertJson(['name' => 'acme/widgets', 'version' => '1.2.3', 'shasum' => $expectedShasum]);
+
+        $package = Package::query()->where('name', 'acme/widgets')->sole();
+
+        $this->assertNull($package->repository);
+        $this->assertFalse($package->webhook_enabled);
+        $this->assertSame('Built by CI.', $package->description);
+        $this->assertSame('1.2.3', $package->latest_version);
+        $this->assertTrue($package->composerRepository->isDefault());
+
+        $version = $package->versions()->sole();
+
+        $this->assertSame('1.2.3', $version->version);
+        $this->assertSame($expectedShasum, $version->shasum);
+        $this->assertSame(['php' => '^8.3'], $version->metadata['require']);
+        $this->assertArrayHasKey('scripts', $version->metadata);
+        $this->assertArrayNotHasKey('repositories', $version->metadata);
+        $this->assertTrue(Storage::disk('s3')->exists($version->archive_path));
+
+        // Served end to end: metadata advertises it and the dist streams it.
+        $this->get('/p2/acme/widgets.json')
+            ->assertOk()
+            ->assertJsonPath('packages.acme/widgets.0.version', '1.2.3');
+
+        $this->get("/dist/acme/widgets/{$version->reference}.zip")->assertOk();
+    }
+
+    public function test_an_explicit_version_field_beats_the_manifests(): void
+    {
+        $this->withToken($this->writeToken())
+            ->post('/upload/acme/widgets', [
+                'file' => $this->makeZip(['name' => 'acme/widgets', 'version' => '0.9.0']),
+                'version' => '1.0.0-rc.1',
+            ])
+            ->assertCreated()
+            ->assertJsonPath('version', '1.0.0-rc.1');
+    }
+
+    public function test_a_version_must_come_from_somewhere(): void
+    {
+        $this->withToken($this->writeToken())
+            ->post('/upload/acme/widgets', ['file' => $this->makeZip(['name' => 'acme/widgets'])])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['version']);
+    }
+
+    public function test_reuploading_a_version_replaces_its_archive(): void
+    {
+        $token = $this->writeToken();
+
+        $this->withToken($token)->post('/upload/acme/widgets', [
+            'file' => $this->makeZip(['name' => 'acme/widgets', 'version' => '1.0.0']),
+        ])->assertCreated();
+
+        $first = Package::query()->where('name', 'acme/widgets')->sole()->versions()->sole();
+
+        $this->withToken($token)->post('/upload/acme/widgets', [
+            'file' => $this->makeZip(['name' => 'acme/widgets', 'version' => '1.0.0', 'description' => 'rebuilt']),
+        ])->assertCreated();
+
+        $versions = Package::query()->where('name', 'acme/widgets')->sole()->versions()->get();
+
+        $this->assertCount(1, $versions);
+        $this->assertNotSame($first->shasum, $versions->sole()->shasum);
+    }
+
+    public function test_a_zip_without_a_manifest_is_rejected(): void
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'upload-zip-');
+
+        $zip = new ZipArchive;
+        $zip->open($path, ZipArchive::OVERWRITE);
+        $zip->addFromString('src/Widget.php', '<?php');
+        $zip->close();
+
+        $this->withToken($this->writeToken())
+            ->post('/upload/acme/widgets', [
+                'file' => new UploadedFile($path, 'package.zip', 'application/zip', test: true),
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['file']);
+    }
+
+    public function test_a_manifest_naming_another_package_is_rejected(): void
+    {
+        $this->withToken($this->writeToken())
+            ->post('/upload/acme/widgets', [
+                'file' => $this->makeZip(['name' => 'acme/gadgets', 'version' => '1.0.0']),
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['file']);
+    }
+
+    public function test_something_that_is_not_a_zip_is_rejected(): void
+    {
+        $this->withToken($this->writeToken())
+            ->post('/upload/acme/widgets', [
+                'file' => UploadedFile::fake()->create('package.txt', 1, 'text/plain'),
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['file']);
+    }
+
+    public function test_uploads_land_in_the_addressed_repository(): void
+    {
+        Repository::factory()->create(['path' => 'internal', 'public' => false]);
+
+        $this->withToken($this->writeToken())
+            ->post('/r/internal/upload/acme/widgets', [
+                'file' => $this->makeZip(['name' => 'acme/widgets', 'version' => '2.0.0']),
+            ])
+            ->assertCreated();
+
+        $package = Package::query()->where('name', 'acme/widgets')->sole();
+
+        $this->assertSame('internal', $package->composerRepository->path);
+    }
+
+    public function test_a_scoped_deploy_token_only_publishes_into_its_grants(): void
+    {
+        $internal = Repository::factory()->create(['path' => 'internal', 'public' => false]);
+
+        $deployToken = DeployToken::factory()->create();
+        $deployToken->repositories()->attach($internal);
+
+        $plain = Token::issue($deployToken, 'ci', [TokenAbility::RepositoryWrite])->plainText;
+
+        // The granted repository accepts the publish...
+        $this->withToken($plain)
+            ->post('/r/internal/upload/acme/widgets', [
+                'file' => $this->makeZip(['name' => 'acme/widgets', 'version' => '1.0.0']),
+            ])
+            ->assertCreated();
+
+        // ...the (public!) default repository does not: readable is not
+        // writable.
+        $this->withToken($plain)
+            ->post('/upload/acme/gadgets', [
+                'file' => $this->makeZip(['name' => 'acme/gadgets', 'version' => '1.0.0']),
+            ])
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/CleanArchivesCommandTest.php
+++ b/tests/Feature/CleanArchivesCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\PackageVersion;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class CleanArchivesCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * A referenced archive and an orphan side by side on the dist disk.
+     */
+    private function disk(): Filesystem
+    {
+        Storage::fake(config('filesystems.dists'));
+
+        $disk = Storage::disk(config('filesystems.dists'));
+        $disk->put('packages/acme/widgets/kept.zip', 'zip-bytes');
+        $disk->put('packages/acme/widgets/orphan.zip', 'stale-bytes');
+
+        PackageVersion::factory()
+            ->for(Package::factory()->create(['name' => 'acme/widgets']))
+            ->create([
+                'archive_path' => 'packages/acme/widgets/kept.zip',
+                'shasum' => sha1('zip-bytes'),
+            ]);
+
+        return $disk;
+    }
+
+    public function test_clean_deletes_only_unreferenced_archives(): void
+    {
+        $disk = $this->disk();
+
+        $this->artisan('archives:clean')
+            ->expectsOutputToContain('packages/acme/widgets/orphan.zip')
+            ->assertSuccessful();
+
+        $disk->assertExists('packages/acme/widgets/kept.zip');
+        $disk->assertMissing('packages/acme/widgets/orphan.zip');
+    }
+
+    public function test_a_dry_run_reports_orphans_without_deleting_them(): void
+    {
+        $disk = $this->disk();
+
+        $this->artisan('archives:clean', ['--dry-run' => true])
+            ->expectsOutputToContain('packages/acme/widgets/orphan.zip')
+            ->assertSuccessful();
+
+        $disk->assertExists('packages/acme/widgets/kept.zip');
+        $disk->assertExists('packages/acme/widgets/orphan.zip');
+    }
+
+    public function test_clean_reports_when_nothing_is_orphaned(): void
+    {
+        $disk = $this->disk();
+        $disk->delete('packages/acme/widgets/orphan.zip');
+
+        $this->artisan('archives:clean')
+            ->expectsOutputToContain('nothing to clean')
+            ->assertSuccessful();
+
+        $disk->assertExists('packages/acme/widgets/kept.zip');
+    }
+}

--- a/tests/Feature/ComposerAuthTest.php
+++ b/tests/Feature/ComposerAuthTest.php
@@ -39,7 +39,10 @@ class ComposerAuthTest extends TestCase
 
     private function issueToken(array $abilities = [TokenAbility::RepositoryRead]): NewToken
     {
-        return Token::issue(User::factory()->create(), 'test token', $abilities);
+        // A personal token reaches what its owner can see; these tests are
+        // about authentication, so the owner is someone who sees everything.
+        // Row-level scoping has its own coverage in UserAccessScopingTest.
+        return Token::issue(User::factory()->superAdmin()->create(), 'test token', $abilities);
     }
 
     public function test_a_private_repository_rejects_unauthenticated_reads(): void
@@ -114,7 +117,7 @@ class ComposerAuthTest extends TestCase
 
     public function test_an_expired_token_stops_authenticating(): void
     {
-        $new = Token::issue(User::factory()->create(), 'expired', [TokenAbility::RepositoryRead], now()->subDay());
+        $new = Token::issue(User::factory()->superAdmin()->create(), 'expired', [TokenAbility::RepositoryRead], now()->subDay());
 
         $this->withBasicAuth('token', $new->plainText)
             ->getJson('/r/internal/list.json')

--- a/tests/Feature/ComposerAuthTest.php
+++ b/tests/Feature/ComposerAuthTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TokenAbility;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Token;
+use App\Models\User;
+use App\Support\NewToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Token authentication on the Composer endpoints: public repositories read
+ * openly, private ones require a live token with the read ability.
+ */
+class ComposerAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $private;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->private = Repository::factory()->create(['path' => 'internal', 'public' => false]);
+
+        Package::factory()
+            ->create(['name' => 'acme/widgets', 'repository_id' => $this->private->id])
+            ->versions()->create([
+                'version' => 'v1.0.0',
+                'reference' => str_repeat('a', 40),
+                'is_dev' => false,
+                'metadata' => ['name' => 'acme/widgets', 'version' => 'v1.0.0'],
+            ]);
+    }
+
+    private function issueToken(array $abilities = [TokenAbility::RepositoryRead]): NewToken
+    {
+        return Token::issue(User::factory()->create(), 'test token', $abilities);
+    }
+
+    public function test_a_private_repository_rejects_unauthenticated_reads(): void
+    {
+        foreach ([
+            '/r/internal/packages.json',
+            '/r/internal/search.json?q=acme',
+            '/r/internal/list.json',
+            '/r/internal/p2/acme/widgets.json',
+            '/r/internal/dist/acme/widgets/'.str_repeat('a', 40).'.zip',
+        ] as $url) {
+            $this->getJson($url)
+                ->assertUnauthorized()
+                ->assertHeader('WWW-Authenticate', 'Basic realm="Composer repository"');
+        }
+    }
+
+    public function test_the_401_tells_the_user_how_to_authenticate(): void
+    {
+        $message = $this->getJson('/r/internal/packages.json')->json('message');
+
+        $this->assertStringContainsString('composer config http-basic.', $message);
+    }
+
+    public function test_a_public_repository_reads_without_a_token(): void
+    {
+        $this->private->update(['public' => true]);
+
+        $this->getJson('/r/internal/list.json')->assertOk();
+    }
+
+    public function test_a_valid_token_authenticates_as_the_basic_password_with_any_username(): void
+    {
+        $new = $this->issueToken();
+
+        $this->withBasicAuth('anything-at-all', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/widgets']]);
+    }
+
+    public function test_a_valid_token_authenticates_as_a_bearer_token(): void
+    {
+        $new = $this->issueToken();
+
+        $this->withToken($new->plainText)
+            ->getJson('/r/internal/p2/acme/widgets.json')
+            ->assertOk();
+    }
+
+    public function test_an_unknown_token_is_rejected_even_on_a_public_repository(): void
+    {
+        // A CI system with a bad credential should hear about it now, not
+        // keep working by accident until the repository goes private.
+        $this->private->update(['public' => true]);
+
+        $this->withBasicAuth('token', 'pp_not-a-real-token')
+            ->getJson('/r/internal/list.json')
+            ->assertUnauthorized();
+    }
+
+    public function test_a_revoked_token_stops_authenticating(): void
+    {
+        $new = $this->issueToken();
+
+        $new->token->delete();
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertUnauthorized();
+    }
+
+    public function test_an_expired_token_stops_authenticating(): void
+    {
+        $new = Token::issue(User::factory()->create(), 'expired', [TokenAbility::RepositoryRead], now()->subDay());
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertUnauthorized();
+    }
+
+    public function test_reading_requires_the_read_ability(): void
+    {
+        $new = $this->issueToken([TokenAbility::RepositoryWrite]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertForbidden();
+    }
+
+    public function test_using_a_token_records_when(): void
+    {
+        $new = $this->issueToken();
+
+        $this->assertNull($new->token->last_used_at);
+
+        $this->withBasicAuth('token', $new->plainText)->getJson('/r/internal/list.json')->assertOk();
+
+        $this->assertNotNull($new->token->fresh()->last_used_at);
+    }
+
+    public function test_the_default_repository_stays_open_while_public(): void
+    {
+        // The default repository is created public, so a registry upgrading
+        // to token auth serves its existing consumers exactly as before.
+        Package::factory()->create(['name' => 'acme/open'])
+            ->versions()->create([
+                'version' => 'v1.0.0',
+                'reference' => str_repeat('b', 40),
+                'is_dev' => false,
+                'metadata' => ['name' => 'acme/open', 'version' => 'v1.0.0'],
+            ]);
+
+        $this->getJson('/packages.json')->assertOk();
+        $this->getJson('/list.json')->assertOk();
+
+        Repository::default()->update(['public' => false]);
+
+        $this->getJson('/list.json')->assertUnauthorized();
+    }
+}

--- a/tests/Feature/ComposerRepositoryScopingTest.php
+++ b/tests/Feature/ComposerRepositoryScopingTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The Composer endpoints are mounted once per repository — at the root for
+ * the default repository and under /r/{path} for named ones — and each mount
+ * must behave as its own registry.
+ */
+class ComposerRepositoryScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $internal;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->internal = Repository::factory()->public()->create(['path' => 'internal']);
+    }
+
+    /**
+     * A package in the default repository and one in /r/internal, sharing a
+     * name and a VCS URL — which the per-repository unique indexes must allow.
+     */
+    private function makeTwinPackages(): void
+    {
+        Package::factory()
+            ->create(['name' => 'acme/widgets', 'repository' => 'https://github.com/acme/widgets'])
+            ->versions()->create([
+                'version' => 'v1.0.0',
+                'reference' => str_repeat('a', 40),
+                'is_dev' => false,
+                'metadata' => ['name' => 'acme/widgets', 'version' => 'v1.0.0'],
+            ]);
+
+        Package::factory()
+            ->create([
+                'name' => 'acme/widgets',
+                'repository' => 'https://github.com/acme/widgets',
+                'repository_id' => $this->internal->id,
+                'description' => 'The internal build.',
+            ])
+            ->versions()->create([
+                'version' => 'v2.0.0',
+                'reference' => str_repeat('b', 40),
+                'is_dev' => false,
+                'metadata' => ['name' => 'acme/widgets', 'version' => 'v2.0.0'],
+            ]);
+    }
+
+    public function test_a_package_created_without_a_repository_lands_in_the_default_one(): void
+    {
+        $package = Package::factory()->create();
+
+        $this->assertTrue($package->composerRepository->isDefault());
+        $this->assertTrue($package->composerRepository->public);
+    }
+
+    public function test_the_same_package_name_resolves_independently_per_repository(): void
+    {
+        $this->makeTwinPackages();
+
+        $this->get('/p2/acme/widgets.json')
+            ->assertOk()
+            ->assertJsonPath('packages.acme/widgets.0.version', 'v1.0.0');
+
+        $this->get('/r/internal/p2/acme/widgets.json')
+            ->assertOk()
+            ->assertJsonPath('packages.acme/widgets.0.version', 'v2.0.0');
+    }
+
+    public function test_list_and_search_only_see_the_repositorys_own_packages(): void
+    {
+        $this->makeTwinPackages();
+
+        Package::factory()->create(['name' => 'acme/gadgets', 'repository_id' => $this->internal->id])
+            ->versions()->create([
+                'version' => 'v1.0.0',
+                'reference' => str_repeat('c', 40),
+                'is_dev' => false,
+                'metadata' => ['name' => 'acme/gadgets', 'version' => 'v1.0.0'],
+            ]);
+
+        $this->get('/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/widgets']]);
+
+        $this->get('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/gadgets', 'acme/widgets']]);
+
+        $this->assertSame(
+            'The internal build.',
+            $this->get('/r/internal/search.json?q=acme/w')->assertOk()->json('results.0.description'),
+        );
+    }
+
+    public function test_a_named_repositorys_root_advertises_its_own_mount(): void
+    {
+        $this->get('/r/internal/packages.json')
+            ->assertOk()
+            ->assertJson([
+                'metadata-url' => '/r/internal/p2/%package%.json',
+                'search' => url('/r/internal/search.json').'?q=%query%&type=%type%',
+                'list' => url('/r/internal/list.json'),
+            ]);
+    }
+
+    public function test_metadata_dist_urls_point_into_the_repositorys_mount(): void
+    {
+        $this->makeTwinPackages();
+
+        $url = $this->get('/r/internal/p2/acme/widgets.json')->assertOk()
+            ->json('packages.acme/widgets.0.dist.url');
+
+        $this->assertStringContainsString('/r/internal/dist/acme/widgets/'.str_repeat('b', 40).'.zip', $url);
+    }
+
+    public function test_dist_does_not_serve_another_repositorys_reference(): void
+    {
+        $this->makeTwinPackages();
+
+        // The internal build's reference is not a version of the default
+        // repository's package, twin name or not.
+        $this->get('/dist/acme/widgets/'.str_repeat('b', 40).'.zip')->assertNotFound();
+    }
+
+    public function test_an_unknown_repository_path_is_a_404_on_every_endpoint(): void
+    {
+        $this->makeTwinPackages();
+
+        $this->get('/r/nope/packages.json')->assertNotFound();
+        $this->get('/r/nope/list.json')->assertNotFound();
+        $this->get('/r/nope/search.json?q=acme')->assertNotFound();
+        $this->get('/r/nope/p2/acme/widgets.json')->assertNotFound();
+        $this->get('/r/nope/dist/acme/widgets/'.str_repeat('b', 40).'.zip')->assertNotFound();
+    }
+
+    public function test_install_commands_point_at_the_repositorys_mount(): void
+    {
+        $this->makeTwinPackages();
+
+        $package = $this->internal->packages()->sole();
+        $commands = $package->installCommands();
+
+        $this->assertStringContainsString(url('/r/internal'), $commands['repository']);
+        // The config key carries the path, so two repositories on the same
+        // registry never overwrite each other's entry in composer.json.
+        $this->assertStringContainsString('-internal composer', $commands['repository']);
+
+        $default = Repository::default()->packages()->sole();
+
+        $this->assertStringNotContainsString('/r/', $default->installCommands()['repository']);
+    }
+}

--- a/tests/Feature/ComposerRepositoryTest.php
+++ b/tests/Feature/ComposerRepositoryTest.php
@@ -243,6 +243,34 @@ class ComposerRepositoryTest extends TestCase
         $this->get('/dist/acme/widgets/'.str_repeat('b', 40).'.zip')->assertNotFound();
     }
 
+    public function test_the_dist_endpoint_falls_back_to_a_sibling_row_for_the_same_commit(): void
+    {
+        // A tag and a branch can point at the same commit. When the first
+        // row's file is gone from the disk, a sibling row's still-stored zip
+        // must serve rather than 404ing on the first path checked.
+        config(['filesystems.dists' => 's3']);
+        Storage::fake('s3');
+
+        // v1.1.0's archive_path points at a file that was never stored; only
+        // the sibling branch row's archive exists on the disk.
+        $package = $this->makeServedPackage();
+
+        $package->versions()->create([
+            'version' => 'dev-release',
+            'reference' => str_repeat('b', 40),
+            'is_dev' => true,
+            'archive_path' => 'packages/acme/widgets/sibling.zip',
+            'shasum' => sha1('sibling-bytes'),
+            'metadata' => ['name' => 'acme/widgets', 'version' => 'dev-release'],
+        ]);
+
+        Storage::disk('s3')->put('packages/acme/widgets/sibling.zip', 'sibling-bytes');
+
+        $response = $this->get('/dist/acme/widgets/'.str_repeat('b', 40).'.zip')->assertOk();
+
+        $this->assertSame('sibling-bytes', $response->streamedContent());
+    }
+
     public function test_the_dist_endpoint_rejects_unknown_references(): void
     {
         $this->makeServedPackage();

--- a/tests/Feature/ComposerRepositoryTest.php
+++ b/tests/Feature/ComposerRepositoryTest.php
@@ -3,11 +3,9 @@
 namespace Tests\Feature;
 
 use App\Models\Package;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Mockery;
 use Tests\TestCase;
 
 class ComposerRepositoryTest extends TestCase
@@ -29,6 +27,8 @@ class ComposerRepositoryTest extends TestCase
             'reference' => str_repeat('b', 40),
             'is_dev' => false,
             'released_at' => '2026-02-01 12:00:00',
+            'archive_path' => 'packages/acme/widgets/v110.zip',
+            'shasum' => sha1('zip-bytes'),
             'metadata' => [
                 'name' => 'acme/widgets',
                 'version' => 'v1.1.0',
@@ -37,6 +37,7 @@ class ComposerRepositoryTest extends TestCase
             ],
         ]);
 
+        // dev-main predates archive storage: no archive_path, no shasum.
         $package->versions()->create([
             'version' => 'dev-main',
             'reference' => str_repeat('d', 40),
@@ -141,7 +142,7 @@ class ComposerRepositoryTest extends TestCase
             ->assertExactJson(['packageNames' => ['aaa/first', 'acme/widgets']]);
     }
 
-    public function test_stable_metadata_lists_tagged_versions_with_proxied_dists(): void
+    public function test_stable_metadata_lists_tagged_versions_with_local_dists(): void
     {
         $this->makeServedPackage();
 
@@ -154,8 +155,20 @@ class ComposerRepositoryTest extends TestCase
         $this->assertSame(['php' => '^8.3'], $versions[0]['require']);
         $this->assertSame('zip', $versions[0]['dist']['type']);
         $this->assertSame(str_repeat('b', 40), $versions[0]['dist']['reference']);
+        $this->assertSame(sha1('zip-bytes'), $versions[0]['dist']['shasum']);
         $this->assertStringContainsString('/dist/acme/widgets/'.str_repeat('b', 40).'.zip', $versions[0]['dist']['url']);
         $this->assertSame('2026-02-01T12:00:00+00:00', $versions[0]['time']);
+    }
+
+    public function test_a_version_without_a_stored_archive_is_served_without_a_shasum(): void
+    {
+        // Composer treats the key as a checksum to enforce; advertising a null
+        // would be worse than admitting there is none yet.
+        $this->makeServedPackage();
+
+        $versions = $this->get('/p2/acme/widgets~dev.json')->assertOk()->json('packages.acme/widgets');
+
+        $this->assertArrayNotHasKey('shasum', $versions[0]['dist']);
     }
 
     public function test_a_version_with_no_recorded_date_is_served_without_a_time(): void
@@ -184,15 +197,14 @@ class ComposerRepositoryTest extends TestCase
         $this->get('/p2/acme/missing.json')->assertNotFound();
     }
 
-    public function test_the_dist_endpoint_proxies_and_caches_the_zipball(): void
+    public function test_the_dist_endpoint_serves_the_stored_archive(): void
     {
         // The dist disk is configurable so it can be pointed at object
         // storage; the endpoint must not assume a local one.
         config(['filesystems.dists' => 's3']);
         Storage::fake('s3');
-        Http::fake([
-            'api.github.com/repos/acme/widgets/zipball/*' => Http::response('zip-bytes'),
-        ]);
+        Storage::disk('s3')->put('packages/acme/widgets/v110.zip', 'zip-bytes');
+        Http::fake();
 
         $this->makeServedPackage();
         $reference = str_repeat('b', 40);
@@ -203,53 +215,32 @@ class ComposerRepositoryTest extends TestCase
 
         $this->assertSame('zip-bytes', $response->streamedContent());
 
-        Storage::disk('s3')->assertExists("composer-dists/acme/widgets/{$reference}.zip");
-        $this->assertSame('zip-bytes', Storage::disk('s3')->get("composer-dists/acme/widgets/{$reference}.zip"));
-        Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer ghp_secret'));
-
-        // A second download is served from the cache without touching GitHub.
-        $this->get("/dist/acme/widgets/{$reference}.zip")->assertOk();
-        Http::assertSentCount(1);
+        // Serving is storage only. GitHub is never consulted, so consumers
+        // need no GitHub credentials and an outage there changes nothing.
+        Http::assertNothingSent();
     }
 
-    public function test_a_failed_zipball_download_is_not_cached(): void
+    public function test_a_version_without_a_stored_archive_is_a_404(): void
     {
         config(['filesystems.dists' => 's3']);
         Storage::fake('s3');
-        Http::fake([
-            'api.github.com/repos/acme/widgets/zipball/*' => Http::response('nope', 500),
-        ]);
 
+        // dev-main's row predates archive storage, so nothing is stored yet.
         $this->makeServedPackage();
-        $reference = str_repeat('b', 40);
 
-        $this->get("/dist/acme/widgets/{$reference}.zip")->assertServerError();
-
-        Storage::disk('s3')->assertMissing("composer-dists/acme/widgets/{$reference}.zip");
+        $this->get('/dist/acme/widgets/'.str_repeat('d', 40).'.zip')->assertNotFound();
     }
 
-    public function test_a_failed_dist_write_is_removed_from_the_disk(): void
+    public function test_an_archive_missing_from_the_disk_is_a_404(): void
     {
+        // The row says stored, the disk disagrees — the next sync backfills
+        // it; until then the honest answer is a 404, not a broken stream.
         config(['filesystems.dists' => 's3']);
-        Http::fake([
-            'api.github.com/repos/acme/widgets/zipball/*' => Http::response('zip-bytes'),
-        ]);
-
-        $reference = str_repeat('b', 40);
-        $path = "composer-dists/acme/widgets/{$reference}.zip";
-
-        // A write that fails after partially uploading must not leave the
-        // truncated object behind for the next request to serve.
-        $disk = Mockery::mock(Filesystem::class);
-        $disk->shouldReceive('exists')->with($path)->andReturnFalse();
-        $disk->shouldReceive('writeStream')->once()->with($path, Mockery::any())->andReturnFalse();
-        $disk->shouldReceive('delete')->once()->with($path);
-
-        Storage::set('s3', $disk);
+        Storage::fake('s3');
 
         $this->makeServedPackage();
 
-        $this->get("/dist/acme/widgets/{$reference}.zip")->assertServerError();
+        $this->get('/dist/acme/widgets/'.str_repeat('b', 40).'.zip')->assertNotFound();
     }
 
     public function test_the_dist_endpoint_rejects_unknown_references(): void

--- a/tests/Feature/CreatePackageWizardTest.php
+++ b/tests/Feature/CreatePackageWizardTest.php
@@ -3,12 +3,14 @@
 namespace Tests\Feature;
 
 use App\Filament\Resources\Packages\Pages\CreatePackage;
+use App\Jobs\SyncPackageJob;
 use App\Models\Package;
 use App\Models\Source;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -53,6 +55,8 @@ class CreatePackageWizardTest extends TestCase
 
     public function test_the_deciphered_details_can_be_customised_before_creating(): void
     {
+        Queue::fake([SyncPackageJob::class]);
+
         $this->fakeComposerJson();
 
         Livewire::test(CreatePackage::class)
@@ -158,6 +162,8 @@ class CreatePackageWizardTest extends TestCase
 
     public function test_a_token_typed_into_the_wizard_is_used_to_read_the_repository(): void
     {
+        Queue::fake([SyncPackageJob::class]);
+
         $this->fakeComposerJson();
 
         Livewire::test(CreatePackage::class)

--- a/tests/Feature/DeployTokenTest.php
+++ b/tests/Feature/DeployTokenTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TokenAbility;
+use App\Filament\Resources\DeployTokens\Pages\CreateDeployToken;
+use App\Models\DeployToken;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Token;
+use App\Models\User;
+use App\Support\NewToken;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Deploy tokens are machine principals whose visibility is the union of
+ * their granted repositories and packages — or everything when unscoped.
+ */
+class DeployTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $internal;
+
+    private Repository $other;
+
+    private Package $widgets;
+
+    private Package $gadgets;
+
+    private Package $secret;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->internal = Repository::factory()->create(['path' => 'internal', 'public' => false]);
+        $this->other = Repository::factory()->create(['path' => 'other', 'public' => false]);
+
+        $this->widgets = $this->makeServedPackage('acme/widgets', $this->internal);
+        $this->gadgets = $this->makeServedPackage('acme/gadgets', $this->internal);
+        $this->secret = $this->makeServedPackage('acme/secret', $this->other);
+    }
+
+    private function makeServedPackage(string $name, Repository $repository): Package
+    {
+        $package = Package::factory()->create(['name' => $name, 'repository_id' => $repository->id]);
+
+        $package->versions()->create([
+            'version' => 'v1.0.0',
+            'reference' => sha1($name),
+            'is_dev' => false,
+            'metadata' => ['name' => $name, 'version' => 'v1.0.0'],
+        ]);
+
+        return $package;
+    }
+
+    private function issueFor(DeployToken $deployToken): NewToken
+    {
+        return Token::issue($deployToken, $deployToken->name, [TokenAbility::RepositoryRead]);
+    }
+
+    public function test_an_unscoped_deploy_token_sees_everything(): void
+    {
+        $new = $this->issueFor(DeployToken::factory()->create());
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/gadgets', 'acme/widgets']]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/other/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/secret']]);
+    }
+
+    public function test_a_package_scoped_token_sees_only_its_grants(): void
+    {
+        $deployToken = DeployToken::factory()->create();
+        $deployToken->packages()->attach($this->widgets);
+
+        $new = $this->issueFor($deployToken);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/widgets']]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/search.json?q=acme/')
+            ->assertOk()
+            ->assertJsonPath('total', 1);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/p2/acme/gadgets.json')
+            ->assertNotFound();
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/dist/acme/gadgets/'.sha1('acme/gadgets').'.zip')
+            ->assertNotFound();
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/other/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => []]);
+    }
+
+    public function test_a_repository_scoped_token_sees_that_repositorys_packages(): void
+    {
+        $deployToken = DeployToken::factory()->create();
+        $deployToken->repositories()->attach($this->internal);
+
+        $new = $this->issueFor($deployToken);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/gadgets', 'acme/widgets']]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/other/p2/acme/secret.json')
+            ->assertNotFound();
+    }
+
+    public function test_a_scoped_token_still_reads_public_repositories(): void
+    {
+        $this->makeServedPackage('acme/open', Repository::default());
+
+        $deployToken = DeployToken::factory()->create();
+        $deployToken->packages()->attach($this->widgets);
+
+        $new = $this->issueFor($deployToken);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/open']]);
+    }
+
+    public function test_deleting_the_deploy_token_revokes_its_access_token(): void
+    {
+        $deployToken = DeployToken::factory()->create();
+        $new = $this->issueFor($deployToken);
+
+        $this->withBasicAuth('token', $new->plainText)->getJson('/r/internal/list.json')->assertOk();
+
+        $deployToken->delete();
+
+        $this->withBasicAuth('token', $new->plainText)->getJson('/r/internal/list.json')->assertUnauthorized();
+    }
+
+    public function test_creating_in_the_panel_issues_a_read_token_and_stores_the_grants(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        Livewire::test(CreateDeployToken::class)
+            ->fillForm([
+                'name' => 'production-deploys',
+                'repositories' => [$this->internal->id],
+                'packages' => [$this->secret->id],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        $deployToken = DeployToken::query()->where('name', 'production-deploys')->sole();
+
+        $this->assertTrue($deployToken->repositories->contains($this->internal));
+        $this->assertTrue($deployToken->packages->contains($this->secret));
+
+        $token = $deployToken->token;
+
+        $this->assertNotNull($token);
+        $this->assertSame([TokenAbility::RepositoryRead->value], $token->abilities);
+    }
+}

--- a/tests/Feature/DownloadStatsTest.php
+++ b/tests/Feature/DownloadStatsTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TokenAbility;
+use App\Filament\Widgets\DownloadsChart;
+use App\Filament\Widgets\RegistryStatsOverview;
+use App\Models\Download;
+use App\Models\Package;
+use App\Models\Token;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Download analytics: every served dist writes a row and bumps the
+ * denormalized counters; the dashboard and search read them back.
+ */
+class DownloadStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Package $package;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.dists' => 's3']);
+        Storage::fake('s3');
+        Storage::disk('s3')->put('packages/acme/widgets/v100.zip', 'zip-bytes');
+
+        $this->package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        $this->package->versions()->create([
+            'version' => 'v1.0.0',
+            'reference' => str_repeat('a', 40),
+            'is_dev' => false,
+            'archive_path' => 'packages/acme/widgets/v100.zip',
+            'shasum' => sha1('zip-bytes'),
+            'metadata' => ['name' => 'acme/widgets', 'version' => 'v1.0.0'],
+        ]);
+    }
+
+    private function download(): void
+    {
+        $this->get('/dist/acme/widgets/'.str_repeat('a', 40).'.zip')->assertOk();
+    }
+
+    public function test_a_served_dist_records_a_download_and_bumps_the_counters(): void
+    {
+        $this->download();
+
+        $version = $this->package->versions()->sole();
+        $download = Download::query()->sole();
+
+        $this->assertSame($this->package->id, $download->package_id);
+        $this->assertSame($version->id, $download->package_version_id);
+        $this->assertSame('v1.0.0', $download->version);
+        $this->assertNull($download->token_prefix);
+
+        $this->assertSame(1, $this->package->fresh()->total_downloads);
+        $this->assertSame(1, $version->fresh()->total_downloads);
+    }
+
+    public function test_the_token_that_fetched_is_recorded_by_prefix(): void
+    {
+        $new = Token::issue(User::factory()->superAdmin()->create(), 'ci', [TokenAbility::RepositoryRead]);
+
+        $this->withToken($new->plainText)
+            ->get('/dist/acme/widgets/'.str_repeat('a', 40).'.zip')
+            ->assertOk();
+
+        $this->assertSame($new->token->token_prefix, Download::query()->sole()->token_prefix);
+    }
+
+    public function test_a_404_records_nothing(): void
+    {
+        $this->get('/dist/acme/widgets/'.str_repeat('f', 40).'.zip')->assertNotFound();
+
+        $this->assertSame(0, Download::query()->count());
+    }
+
+    public function test_search_serves_the_real_download_count(): void
+    {
+        $this->download();
+        $this->download();
+
+        $this->get('/search.json?q=acme/')
+            ->assertOk()
+            ->assertJsonPath('results.0.downloads', 2);
+    }
+
+    public function test_recalculate_rebuilds_the_counters_from_the_rows(): void
+    {
+        $this->download();
+        $this->download();
+
+        // Knock both counters out of step, as a botched import would.
+        $this->package->forceFill(['total_downloads' => 99])->save();
+        $this->package->versions()->update(['total_downloads' => 99]);
+
+        $this->artisan('downloads:recalculate')->assertSuccessful();
+
+        $this->assertSame(2, $this->package->fresh()->total_downloads);
+        $this->assertSame(2, $this->package->versions()->sole()->total_downloads);
+    }
+
+    public function test_the_dashboard_widgets_render_with_scoped_data(): void
+    {
+        $this->download();
+
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        Livewire::test(RegistryStatsOverview::class)
+            ->assertOk()
+            ->assertSee('Downloads · 30 days');
+
+        Livewire::test(DownloadsChart::class)->assertOk();
+    }
+
+    public function test_the_download_history_survives_pruning_the_version(): void
+    {
+        $this->download();
+
+        $this->package->versions()->sole()->delete();
+
+        $download = Download::query()->sole();
+
+        $this->assertNull($download->package_version_id);
+        $this->assertSame('v1.0.0', $download->version);
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,11 +2,15 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    // The login page reads the active authentication sources for its SSO
+    // buttons, so even this smoke test needs a migrated database.
+    use RefreshDatabase;
+
     public function test_the_root_url_redirects_to_the_filament_login_page(): void
     {
         $response = $this->get('/');

--- a/tests/Feature/GitLabProviderTest.php
+++ b/tests/Feature/GitLabProviderTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\SourceProvider;
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\Source;
+use App\Services\GitHub\GitHubSourceClient;
+use App\Services\GitHub\WebhookRegistrar;
+use App\Services\GitLab\GitLabSourceClient;
+use App\Services\PackageSynchronizer;
+use App\Sources\UnsupportedProviderException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * The provider abstraction: GitLab speaks the same RepositoryClient and
+ * SourceClient contracts GitHub does, and undeclared providers refuse loudly.
+ */
+class GitLabProviderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeGitLabPackage(): Package
+    {
+        return Package::factory()->unreleased()->create([
+            'name' => 'group/widgets-placeholder',
+            'repository' => 'https://gitlab.com/group/widgets',
+            'token' => 'glpat-secret',
+        ]);
+    }
+
+    private function fakeGitLab(): void
+    {
+        Storage::fake(config('filesystems.dists'));
+
+        Http::fake([
+            'gitlab.com/api/v4/projects/group%2Fwidgets/repository/tags*' => Http::response([
+                ['name' => 'v1.0.0', 'commit' => ['id' => str_repeat('a', 40)]],
+            ]),
+            'gitlab.com/api/v4/projects/group%2Fwidgets/repository/branches*' => Http::response([
+                ['name' => 'main', 'commit' => ['id' => str_repeat('b', 40)]],
+            ]),
+            'gitlab.com/api/v4/projects/group%2Fwidgets/repository/files/composer.json/raw*' => Http::response(
+                json_encode(['name' => 'acme/widgets', 'description' => 'Widgets.', 'type' => 'library']),
+            ),
+            'gitlab.com/api/v4/projects/group%2Fwidgets/repository/commits/*' => Http::response([
+                'committed_date' => '2026-02-01T12:00:00Z',
+            ]),
+            'gitlab.com/api/v4/projects/group%2Fwidgets/repository/archive.zip*' => fn () => Http::response(
+                'zip-bytes', 200, ['Content-Type' => 'application/zip'],
+            ),
+            'gitlab.com/api/v4/projects/group%2Fwidgets' => Http::response(['default_branch' => 'main']),
+        ]);
+    }
+
+    public function test_a_gitlab_url_resolves_the_gitlab_client_from_the_host(): void
+    {
+        $package = $this->makeGitLabPackage();
+
+        $this->assertSame(SourceProvider::Gitlab, $package->provider());
+        $this->assertSame('group/widgets', $package->repositoryPath());
+        $this->assertSame('https://gitlab.com/api/v4', $package->apiUrl());
+    }
+
+    public function test_a_gitlab_package_syncs_end_to_end(): void
+    {
+        $this->fakeGitLab();
+
+        $package = $this->makeGitLabPackage();
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $package->refresh();
+
+        $this->assertSame('acme/widgets', $package->name);
+        $this->assertSame('1.0.0', $package->latest_version);
+        $this->assertSame(
+            ['1.0.0', 'dev-main'],
+            $package->versions()->pluck('version')->sort()->values()->all(),
+        );
+
+        // The archive came from GitLab's archive endpoint, stored like any other.
+        $this->assertSame(0, $package->versions()->whereNull('archive_path')->count());
+
+        // Every call carried the token in GitLab's own header.
+        Http::assertSent(fn ($request): bool => $request->hasHeader('PRIVATE-TOKEN', 'glpat-secret'));
+    }
+
+    public function test_gitlab_pagination_follows_the_next_page_header(): void
+    {
+        Storage::fake(config('filesystems.dists'));
+
+        Http::fakeSequence('gitlab.com/api/v4/projects/group%2Fwidgets/repository/tags*')
+            ->push([['name' => 'v1.0.0', 'commit' => ['id' => str_repeat('a', 40)]]], 200, ['X-Next-Page' => '2'])
+            ->push([['name' => 'v1.1.0', 'commit' => ['id' => str_repeat('b', 40)]]]);
+
+        $package = $this->makeGitLabPackage();
+
+        $tags = $package->client()->tags();
+
+        $this->assertSame(['v1.0.0', 'v1.1.0'], array_keys($tags));
+    }
+
+    public function test_the_gitlab_fallback_never_leaks_the_github_token(): void
+    {
+        config(['services.github.token' => 'ghp_environment']);
+
+        $package = Package::factory()->create(['repository' => 'https://gitlab.com/group/other', 'token' => null]);
+
+        $this->assertNull($package->accessToken());
+    }
+
+    public function test_registering_a_webhook_uses_the_gitlab_api_and_endpoint(): void
+    {
+        Http::fake([
+            'gitlab.com/api/v4/projects/group%2Fwidgets/hooks' => Http::response(['id' => 77], 201),
+        ]);
+
+        $package = $this->makeGitLabPackage();
+
+        app(WebhookRegistrar::class)->register($package);
+
+        $package->refresh();
+
+        $this->assertSame(77, $package->webhook_id);
+        $this->assertNotNull($package->webhook_secret);
+
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), '/hooks')
+            && $request['url'] === route('webhooks.gitlab.package', $package)
+            && $request['token'] === $package->webhook_secret);
+    }
+
+    public function test_a_gitlab_delivery_with_the_right_token_queues_a_sync(): void
+    {
+        Queue::fake();
+
+        $package = $this->makeGitLabPackage();
+        $package->forceFill(['webhook_id' => 77, 'webhook_secret' => 'hook-secret'])->save();
+
+        $this->postJson(route('webhooks.gitlab.package', $package), ['ref' => 'refs/tags/v1.0.0'], [
+            'X-Gitlab-Token' => 'hook-secret',
+            'X-Gitlab-Event' => 'Tag Push Hook',
+        ])->assertAccepted();
+
+        $this->assertNotNull($package->fresh()->webhook_received_at);
+        Queue::assertPushed(SyncPackageJob::class);
+    }
+
+    public function test_a_gitlab_delivery_with_the_wrong_token_is_rejected(): void
+    {
+        Queue::fake();
+
+        $package = $this->makeGitLabPackage();
+        $package->forceFill(['webhook_secret' => 'hook-secret'])->save();
+
+        $this->postJson(route('webhooks.gitlab.package', $package), [], [
+            'X-Gitlab-Token' => 'wrong',
+            'X-Gitlab-Event' => 'Push Hook',
+        ])->assertUnauthorized();
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_gitlab_sources_browse_projects(): void
+    {
+        Http::fake([
+            'gitlab.com/api/v4/projects*' => Http::response([
+                ['id' => 7, 'path_with_namespace' => 'group/widgets', 'web_url' => 'https://gitlab.com/group/widgets'],
+            ]),
+        ]);
+
+        $source = Source::factory()->withToken('glpat-secret')->create([
+            'provider' => SourceProvider::Gitlab,
+        ]);
+
+        $client = $source->client();
+
+        $this->assertInstanceOf(GitLabSourceClient::class, $client);
+
+        $projects = $client->projects('widg');
+
+        $this->assertCount(1, $projects);
+        $this->assertSame('group/widgets', $projects[0]->fullName);
+        $this->assertSame('7', $projects[0]->id);
+    }
+
+    public function test_github_sources_browse_projects_with_client_side_search(): void
+    {
+        Http::fake([
+            'api.github.com/app/installations/*/access_tokens' => Http::response([
+                'token' => 'ghs_installation',
+                'expires_at' => now()->addHour()->toIso8601String(),
+            ]),
+            'api.github.com/installation/repositories*' => Http::response([
+                'repositories' => [
+                    ['id' => 1, 'full_name' => 'acme/widgets', 'html_url' => 'https://github.com/acme/widgets'],
+                    ['id' => 2, 'full_name' => 'acme/gadgets', 'html_url' => 'https://github.com/acme/gadgets'],
+                ],
+            ]),
+        ]);
+
+        $this->configureGitHubApp();
+
+        $source = Source::factory()->create(['account' => 'acme']);
+
+        $client = $source->client();
+
+        $this->assertInstanceOf(GitHubSourceClient::class, $client);
+
+        $projects = $client->projects('widg');
+
+        $this->assertCount(1, $projects);
+        $this->assertSame('acme/widgets', $projects[0]->fullName);
+    }
+
+    public function test_undeclared_providers_refuse_loudly(): void
+    {
+        $package = Package::factory()->create(['repository' => 'https://gitea.example.com/acme/widgets']);
+
+        $this->assertSame(SourceProvider::Gitea, $package->provider());
+
+        $this->expectException(UnsupportedProviderException::class);
+
+        $package->client()->tags();
+    }
+
+    private function configureGitHubApp(): void
+    {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($key, $pem);
+
+        config()->set('services.github.app', [
+            'id' => '123456',
+            'slug' => 'acme-pipeline',
+            'private_key' => $pem,
+            'api_url' => 'https://api.github.com',
+        ]);
+    }
+}

--- a/tests/Feature/ImportFromSourceTest.php
+++ b/tests/Feature/ImportFromSourceTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Packages\Pages\ListPackages;
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Source;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * One-click onboarding from a source's project browser: each picked project
+ * becomes a package with its first sync queued.
+ */
+class ImportFromSourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Source $source;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $this->source = Source::factory()->withToken()->create(['account' => 'acme']);
+
+        // The select validates chosen values against the browsable projects,
+        // so the provider listing has to answer during the action call too.
+        Http::fake([
+            'api.github.com/orgs/acme/repos*' => Http::response([
+                ['id' => 1, 'full_name' => 'acme/widgets', 'html_url' => 'https://github.com/acme/widgets'],
+                ['id' => 2, 'full_name' => 'acme/gadgets', 'html_url' => 'https://github.com/acme/gadgets'],
+            ]),
+        ]);
+    }
+
+    public function test_selected_projects_become_packages_with_their_first_sync_queued(): void
+    {
+        Queue::fake();
+
+        Livewire::test(ListPackages::class)
+            ->callAction('importFromSource', [
+                'source_id' => $this->source->id,
+                'projects' => [
+                    'https://github.com/acme/widgets',
+                    'https://github.com/acme/gadgets',
+                ],
+                'repository_id' => Repository::default()->id,
+                'create_webhook' => false,
+            ])
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        $widgets = Package::query()->where('repository', 'https://github.com/acme/widgets')->sole();
+
+        $this->assertSame('acme/widgets', $widgets->name);
+        $this->assertSame($this->source->id, $widgets->source_id);
+        $this->assertTrue($widgets->composerRepository->isDefault());
+
+        $this->assertSame(2, Package::query()->count());
+
+        Queue::assertPushed(SyncPackageJob::class, 2);
+    }
+
+    public function test_projects_already_onboarded_are_skipped_not_duplicated(): void
+    {
+        Queue::fake();
+
+        Package::factory()->create(['repository' => 'https://github.com/acme/widgets']);
+
+        Livewire::test(ListPackages::class)
+            ->callAction('importFromSource', [
+                'source_id' => $this->source->id,
+                'projects' => [
+                    'https://github.com/acme/widgets',
+                    'https://github.com/acme/gadgets',
+                ],
+                'repository_id' => Repository::default()->id,
+                'create_webhook' => false,
+            ])
+            ->assertHasNoActionErrors();
+
+        $this->assertSame(2, Package::query()->count());
+
+        // Only the new project syncs; the existing one was left alone.
+        Queue::assertPushed(SyncPackageJob::class, 1);
+    }
+
+    public function test_importing_can_arrange_the_webhook_per_project(): void
+    {
+        Queue::fake();
+
+        Http::fake([
+            'api.github.com/repos/acme/widgets/hooks' => Http::response(['id' => 55], 201),
+        ]);
+
+        Livewire::test(ListPackages::class)
+            ->callAction('importFromSource', [
+                'source_id' => $this->source->id,
+                'projects' => ['https://github.com/acme/widgets'],
+                'repository_id' => Repository::default()->id,
+                'create_webhook' => true,
+            ])
+            ->assertHasNoActionErrors();
+
+        $package = Package::query()->where('repository', 'https://github.com/acme/widgets')->sole();
+
+        $this->assertSame(55, $package->webhook_id);
+    }
+
+    public function test_one_refused_project_does_not_abort_the_rest(): void
+    {
+        Queue::fake();
+
+        // Same composer name, different URL: the unique (repository, name)
+        // index refuses the import of widgets-fork under the guessed name.
+        Package::factory()->create([
+            'name' => 'acme/widgets',
+            'repository' => 'https://github.com/acme/widgets-old',
+        ]);
+
+        Livewire::test(ListPackages::class)
+            ->callAction('importFromSource', [
+                'source_id' => $this->source->id,
+                'projects' => [
+                    'https://github.com/acme/widgets',
+                    'https://github.com/acme/gadgets',
+                ],
+                'repository_id' => Repository::default()->id,
+                'create_webhook' => false,
+            ])
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        // The collision was reported, the other project still landed.
+        $this->assertNotNull(Package::query()->where('repository', 'https://github.com/acme/gadgets')->first());
+        $this->assertNull(Package::query()->where('repository', 'https://github.com/acme/widgets')->first());
+
+        Queue::assertPushed(SyncPackageJob::class, 1);
+    }
+}

--- a/tests/Feature/OperationalCommandsTest.php
+++ b/tests/Feature/OperationalCommandsTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TokenAbility;
+use App\Jobs\SyncPackageJob;
+use App\Models\DeployToken;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Token;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * The operational console commands: everything the panel does, scriptable.
+ */
+class OperationalCommandsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_add_creates_the_account_with_roles_and_prints_a_reset_link(): void
+    {
+        Role::findOrCreate('developer', 'web');
+
+        $this->artisan('user:add', [
+            'email' => 'dev@example.com',
+            '--name' => 'Dev Example',
+            '--role' => ['developer'],
+        ])
+            ->expectsOutputToContain('single-use link')
+            ->assertSuccessful();
+
+        $user = User::query()->where('email', 'dev@example.com')->sole();
+
+        $this->assertSame('Dev Example', $user->name);
+        $this->assertTrue($user->hasRole('developer'));
+    }
+
+    public function test_user_add_rejects_unknown_roles_and_duplicate_emails(): void
+    {
+        $this->artisan('user:add', ['email' => 'dev@example.com', '--role' => ['nope']])
+            ->assertFailed();
+
+        $this->assertDatabaseMissing('users', ['email' => 'dev@example.com']);
+
+        User::factory()->create(['email' => 'taken@example.com']);
+
+        $this->artisan('user:add', ['email' => 'taken@example.com'])->assertFailed();
+    }
+
+    public function test_user_reset_password_prints_a_link_for_a_known_account(): void
+    {
+        User::factory()->create(['email' => 'dev@example.com']);
+
+        $this->artisan('user:reset-password', ['email' => 'dev@example.com'])
+            ->expectsOutputToContain('single-use link')
+            ->assertSuccessful();
+
+        $this->artisan('user:reset-password', ['email' => 'nobody@example.com'])->assertFailed();
+    }
+
+    public function test_package_add_creates_the_package_and_queues_its_first_sync(): void
+    {
+        Queue::fake();
+
+        $this->artisan('package:add', [
+            'repository' => 'https://github.com/acme/widgets',
+            '--no-webhook' => true,
+        ])->assertSuccessful();
+
+        $package = Package::query()->where('name', 'acme/widgets')->sole();
+
+        $this->assertTrue($package->composerRepository->isDefault());
+
+        Queue::assertPushed(SyncPackageJob::class);
+    }
+
+    public function test_package_add_targets_a_named_composer_repository(): void
+    {
+        Queue::fake();
+        Repository::factory()->create(['path' => 'internal']);
+
+        $this->artisan('package:add', [
+            'repository' => 'https://github.com/acme/widgets',
+            '--repo' => 'internal',
+            '--no-webhook' => true,
+            '--no-sync' => true,
+        ])->assertSuccessful();
+
+        $this->assertSame(
+            'internal',
+            Package::query()->where('name', 'acme/widgets')->sole()->composerRepository->path,
+        );
+
+        $this->artisan('package:add', [
+            'repository' => 'https://github.com/acme/other',
+            '--repo' => 'missing',
+        ])->assertFailed();
+    }
+
+    public function test_package_add_refuses_a_duplicate(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets', 'repository' => 'https://github.com/acme/widgets']);
+
+        $this->artisan('package:add', [
+            'repository' => 'https://github.com/acme/widgets',
+            '--no-webhook' => true,
+        ])->assertFailed();
+    }
+
+    public function test_package_delete_removes_rows_and_stored_archives(): void
+    {
+        config(['filesystems.dists' => 's3']);
+        Storage::fake('s3');
+        Storage::disk('s3')->put('packages/acme/widgets/v100.zip', 'zip-bytes');
+
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        $package->versions()->create([
+            'version' => 'v1.0.0',
+            'reference' => str_repeat('a', 40),
+            'is_dev' => false,
+            'archive_path' => 'packages/acme/widgets/v100.zip',
+            'shasum' => sha1('zip-bytes'),
+            'metadata' => ['name' => 'acme/widgets', 'version' => 'v1.0.0'],
+        ]);
+
+        $this->artisan('package:delete', ['name' => 'acme/widgets', '--force' => true])
+            ->assertSuccessful();
+
+        $this->assertDatabaseMissing('packages', ['name' => 'acme/widgets']);
+        Storage::disk('s3')->assertMissing('packages/acme/widgets/v100.zip');
+    }
+
+    public function test_package_delete_demands_a_repo_when_the_name_is_served_twice(): void
+    {
+        $internal = Repository::factory()->create(['path' => 'internal']);
+        Package::factory()->create(['name' => 'acme/widgets']);
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $internal->id]);
+
+        $this->artisan('package:delete', ['name' => 'acme/widgets', '--force' => true])->assertFailed();
+
+        $this->artisan('package:delete', ['name' => 'acme/widgets', '--repo' => 'internal', '--force' => true])
+            ->assertSuccessful();
+
+        $this->assertDatabaseCount('packages', 1);
+    }
+
+    public function test_token_add_issues_for_a_user_and_prints_the_plain_text(): void
+    {
+        User::factory()->create(['email' => 'dev@example.com']);
+
+        $this->artisan('token:add', ['name' => 'laptop', '--user' => 'dev@example.com'])
+            ->expectsOutputToContain('pp_')
+            ->assertSuccessful();
+
+        $token = Token::query()->sole();
+
+        $this->assertSame(User::class, $token->tokenable_type);
+        $this->assertSame([TokenAbility::RepositoryRead->value], $token->abilities);
+    }
+
+    public function test_token_add_creates_a_deploy_token_on_demand(): void
+    {
+        $this->artisan('token:add', [
+            'name' => 'ci',
+            '--deploy' => 'production',
+            '--ability' => ['read', 'write'],
+            '--expires-days' => '30',
+        ])->assertSuccessful();
+
+        $deployToken = DeployToken::query()->where('name', 'production')->sole();
+        $token = $deployToken->token;
+
+        $this->assertNotNull($token);
+        $this->assertSame(
+            [TokenAbility::RepositoryRead->value, TokenAbility::RepositoryWrite->value],
+            $token->abilities,
+        );
+        $this->assertNotNull($token->expires_at);
+    }
+
+    public function test_token_add_demands_exactly_one_owner(): void
+    {
+        $this->artisan('token:add', ['name' => 'nobody'])->assertFailed();
+
+        $this->artisan('token:add', ['name' => 'both', '--user' => 'a@b.c', '--deploy' => 'x'])->assertFailed();
+    }
+
+    public function test_token_revoke_by_prefix(): void
+    {
+        $token = Token::factory()->create();
+
+        $this->artisan('token:revoke', ['prefix' => $token->token_prefix])->assertSuccessful();
+
+        $this->assertSoftDeleted('access_tokens', ['id' => $token->id]);
+
+        $this->artisan('token:revoke', ['prefix' => $token->token_prefix])->assertFailed();
+    }
+}

--- a/tests/Feature/PackageRebuildTest.php
+++ b/tests/Feature/PackageRebuildTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Packages\Pages\ViewPackage;
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\User;
+use App\Services\RebuildPackage;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Rebuild is a forced sync: every version re-imported from the source,
+ * trusting nothing stored, idempotent by design.
+ */
+class PackageRebuildTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake(config('filesystems.dists'));
+
+        Http::fake([
+            'api.github.com/repos/acme/widgets/tags*' => Http::response([
+                ['name' => 'v1.0.0', 'commit' => ['sha' => str_repeat('a', 40)]],
+            ]),
+            'api.github.com/repos/acme/widgets/branches*' => Http::response([]),
+            'api.github.com/repos/acme/widgets/contents/composer.json*' => Http::response([
+                'name' => 'acme/widgets',
+                'description' => 'Widgets for Acme.',
+                'type' => 'library',
+            ]),
+            'api.github.com/repos/acme/widgets/commits/*' => Http::response([
+                'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'api.github.com/repos/acme/widgets/zipball/*' => fn () => Http::response('zip-bytes', 200, [
+                'Content-Type' => 'application/zip',
+            ]),
+        ]);
+    }
+
+    private function makeSyncedPackage(): Package
+    {
+        $package = Package::factory()->unreleased()->create([
+            'name' => 'acme/widgets',
+            'repository' => 'https://github.com/acme/widgets',
+            'token' => 'ghp_secret',
+        ]);
+
+        app(RebuildPackage::class)->rebuild($package);
+
+        return $package->refresh();
+    }
+
+    public function test_rebuild_restores_a_mutated_row_and_a_missing_archive(): void
+    {
+        $package = $this->makeSyncedPackage();
+
+        $version = $package->versions()->sole();
+
+        // The two corruptions a sync would never notice: the row still says
+        // stored-and-unmoved, so unchanged() skips it.
+        $version->forceFill(['metadata' => ['name' => 'acme/widgets', 'require' => ['php' => 'corrupted']]])->save();
+        Storage::disk(config('filesystems.dists'))->delete($version->archive_path);
+
+        app(RebuildPackage::class)->rebuild($package);
+
+        $version->refresh();
+
+        $this->assertArrayNotHasKey('require', $version->metadata);
+        $this->assertSame('Widgets for Acme.', $version->metadata['description']);
+        $this->assertSame(sha1('zip-bytes'), $version->shasum);
+        Storage::disk(config('filesystems.dists'))->assertExists($version->archive_path);
+    }
+
+    public function test_rebuild_prunes_rows_the_source_no_longer_publishes(): void
+    {
+        $package = $this->makeSyncedPackage();
+
+        $package->versions()->create([
+            'version' => '9.9.9',
+            'reference' => str_repeat('f', 40),
+            'is_dev' => false,
+            'metadata' => ['name' => 'acme/widgets', 'version' => '9.9.9'],
+        ]);
+
+        app(RebuildPackage::class)->rebuild($package);
+
+        $this->assertSame(['1.0.0'], $package->versions()->pluck('version')->all());
+    }
+
+    public function test_rebuild_is_idempotent(): void
+    {
+        $package = $this->makeSyncedPackage();
+
+        $first = $package->versions()->get(['version', 'reference', 'shasum', 'metadata'])->toArray();
+
+        app(RebuildPackage::class)->rebuild($package);
+
+        $second = $package->versions()->get(['version', 'reference', 'shasum', 'metadata'])->toArray();
+
+        $this->assertSame($first, $second);
+        $this->assertSame('1.0.0', $package->fresh()->latest_version);
+    }
+
+    public function test_the_command_rebuilds_one_or_all_packages(): void
+    {
+        $package = $this->makeSyncedPackage();
+
+        // An uploaded artifact has no source; the sweep must skip it, not die.
+        Package::factory()->create(['name' => 'acme/artifact', 'repository' => null]);
+
+        $this->artisan('package:rebuild', ['name' => 'acme/widgets'])->assertSuccessful();
+        $this->artisan('package:rebuild')->assertSuccessful();
+
+        $this->assertSame(1, $package->versions()->count());
+
+        $this->artisan('package:rebuild', ['name' => 'acme/artifact'])->assertFailed();
+    }
+
+    public function test_the_panel_action_queues_a_forced_sync(): void
+    {
+        $package = $this->makeSyncedPackage();
+
+        Queue::fake();
+
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        Livewire::test(ViewPackage::class, ['record' => $package->getKey()])
+            ->callAction('rebuild')
+            ->assertNotified();
+
+        Queue::assertPushed(SyncPackageJob::class, fn (SyncPackageJob $job): bool => $job->force);
+    }
+}

--- a/tests/Feature/PackageResourceTest.php
+++ b/tests/Feature/PackageResourceTest.php
@@ -5,9 +5,12 @@ namespace Tests\Feature;
 use App\Filament\Resources\Packages\Pages\CreatePackage;
 use App\Filament\Resources\Packages\Pages\EditPackage;
 use App\Filament\Resources\Packages\Pages\ListPackages;
+use App\Jobs\SyncPackageJob;
 use App\Models\Package;
+use App\Models\Source;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -32,6 +35,8 @@ class PackageResourceTest extends TestCase
 
     public function test_a_package_can_be_created(): void
     {
+        Queue::fake([SyncPackageJob::class]);
+
         Livewire::test(CreatePackage::class)
             ->fillForm([
                 'name' => 'acme/widgets',
@@ -46,10 +51,16 @@ class PackageResourceTest extends TestCase
             'repository' => 'https://github.com/acme/widgets',
             'description' => 'Widgets for Acme.',
         ]);
+
+        // A new package imports its versions right away rather than waiting
+        // for the next push.
+        Queue::assertPushed(SyncPackageJob::class, fn (SyncPackageJob $job): bool => $job->package->name === 'acme/widgets');
     }
 
     public function test_a_package_can_be_created_without_a_release(): void
     {
+        Queue::fake([SyncPackageJob::class]);
+
         Livewire::test(CreatePackage::class)
             ->fillForm([
                 'name' => 'acme/preview',
@@ -62,6 +73,22 @@ class PackageResourceTest extends TestCase
             'name' => 'acme/preview',
             'latest_version' => null,
         ]);
+    }
+
+    public function test_arriving_from_a_source_preselects_it(): void
+    {
+        $source = Source::factory()->create();
+
+        Livewire::withQueryParams(['source' => $source->getKey()])
+            ->test(CreatePackage::class)
+            ->assertSchemaStateSet(['source_id' => $source->getKey()]);
+    }
+
+    public function test_an_unknown_source_in_the_url_is_ignored(): void
+    {
+        Livewire::withQueryParams(['source' => 999])
+            ->test(CreatePackage::class)
+            ->assertSchemaStateSet(['source_id' => null]);
     }
 
     public function test_the_repository_must_be_a_unique_url(): void

--- a/tests/Feature/PackageSyncBatchTest.php
+++ b/tests/Feature/PackageSyncBatchTest.php
@@ -283,13 +283,17 @@ class PackageSyncBatchTest extends TestCase
         Bus::fake();
 
         $package = $this->makePackage();
-        $package->forceFill(['sync_batch_id' => $this->storedBatch([
+        $package->forceFill(['sync_batch_id' => $lost = $this->storedBatch([
             'created_at' => now()->subHours(3)->getTimestamp(),
         ])])->save();
 
         (new SyncPackageJob($package))->handle();
 
         Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->first() instanceof DiscoverVersions);
+
+        // The lost batch may still hold queued import jobs; cancelled, they
+        // no-op instead of racing the new sync's prune and imports.
+        $this->assertNotNull(DB::table('job_batches')->where('id', $lost)->value('cancelled_at'));
     }
 
     public function test_the_view_page_widget_shows_the_running_import(): void

--- a/tests/Feature/PackageSyncBatchTest.php
+++ b/tests/Feature/PackageSyncBatchTest.php
@@ -114,7 +114,8 @@ class PackageSyncBatchTest extends TestCase
         $package->refresh();
 
         $this->assertSame('acme/widgets', $package->name);
-        $this->assertSame('v1.1.0', $package->latest_version);
+        // Tags are stored under their normalized spelling: v1.1.0 → 1.1.0.
+        $this->assertSame('1.1.0', $package->latest_version);
         $this->assertSame('Widgets for Acme.', $package->description);
         $this->assertNotNull($package->last_synced_at);
         $this->assertNull($package->sync_error);
@@ -182,13 +183,13 @@ class PackageSyncBatchTest extends TestCase
 
         // Three of four versions made it; the broken one is simply missing.
         $this->assertSame(
-            ['2.x-dev', 'dev-main', 'v1.0.0'],
+            ['1.0.0', '2.x-dev', 'dev-main'],
             $package->versions()->pluck('version')->sort()->values()->all(),
         );
 
         // The package still counts as synced — and says what it is missing.
         $this->assertNotNull($package->last_synced_at);
-        $this->assertSame('v1.0.0', $package->latest_version);
+        $this->assertSame('1.0.0', $package->latest_version);
         $this->assertSame('1 of 4 version imports failed; the next sync will retry them.', $package->sync_error);
 
         $this->assertSame(1, $package->syncBatch()->failedJobs);

--- a/tests/Feature/PackageSyncBatchTest.php
+++ b/tests/Feature/PackageSyncBatchTest.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Packages\Widgets\PackageSyncProgress;
+use App\Jobs\DiscoverVersions;
+use App\Jobs\PackageSyncBatch;
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\User;
+use App\Notifications\PackageSyncFailed;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * The sync as a job batch: discovery fanning out one import job per ref,
+ * failures costing one version rather than the sync, and the panel able to
+ * watch it all happen.
+ */
+class PackageSyncBatchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Syncing stores an archive per version on the dist disk.
+        Storage::fake(config('filesystems.dists'));
+    }
+
+    /**
+     * Fake the endpoints a sync reads. Overrides are registered ahead of the
+     * defaults because the first matching stub wins.
+     *
+     * @param  array<string, mixed>  $overrides
+     */
+    private function fakeGitHub(array $overrides = []): void
+    {
+        Http::fake($overrides + [
+            'api.github.com/repos/acme/widgets/tags*' => Http::response([
+                ['name' => 'v1.0.0', 'commit' => ['sha' => str_repeat('a', 40)]],
+                ['name' => 'v1.1.0', 'commit' => ['sha' => str_repeat('b', 40)]],
+            ]),
+            'api.github.com/repos/acme/widgets/branches*' => Http::response([
+                ['name' => 'main', 'commit' => ['sha' => str_repeat('d', 40)]],
+                ['name' => '2.x', 'commit' => ['sha' => str_repeat('e', 40)]],
+            ]),
+            'api.github.com/repos/acme/widgets/contents/composer.json*' => Http::response([
+                'name' => 'acme/widgets',
+                'description' => 'Widgets for Acme.',
+                'type' => 'library',
+            ]),
+            'api.github.com/repos/acme/widgets/commits/*' => Http::response([
+                'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'api.github.com/repos/acme/widgets/zipball/*' => fn () => Http::response('zip-bytes', 200, [
+                'Content-Type' => 'application/zip',
+            ]),
+        ]);
+    }
+
+    private function makePackage(): Package
+    {
+        return Package::factory()->unreleased()->create([
+            'name' => 'acme/widgets-placeholder',
+            'repository' => 'https://github.com/acme/widgets',
+        ]);
+    }
+
+    /**
+     * A batch row as the repository would store it, so tests can stage a sync
+     * in any state without racing a real worker.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    private function storedBatch(array $attributes = []): string
+    {
+        $id = (string) Str::orderedUuid();
+
+        DB::table('job_batches')->insert($attributes + [
+            'id' => $id,
+            'name' => 'Sync acme/widgets',
+            'total_jobs' => 5,
+            'pending_jobs' => 3,
+            'failed_jobs' => 0,
+            'failed_job_ids' => '[]',
+            'options' => serialize([]),
+            'cancelled_at' => null,
+            'created_at' => now()->getTimestamp(),
+            'finished_at' => null,
+        ]);
+
+        return $id;
+    }
+
+    public function test_the_batch_imports_every_version_and_finalizes_the_package(): void
+    {
+        $this->fakeGitHub();
+
+        $package = $this->makePackage();
+
+        PackageSyncBatch::dispatchFor($package);
+
+        $package->refresh();
+
+        $this->assertSame('acme/widgets', $package->name);
+        $this->assertSame('v1.1.0', $package->latest_version);
+        $this->assertSame('Widgets for Acme.', $package->description);
+        $this->assertNotNull($package->last_synced_at);
+        $this->assertNull($package->sync_error);
+        $this->assertSame(4, $package->versions()->count());
+
+        // Every version got its archive, exactly as the inline sync stores it.
+        $this->assertSame(0, $package->versions()->whereNull('archive_path')->count());
+
+        // One discovery plus one import per ref, all accounted for.
+        $batch = $package->syncBatch();
+
+        $this->assertNotNull($batch);
+        $this->assertTrue($batch->finished());
+        $this->assertSame(5, $batch->totalJobs);
+        $this->assertSame(0, $batch->failedJobs);
+        $this->assertFalse($package->syncRunning());
+    }
+
+    public function test_a_second_batch_fans_out_no_import_for_unmoved_refs(): void
+    {
+        $this->fakeGitHub();
+
+        $package = $this->makePackage();
+
+        PackageSyncBatch::dispatchFor($package);
+        PackageSyncBatch::dispatchFor($package->refresh());
+
+        // Nothing moved, so the second batch is the discovery job alone.
+        $this->assertSame(1, $package->refresh()->syncBatch()->totalJobs);
+        $this->assertSame(4, $package->versions()->count());
+    }
+
+    /**
+     * The reason the sync is a batch at all: with allowFailures(), a tag whose
+     * archive cannot be fetched fails its own import job and nothing else.
+     * Needs a real queue — on the sync driver an exception has no batch to be
+     * isolated by.
+     */
+    public function test_a_failing_ref_costs_its_own_version_and_not_the_sync(): void
+    {
+        config(['queue.default' => 'database']);
+
+        // v1.1.0's zipball comes back as an HTML error page every time.
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/zipball/*' => fn ($request) => str_contains($request->url(), str_repeat('b', 40))
+                ? Http::response('<html>maintenance</html>', 200, ['Content-Type' => 'text/html'])
+                : Http::response('zip-bytes', 200, ['Content-Type' => 'application/zip']),
+        ]);
+
+        $package = $this->makePackage();
+
+        PackageSyncBatch::dispatchFor($package);
+
+        // First pass: discovery fans out, three imports land, the fourth is
+        // released for retry. The batch cannot finish until the retries are
+        // spent, so wind the clock past each backoff and let the worker at it.
+        $this->artisan('queue:work', ['--stop-when-empty' => true])->assertSuccessful();
+
+        foreach ([31, 121] as $seconds) {
+            $this->travelTo(now()->addSeconds($seconds));
+            $this->artisan('queue:work', ['--stop-when-empty' => true])->assertSuccessful();
+        }
+
+        $package->refresh();
+
+        // Three of four versions made it; the broken one is simply missing.
+        $this->assertSame(
+            ['2.x-dev', 'dev-main', 'v1.0.0'],
+            $package->versions()->pluck('version')->sort()->values()->all(),
+        );
+
+        // The package still counts as synced — and says what it is missing.
+        $this->assertNotNull($package->last_synced_at);
+        $this->assertSame('v1.0.0', $package->latest_version);
+        $this->assertSame('1 of 4 version imports failed; the next sync will retry them.', $package->sync_error);
+
+        $this->assertSame(1, $package->syncBatch()->failedJobs);
+        $this->assertFalse($package->syncRunning());
+    }
+
+    public function test_a_failed_discovery_cancels_the_batch_and_raises_the_alarm(): void
+    {
+        Notification::fake();
+
+        User::factory()->superAdmin()->create();
+
+        $package = $this->makePackage();
+
+        // An empty real batch to hang the job on; failed() must cancel it so
+        // the finalizer cannot stamp the package as freshly synced.
+        $batch = Bus::batch([])->allowFailures()->dispatch();
+
+        $job = (new DiscoverVersions($package))->withBatchId($batch->id);
+        $job->failed(new RuntimeException('GitHub timed out.'));
+
+        $this->assertSame('GitHub timed out.', $package->refresh()->sync_error);
+        $this->assertNull($package->last_synced_at);
+        $this->assertTrue(Bus::findBatch($batch->id)->cancelled());
+
+        Notification::assertSentTo(
+            User::query()->get(),
+            PackageSyncFailed::class,
+            fn (PackageSyncFailed $notification): bool => str_contains($notification->reason, 'GitHub timed out.'),
+        );
+    }
+
+    public function test_a_sync_steps_aside_while_a_batch_is_still_importing(): void
+    {
+        Bus::fake();
+
+        $package = $this->makePackage();
+        $package->forceFill(['sync_batch_id' => $this->storedBatch()])->save();
+
+        (new SyncPackageJob($package))->handle();
+
+        // No new batch — the running one owns the package's versions — but the
+        // sync is not dropped either: it comes back once the imports are done.
+        Bus::assertNothingBatched();
+        Bus::assertDispatched(
+            SyncPackageJob::class,
+            fn (SyncPackageJob $job): bool => $job->package->is($package) && $job->delay !== null,
+        );
+    }
+
+    public function test_a_finished_batch_does_not_block_the_next_sync(): void
+    {
+        Bus::fake();
+
+        $package = $this->makePackage();
+        $package->forceFill(['sync_batch_id' => $this->storedBatch([
+            'pending_jobs' => 0,
+            'finished_at' => now()->getTimestamp(),
+        ])])->save();
+
+        (new SyncPackageJob($package))->handle();
+
+        Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->first() instanceof DiscoverVersions);
+        Bus::assertNotDispatched(SyncPackageJob::class);
+    }
+
+    /**
+     * A batch that finished with failures never gets a finished_at — only its
+     * counts say every job has run. It must read as done, or the package could
+     * never sync again.
+     */
+    public function test_a_batch_done_but_for_failures_does_not_block_the_next_sync(): void
+    {
+        Bus::fake();
+
+        $package = $this->makePackage();
+        $package->forceFill(['sync_batch_id' => $this->storedBatch([
+            'pending_jobs' => 1,
+            'failed_jobs' => 1,
+        ])])->save();
+
+        $this->assertFalse($package->syncRunning());
+
+        (new SyncPackageJob($package))->handle();
+
+        Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->first() instanceof DiscoverVersions);
+    }
+
+    public function test_a_batch_lost_for_hours_does_not_wedge_the_package(): void
+    {
+        Bus::fake();
+
+        $package = $this->makePackage();
+        $package->forceFill(['sync_batch_id' => $this->storedBatch([
+            'created_at' => now()->subHours(3)->getTimestamp(),
+        ])])->save();
+
+        (new SyncPackageJob($package))->handle();
+
+        Bus::assertBatched(fn (PendingBatch $batch): bool => $batch->jobs->first() instanceof DiscoverVersions);
+    }
+
+    public function test_the_view_page_widget_shows_the_running_import(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $package = $this->makePackage();
+        $package->forceFill(['sync_batch_id' => $this->storedBatch([
+            'pending_jobs' => 3,
+            'failed_jobs' => 1,
+        ])])->save();
+
+        // total 5 − pending 3 = 2 processed; minus the discovery job, the
+        // panel reads "1 of 4 versions imported".
+        Livewire::test(PackageSyncProgress::class, ['record' => $package])
+            ->assertSee('Sync in progress')
+            ->assertSee('1 of 4 versions imported')
+            ->assertSee('1 failed');
+    }
+
+    public function test_the_widget_stays_out_of_the_way_when_nothing_is_running(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        Livewire::test(PackageSyncProgress::class, ['record' => $this->makePackage()])
+            ->assertDontSee('Sync in progress');
+    }
+}

--- a/tests/Feature/PackageSyncNotificationTest.php
+++ b/tests/Feature/PackageSyncNotificationTest.php
@@ -126,7 +126,8 @@ class PackageSyncNotificationTest extends TestCase
         Notification::assertSentTo(
             User::query()->get(),
             PackageVersionsPublished::class,
-            fn (PackageVersionsPublished $notification): bool => $notification->outcome->releases === ['v1.1.0']
+            // The tag v1.1.0 publishes as its normalized spelling.
+            fn (PackageVersionsPublished $notification): bool => $notification->outcome->releases === ['1.1.0']
                 && ! $notification->outcome->initialImport,
         );
     }

--- a/tests/Feature/PackageSyncNotificationTest.php
+++ b/tests/Feature/PackageSyncNotificationTest.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -33,6 +34,9 @@ class PackageSyncNotificationTest extends TestCase
 
         Notification::fake();
 
+        // Syncing stores an archive per version on the dist disk.
+        Storage::fake(config('filesystems.dists'));
+
         // Stubs are registered once and read the refs at request time, because
         // a second Http::fake() only ever adds to the first — and these tests
         // are about a repository that changes between two syncs.
@@ -45,6 +49,9 @@ class PackageSyncNotificationTest extends TestCase
             ]),
             'api.github.com/repos/acme/widgets/commits/*' => Http::response([
                 'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'api.github.com/repos/acme/widgets/zipball/*' => fn () => Http::response('zip-bytes', 200, [
+                'Content-Type' => 'application/zip',
             ]),
         ]);
     }

--- a/tests/Feature/PackageSyncTest.php
+++ b/tests/Feature/PackageSyncTest.php
@@ -161,6 +161,35 @@ class PackageSyncTest extends TestCase
         $this->assertSame(0, $package->versions()->count());
     }
 
+    /**
+     * One broken ref costs one version: the others still land, and the gap is
+     * recorded on the package instead of failing the sync outright.
+     */
+    public function test_one_bad_ref_does_not_fail_the_rest_of_the_sync(): void
+    {
+        // Only v1.1.0's zipball comes back as an HTML error page.
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/zipball/*' => fn ($request) => str_contains($request->url(), str_repeat('b', 40))
+                ? Http::response('<html>maintenance</html>', 200, ['Content-Type' => 'text/html'])
+                : Http::response('zip-bytes', 200, ['Content-Type' => 'application/zip']),
+        ]);
+
+        $package = $this->makePackage();
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $package->refresh();
+
+        $this->assertSame(
+            ['2.x-dev', 'dev-main', 'v1.0.0'],
+            $package->versions()->pluck('version')->sort()->values()->all(),
+        );
+
+        $this->assertNotNull($package->last_synced_at);
+        $this->assertSame('v1.0.0', $package->latest_version);
+        $this->assertSame('1 of 4 version imports failed; the next sync will retry them.', $package->sync_error);
+    }
+
     public function test_sync_records_the_commit_date_of_each_version(): void
     {
         $this->fakeGitHub();

--- a/tests/Feature/PackageSyncTest.php
+++ b/tests/Feature/PackageSyncTest.php
@@ -7,12 +7,21 @@ use App\Services\PackageSynchronizer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use RuntimeException;
 use Tests\TestCase;
 
 class PackageSyncTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Syncing stores an archive per version on the dist disk.
+        Storage::fake(config('filesystems.dists'));
+    }
 
     /**
      * Fake the endpoints a sync reads. Overrides are registered ahead of the
@@ -42,6 +51,9 @@ class PackageSyncTest extends TestCase
             'api.github.com/repos/acme/widgets/contents/composer.json*' => Http::response($composerJson),
             'api.github.com/repos/acme/widgets/commits/*' => Http::response([
                 'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'api.github.com/repos/acme/widgets/zipball/*' => fn () => Http::response('zip-bytes', 200, [
+                'Content-Type' => 'application/zip',
             ]),
         ]);
     }
@@ -83,6 +95,70 @@ class PackageSyncTest extends TestCase
 
         // The malformed tag is ignored rather than served.
         $this->assertNull($package->versions()->where('version', 'not-a-version')->first());
+    }
+
+    public function test_sync_stores_an_archive_with_a_shasum_for_every_version(): void
+    {
+        $this->fakeGitHub();
+
+        $package = $this->makePackage();
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $disk = Storage::disk(config('filesystems.dists'));
+
+        foreach ($package->versions()->get() as $version) {
+            $this->assertNotNull($version->archive_path, "{$version->version} has no stored archive.");
+            $this->assertSame(sha1('zip-bytes'), $version->shasum);
+            $disk->assertExists($version->archive_path);
+
+            // Paths carry the composer name, not the pre-sync placeholder.
+            $this->assertStringStartsWith('packages/acme/widgets/', $version->archive_path);
+        }
+    }
+
+    public function test_an_unchanged_version_missing_its_archive_is_backfilled(): void
+    {
+        $this->fakeGitHub();
+
+        $package = $this->makePackage();
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        // A row from before archives were stored: same ref, no archive.
+        $version = $package->versions()->where('version', 'v1.1.0')->sole();
+        $version->forceFill(['archive_path' => null, 'shasum' => null])->save();
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $version->refresh();
+
+        $this->assertNotNull($version->archive_path);
+        $this->assertSame(sha1('zip-bytes'), $version->shasum);
+        Storage::disk(config('filesystems.dists'))->assertExists($version->archive_path);
+    }
+
+    public function test_a_zipball_that_is_not_a_zip_fails_the_sync(): void
+    {
+        // A proxy's HTML error page arriving with a 200 must not be stored
+        // and served to Composer as an archive.
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/zipball/*' => Http::response('<html>maintenance</html>', 200, [
+                'Content-Type' => 'text/html',
+            ]),
+        ]);
+
+        $package = $this->makePackage();
+
+        try {
+            app(PackageSynchronizer::class)->sync($package);
+            $this->fail('Expected the sync to reject the non-zip download.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('instead of a zip archive', $exception->getMessage());
+        }
+
+        $this->assertStringContainsString('instead of a zip archive', (string) $package->refresh()->sync_error);
+        $this->assertSame(0, $package->versions()->count());
     }
 
     public function test_sync_records_the_commit_date_of_each_version(): void
@@ -130,8 +206,8 @@ class PackageSyncTest extends TestCase
         app(PackageSynchronizer::class)->sync($package);
 
         // The second sync still lists tags and branches — it cannot know what
-        // moved otherwise — but reads no composer.json or commit for the four
-        // unchanged refs.
+        // moved otherwise — but reads no composer.json, commit, or zipball
+        // for the four unchanged refs.
         $refListings = 2;
 
         $this->assertSame($requestsAfterFirstSync + $refListings, count(Http::recorded()));

--- a/tests/Feature/PackageSyncTest.php
+++ b/tests/Feature/PackageSyncTest.php
@@ -78,7 +78,8 @@ class PackageSyncTest extends TestCase
         $package->refresh();
 
         $this->assertSame('acme/widgets', $package->name);
-        $this->assertSame('v1.1.0', $package->latest_version);
+        // Tags are stored under their normalized spelling: v1.1.0 → 1.1.0.
+        $this->assertSame('1.1.0', $package->latest_version);
         $this->assertSame('Widgets for Acme.', $package->description);
         $this->assertSame('library', $package->type);
         $this->assertNotNull($package->last_synced_at);
@@ -87,10 +88,10 @@ class PackageSyncTest extends TestCase
         $versions = $package->versions()->pluck('is_dev', 'version');
 
         $this->assertSame([
+            '1.0.0' => false,
+            '1.1.0' => false,
             '2.x-dev' => true,
             'dev-main' => true,
-            'v1.0.0' => false,
-            'v1.1.0' => false,
         ], $versions->sortKeys()->all());
 
         // The malformed tag is ignored rather than served.
@@ -126,7 +127,7 @@ class PackageSyncTest extends TestCase
         app(PackageSynchronizer::class)->sync($package);
 
         // A row from before archives were stored: same ref, no archive.
-        $version = $package->versions()->where('version', 'v1.1.0')->sole();
+        $version = $package->versions()->where('version', '1.1.0')->sole();
         $version->forceFill(['archive_path' => null, 'shasum' => null])->save();
 
         app(PackageSynchronizer::class)->sync($package);
@@ -148,7 +149,7 @@ class PackageSyncTest extends TestCase
 
         // The columns say stored, but the disk lost the file — object storage
         // loss, or a deploy that wiped archives while the database survived.
-        $version = $package->versions()->where('version', 'v1.1.0')->sole();
+        $version = $package->versions()->where('version', '1.1.0')->sole();
         Storage::disk(config('filesystems.dists'))->delete($version->archive_path);
 
         app(PackageSynchronizer::class)->sync($package);
@@ -202,12 +203,12 @@ class PackageSyncTest extends TestCase
         $package->refresh();
 
         $this->assertSame(
-            ['2.x-dev', 'dev-main', 'v1.0.0'],
+            ['1.0.0', '2.x-dev', 'dev-main'],
             $package->versions()->pluck('version')->sort()->values()->all(),
         );
 
         $this->assertNotNull($package->last_synced_at);
-        $this->assertSame('v1.0.0', $package->latest_version);
+        $this->assertSame('1.0.0', $package->latest_version);
         $this->assertSame('1 of 4 version imports failed; the next sync will retry them.', $package->sync_error);
     }
 
@@ -219,7 +220,7 @@ class PackageSyncTest extends TestCase
 
         app(PackageSynchronizer::class)->sync($package);
 
-        $released = $package->versions()->where('version', 'v1.1.0')->sole()->released_at;
+        $released = $package->versions()->where('version', '1.1.0')->sole()->released_at;
 
         $this->assertNotNull($released);
         $this->assertSame('2026-02-01 12:00:00', $released->utc()->toDateTimeString());
@@ -240,7 +241,7 @@ class PackageSyncTest extends TestCase
         app(PackageSynchronizer::class)->sync($package);
 
         $this->assertSame(4, $package->versions()->count());
-        $this->assertNull($package->versions()->where('version', 'v1.1.0')->sole()->released_at);
+        $this->assertNull($package->versions()->where('version', '1.1.0')->sole()->released_at);
     }
 
     public function test_a_second_sync_does_not_refetch_refs_that_have_not_moved(): void
@@ -420,7 +421,7 @@ class PackageSyncTest extends TestCase
         app(PackageSynchronizer::class)->sync($package);
 
         $this->assertSame(205, $package->versions()->count());
-        $this->assertNotNull($package->versions()->where('version', 'v1.0.205')->first());
+        $this->assertNotNull($package->versions()->where('version', '1.0.205')->first());
     }
 
     public function test_sync_stops_at_a_full_page_that_advertises_no_successor(): void

--- a/tests/Feature/PackageSyncTest.php
+++ b/tests/Feature/PackageSyncTest.php
@@ -138,6 +138,27 @@ class PackageSyncTest extends TestCase
         Storage::disk(config('filesystems.dists'))->assertExists($version->archive_path);
     }
 
+    public function test_an_unchanged_version_whose_archive_file_is_gone_is_rebuilt(): void
+    {
+        $this->fakeGitHub();
+
+        $package = $this->makePackage();
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        // The columns say stored, but the disk lost the file — object storage
+        // loss, or a deploy that wiped archives while the database survived.
+        $version = $package->versions()->where('version', 'v1.1.0')->sole();
+        Storage::disk(config('filesystems.dists'))->delete($version->archive_path);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $version->refresh();
+
+        $this->assertNotNull($version->archive_path);
+        Storage::disk(config('filesystems.dists'))->assertExists($version->archive_path);
+    }
+
     public function test_a_zipball_that_is_not_a_zip_fails_the_sync(): void
     {
         // A proxy's HTML error page arriving with a 200 must not be stored

--- a/tests/Feature/PackageSyncTest.php
+++ b/tests/Feature/PackageSyncTest.php
@@ -118,6 +118,39 @@ class PackageSyncTest extends TestCase
         }
     }
 
+    /**
+     * The (repository_id, name) unique index would reject the first-sync
+     * rename with a bare query error; the conflict must fail the sync with a
+     * reason a human can act on instead.
+     */
+    public function test_a_composer_name_already_published_in_the_repository_fails_the_sync_clearly(): void
+    {
+        $this->fakeGitHub();
+
+        // Another package in the same (default) Composer repository already
+        // publishes the name this repository's composer.json declares.
+        Package::factory()->create([
+            'name' => 'acme/widgets',
+            'repository' => 'https://github.com/acme/widgets-fork',
+        ]);
+
+        $package = $this->makePackage();
+
+        try {
+            app(PackageSynchronizer::class)->sync($package);
+            $this->fail('The name conflict should have failed the sync.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('acme/widgets', $exception->getMessage());
+        }
+
+        $package->refresh();
+
+        // The reason lands where the panel reads it, and the placeholder name
+        // survives — the row was never renamed into the collision.
+        $this->assertStringContainsString('already publishes', (string) $package->sync_error);
+        $this->assertSame('acme/widgets-placeholder', $package->name);
+    }
+
     public function test_an_unchanged_version_missing_its_archive_is_backfilled(): void
     {
         $this->fakeGitHub();

--- a/tests/Feature/PackageWebhookRegistrationTest.php
+++ b/tests/Feature/PackageWebhookRegistrationTest.php
@@ -6,6 +6,7 @@ use App\Enums\WebhookCoverage;
 use App\Filament\Resources\Packages\Pages\CreatePackage;
 use App\Filament\Resources\Packages\Pages\EditPackage;
 use App\Filament\Resources\Packages\Pages\ViewPackage;
+use App\Jobs\SyncPackageJob;
 use App\Models\Package;
 use App\Models\Source;
 use App\Models\User;
@@ -14,6 +15,7 @@ use Filament\Actions\Testing\TestAction;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 use RuntimeException;
 use Tests\TestCase;
@@ -431,6 +433,8 @@ class PackageWebhookRegistrationTest extends TestCase
 
     public function test_creating_a_package_through_the_wizard_registers_its_webhook(): void
     {
+        Queue::fake([SyncPackageJob::class]);
+
         $this->fakeGitHub();
         $this->tokenSource();
 

--- a/tests/Feature/RegistryTotalsTest.php
+++ b/tests/Feature/RegistryTotalsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Widgets\RegistryTotals;
+use App\Models\Download;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class RegistryTotalsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_dashboard_registers_the_widget(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $this->assertContains(
+            RegistryTotals::class,
+            array_values(Filament::getPanel('admin')->getWidgets()),
+        );
+    }
+
+    public function test_it_counts_the_whole_registry_for_an_unscoped_user(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $repository = Repository::factory()->create();
+        $package = Package::factory()->create(['repository_id' => $repository->id]);
+        PackageVersion::factory()->count(2)->for($package)->create();
+
+        Download::create(['package_id' => $package->id, 'version' => '1.0.0']);
+
+        // The seeded default repository stands beside the factory-made one.
+        $this->assertSame([
+            'Repositories' => '2',
+            'Packages' => '1',
+            'Versions' => '2',
+            'Downloads' => '1',
+        ], $this->totals()->all());
+
+        Livewire::test(RegistryTotals::class)
+            ->assertSee('Registry totals')
+            ->assertSee('Repositories')
+            ->assertSee('Downloads');
+    }
+
+    public function test_totals_are_narrowed_to_what_the_user_may_see(): void
+    {
+        $this->actingAs($user = User::factory()->create());
+
+        $public = Repository::factory()->public()->create();
+        $granted = Repository::factory()->create();
+        $hidden = Repository::factory()->create();
+
+        $user->repositories()->attach($granted);
+
+        $visible = Package::factory()->create(['repository_id' => $public->id]);
+        Package::factory()->create(['repository_id' => $granted->id]);
+        $unseen = Package::factory()->create(['repository_id' => $hidden->id]);
+
+        // A single granted package also pulls its repository into view.
+        $adopted = Package::factory()->create(['repository_id' => Repository::factory()->create()->id]);
+        $user->packages()->attach($adopted);
+
+        PackageVersion::factory()->for($visible)->create();
+        PackageVersion::factory()->count(3)->for($unseen)->create();
+
+        Download::create(['package_id' => $visible->id, 'version' => '1.0.0']);
+        Download::create(['package_id' => $unseen->id, 'version' => '1.0.0']);
+
+        // Visible: the seeded default (public), $public, $granted, and the
+        // adopted package's home — but never $hidden.
+        $this->assertSame([
+            'Repositories' => '4',
+            'Packages' => '3',
+            'Versions' => '1',
+            'Downloads' => '1',
+        ], $this->totals()->all());
+    }
+
+    /**
+     * The quad's values keyed by label, read off the widget's view data.
+     *
+     * @return Collection<string, string>
+     */
+    private function totals(): Collection
+    {
+        $widget = new RegistryTotals;
+
+        $data = (fn (): array => $this->getViewData())->call($widget);
+
+        return collect($data['stats'])->pluck('value', 'label');
+    }
+}

--- a/tests/Feature/RepositoryResourceTest.php
+++ b/tests/Feature/RepositoryResourceTest.php
@@ -32,6 +32,15 @@ class RepositoryResourceTest extends TestCase
             ->assertCanSeeTableRecords($repositories);
     }
 
+    public function test_the_default_repository_lists_the_registry_root_not_a_bare_mount(): void
+    {
+        Repository::default();
+
+        Livewire::test(ListRepositories::class)
+            ->assertSee('/ (registry root)')
+            ->assertDontSee('/r/');
+    }
+
     public function test_a_repository_can_be_created(): void
     {
         Livewire::test(CreateRepository::class)

--- a/tests/Feature/RepositoryResourceTest.php
+++ b/tests/Feature/RepositoryResourceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Repositories\Pages\CreateRepository;
+use App\Filament\Resources\Repositories\Pages\EditRepository;
+use App\Filament\Resources\Repositories\Pages\ListRepositories;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class RepositoryResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->superAdmin()->create());
+    }
+
+    public function test_the_index_lists_repositories(): void
+    {
+        $repositories = Repository::factory()->count(3)->create();
+
+        Livewire::test(ListRepositories::class)
+            ->assertCanSeeTableRecords($repositories);
+    }
+
+    public function test_a_repository_can_be_created(): void
+    {
+        Livewire::test(CreateRepository::class)
+            ->fillForm([
+                'name' => 'Internal packages',
+                'path' => 'internal',
+                'public' => false,
+                'description' => 'Only for our own projects.',
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('repositories', [
+            'name' => 'Internal packages',
+            'path' => 'internal',
+            'public' => false,
+        ]);
+    }
+
+    public function test_a_created_repository_requires_a_path(): void
+    {
+        // Only the system creates the root repository; every admin-created
+        // one is mounted under /r/{path}.
+        Livewire::test(CreateRepository::class)
+            ->fillForm(['name' => 'No path'])
+            ->call('create')
+            ->assertHasFormErrors(['path' => 'required']);
+    }
+
+    public function test_the_path_must_be_a_url_slug(): void
+    {
+        Livewire::test(CreateRepository::class)
+            ->fillForm(['name' => 'Bad path', 'path' => 'Not A Slug!'])
+            ->call('create')
+            ->assertHasFormErrors(['path']);
+    }
+
+    public function test_the_path_and_name_must_be_unique(): void
+    {
+        Repository::factory()->create(['name' => 'Internal', 'path' => 'internal']);
+
+        Livewire::test(CreateRepository::class)
+            ->fillForm(['name' => 'Internal', 'path' => 'internal'])
+            ->call('create')
+            ->assertHasFormErrors(['name', 'path']);
+    }
+
+    public function test_the_default_repositorys_path_cannot_be_changed(): void
+    {
+        $default = Repository::default();
+
+        // The field is disabled for the default repository, so whatever the
+        // browser claims is never dehydrated into the saved state.
+        Livewire::test(EditRepository::class, ['record' => $default->getKey()])
+            ->fillForm(['name' => 'Renamed', 'path' => 'sneaky'])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $default->refresh();
+
+        $this->assertSame('Renamed', $default->name);
+        $this->assertNull($default->path);
+    }
+
+    public function test_deleting_is_blocked_while_packages_remain(): void
+    {
+        $repository = Repository::factory()->create();
+        Package::factory()->create(['repository_id' => $repository->id]);
+
+        Livewire::test(ListRepositories::class)
+            ->assertActionDisabled(TestAction::make('delete')->table($repository));
+    }
+
+    public function test_the_default_repository_cannot_be_deleted(): void
+    {
+        $default = Repository::default();
+
+        Livewire::test(ListRepositories::class)
+            ->assertActionDisabled(TestAction::make('delete')->table($default));
+    }
+
+    public function test_an_empty_named_repository_can_be_deleted(): void
+    {
+        $repository = Repository::factory()->create();
+
+        Livewire::test(ListRepositories::class)
+            ->callAction(TestAction::make('delete')->table($repository));
+
+        $this->assertDatabaseMissing('repositories', ['id' => $repository->id]);
+    }
+}

--- a/tests/Feature/SourceResourceTest.php
+++ b/tests/Feature/SourceResourceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Enums\SourceProvider;
 use App\Enums\WebhookState;
+use App\Filament\Resources\Packages\PackageResource;
 use App\Filament\Resources\Packages\Pages\EditPackage;
 use App\Filament\Resources\Sources\Pages\CreateSource;
 use App\Filament\Resources\Sources\Pages\EditSource;
@@ -332,6 +333,20 @@ class SourceResourceTest extends TestCase
         ])
             ->assertCanSeeTableRecords([$mine])
             ->assertCanNotSeeTableRecords([$theirs]);
+    }
+
+    public function test_the_packages_list_links_to_creating_a_package_for_the_source(): void
+    {
+        $source = Source::factory()->create(['account' => 'acme']);
+
+        Livewire::test(PackagesRelationManager::class, [
+            'ownerRecord' => $source,
+            'pageClass' => ViewSource::class,
+        ])
+            ->assertActionHasUrl(
+                TestAction::make('createPackage')->table(),
+                PackageResource::getUrl('create', ['source' => $source->getKey()]),
+            );
     }
 
     public function test_the_test_connection_action_records_the_result(): void

--- a/tests/Feature/SourceTest.php
+++ b/tests/Feature/SourceTest.php
@@ -8,6 +8,7 @@ use App\Services\PackageSynchronizer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class SourceTest extends TestCase
@@ -246,6 +247,7 @@ class SourceTest extends TestCase
 
     public function test_syncing_uses_the_source_credential_and_base_url(): void
     {
+        Storage::fake(config('filesystems.dists'));
         Http::fake([
             'api.github.com/app/installations/*/access_tokens' => Http::response([
                 'token' => 'ghs_installation',
@@ -261,6 +263,9 @@ class SourceTest extends TestCase
             ]),
             'github.acme.test/api/v3/repos/acme/widgets/commits/*' => Http::response([
                 'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'github.acme.test/api/v3/repos/acme/widgets/zipball/*' => fn () => Http::response('zip-bytes', 200, [
+                'Content-Type' => 'application/zip',
             ]),
         ]);
 

--- a/tests/Feature/SourceTest.php
+++ b/tests/Feature/SourceTest.php
@@ -165,8 +165,9 @@ class SourceTest extends TestCase
 
     public function test_a_package_without_a_source_uses_its_own_token_then_the_env_fallback(): void
     {
+        // No source exists for this owner, so the package stands alone.
         $package = Package::factory()->create([
-            'repository' => 'https://gitlab.com/acme/widgets',
+            'repository' => 'https://github.com/acme/widgets',
             'token' => 'ghp_package_level',
         ]);
 
@@ -177,6 +178,12 @@ class SourceTest extends TestCase
         $package->forceFill(['token' => null])->save();
 
         $this->assertSame('ghp_env', $package->fresh()->accessToken());
+
+        // The environment fallback is a GitHub credential; a package on any
+        // other host never sees it.
+        $gitlab = Package::factory()->create(['repository' => 'https://gitlab.com/acme/widgets']);
+
+        $this->assertNull($gitlab->accessToken());
     }
 
     public function test_a_new_package_is_linked_to_the_source_owning_its_repository(): void

--- a/tests/Feature/SourceTest.php
+++ b/tests/Feature/SourceTest.php
@@ -283,7 +283,7 @@ class SourceTest extends TestCase
 
         app(PackageSynchronizer::class)->sync($package);
 
-        $this->assertSame('v1.0.0', $package->fresh()->latest_version);
+        $this->assertSame('1.0.0', $package->fresh()->latest_version);
 
         // Every repository call went to the source's own host, carrying the
         // installation token rather than any package-level credential.

--- a/tests/Feature/SsoTest.php
+++ b/tests/Feature/SsoTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Auth\SsoProviderFactory;
+use App\Models\AuthenticationSource;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Two\User as SocialiteUser;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Runtime-configured SSO: the login page advertises active providers, and
+ * the callback resolves an external identity to a panel account.
+ */
+class SsoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AuthenticationSource $source;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::findOrCreate('developer', 'web');
+
+        $this->source = AuthenticationSource::factory()->create([
+            'name' => 'Acme SSO',
+            'default_role' => 'developer',
+        ]);
+    }
+
+    /**
+     * Swap the provider factory for one that returns this identity, skipping
+     * the real OAuth round trip.
+     */
+    private function returningIdentity(string $id, ?string $email, ?string $name = null): void
+    {
+        $identity = (new SocialiteUser)->map(['id' => $id, 'email' => $email, 'name' => $name]);
+
+        $this->mock(SsoProviderFactory::class)
+            ->shouldReceive('provider')
+            ->andReturn(new class($identity) implements Provider
+            {
+                public function __construct(private readonly SocialiteUser $identity) {}
+
+                public function redirect()
+                {
+                    return redirect('https://idp.example/authorize');
+                }
+
+                public function user()
+                {
+                    return $this->identity;
+                }
+            });
+    }
+
+    public function test_the_login_page_lists_active_providers_only(): void
+    {
+        AuthenticationSource::factory()->inactive()->create(['name' => 'Dormant IdP']);
+
+        $this->get('/admin/login')
+            ->assertOk()
+            ->assertSee('Continue with Acme SSO')
+            ->assertDontSee('Dormant IdP');
+    }
+
+    public function test_the_redirect_leg_sends_the_browser_to_the_provider(): void
+    {
+        $response = $this->get(route('sso.redirect', $this->source));
+
+        $response->assertRedirect();
+
+        $this->assertStringContainsString('github.com/login/oauth/authorize', $response->headers->get('Location'));
+        $this->assertStringContainsString($this->source->client_id, $response->headers->get('Location'));
+    }
+
+    public function test_an_inactive_provider_is_unreachable(): void
+    {
+        $dormant = AuthenticationSource::factory()->inactive()->create();
+
+        $this->get(route('sso.redirect', $dormant))->assertNotFound();
+        $this->get(route('sso.callback', $dormant))->assertNotFound();
+    }
+
+    public function test_a_bound_identity_signs_its_user_in(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('developer');
+        $user->forceFill([
+            'authentication_source_id' => $this->source->id,
+            'external_id' => 'ext-42',
+        ])->save();
+
+        $this->returningIdentity('ext-42', $user->email);
+
+        $this->get(route('sso.callback', $this->source))->assertRedirect('/admin');
+
+        $this->assertAuthenticatedAs($user);
+    }
+
+    public function test_an_existing_account_is_matched_by_email_and_bound(): void
+    {
+        $user = User::factory()->create(['email' => 'dev@example.com']);
+        $user->assignRole('developer');
+
+        $this->returningIdentity('ext-7', 'dev@example.com');
+
+        $this->get(route('sso.callback', $this->source))->assertRedirect('/admin');
+
+        $user->refresh();
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertSame($this->source->id, $user->authentication_source_id);
+        $this->assertSame('ext-7', $user->external_id);
+    }
+
+    public function test_an_unknown_identity_registers_just_in_time_with_the_default_role(): void
+    {
+        $this->returningIdentity('ext-9', 'new@example.com', 'New Dev');
+
+        $this->get(route('sso.callback', $this->source))->assertRedirect('/admin');
+
+        $user = User::query()->where('email', 'new@example.com')->sole();
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertSame('New Dev', $user->name);
+        $this->assertTrue($user->hasRole('developer'));
+        $this->assertNotNull($user->email_verified_at);
+        $this->assertSame('ext-9', $user->external_id);
+    }
+
+    public function test_registration_respects_the_domain_allowlist(): void
+    {
+        $this->source->update(['allowed_domains' => ['example.com']]);
+
+        $this->returningIdentity('ext-9', 'stranger@elsewhere.io');
+
+        $this->get(route('sso.callback', $this->source))
+            ->assertRedirect(route('filament.admin.auth.login'))
+            ->assertSessionHas('sso_error');
+
+        $this->assertGuest();
+        $this->assertDatabaseMissing('users', ['email' => 'stranger@elsewhere.io']);
+    }
+
+    public function test_registration_can_be_switched_off(): void
+    {
+        $this->source->update(['allow_registration' => false]);
+
+        $this->returningIdentity('ext-9', 'new@example.com');
+
+        $this->get(route('sso.callback', $this->source))
+            ->assertRedirect(route('filament.admin.auth.login'))
+            ->assertSessionHas('sso_error');
+
+        $this->assertGuest();
+    }
+
+    public function test_a_matched_account_without_a_role_is_told_so_rather_than_403ed(): void
+    {
+        $user = User::factory()->create(['email' => 'dev@example.com']);
+
+        $this->returningIdentity('ext-7', 'dev@example.com');
+
+        $this->get(route('sso.callback', $this->source))
+            ->assertRedirect(route('filament.admin.auth.login'))
+            ->assertSessionHas('sso_error');
+
+        $this->assertGuest();
+    }
+}

--- a/tests/Feature/SyncPackageJobTest.php
+++ b/tests/Feature/SyncPackageJobTest.php
@@ -68,7 +68,7 @@ class SyncPackageJobTest extends TestCase
         $this->app->call([new SyncPackageJob($package), 'handle']);
 
         $this->assertSame('acme/widgets', $package->refresh()->name);
-        $this->assertSame('v1.0.0', $package->latest_version);
+        $this->assertSame('1.0.0', $package->latest_version);
         $this->assertSame(1, $package->versions()->count());
     }
 
@@ -283,7 +283,7 @@ class SyncPackageJobTest extends TestCase
         $this->assertDatabaseCount('jobs', 0);
         $this->assertDatabaseCount('failed_jobs', 0);
         $this->assertSame('acme/widgets', $package->refresh()->name);
-        $this->assertSame('v1.0.0', $package->latest_version);
+        $this->assertSame('1.0.0', $package->latest_version);
         $this->assertNotNull($package->last_synced_at);
         $this->assertNull($package->sync_error);
 

--- a/tests/Feature/SyncPackageJobTest.php
+++ b/tests/Feature/SyncPackageJobTest.php
@@ -251,7 +251,8 @@ class SyncPackageJobTest extends TestCase
 
     /**
      * The end-to-end path, with no Queue::fake() anywhere: the command writes a
-     * real row to the `jobs` table and a real worker picks it up and syncs.
+     * real row to the `jobs` table and a real worker picks up the whole
+     * cascade — dispatcher, discovery, one import per ref, finalization.
      * Everything above this proves only that dispatch() was called.
      */
     public function test_a_queued_sync_is_picked_up_and_run_by_a_worker(): void
@@ -265,17 +266,19 @@ class SyncPackageJobTest extends TestCase
 
         $this->artisan('packages:sync', ['--queue' => true])->assertSuccessful();
 
-        // Nothing has run yet: the work is parked in the database.
+        // Nothing has run yet: the work is parked in the database, and the
+        // batch does not exist until the dispatcher job runs.
         $this->assertDatabaseCount('jobs', 1);
+        $this->assertDatabaseCount('job_batches', 0);
 
         $payload = json_decode((string) DB::table('jobs')->value('payload'), true);
 
         $this->assertSame(SyncPackageJob::class, $payload['displayName']);
         $this->assertSame(3, $payload['maxTries']);
-        $this->assertSame(600, $payload['timeout']);
+        $this->assertSame(60, $payload['timeout']);
         $this->assertNull($package->refresh()->last_synced_at);
 
-        $this->artisan('queue:work', ['--once' => true])->assertSuccessful();
+        $this->artisan('queue:work', ['--stop-when-empty' => true])->assertSuccessful();
 
         $this->assertDatabaseCount('jobs', 0);
         $this->assertDatabaseCount('failed_jobs', 0);
@@ -283,6 +286,11 @@ class SyncPackageJobTest extends TestCase
         $this->assertSame('v1.0.0', $package->latest_version);
         $this->assertNotNull($package->last_synced_at);
         $this->assertNull($package->sync_error);
+
+        // The batch ran to completion and the package knows which one it was.
+        $this->assertNotNull($package->syncBatch());
+        $this->assertTrue($package->syncBatch()->finished());
+        $this->assertFalse($package->syncRunning());
     }
 
     public function test_a_worker_records_a_failed_sync_rather_than_losing_it(): void
@@ -295,11 +303,16 @@ class SyncPackageJobTest extends TestCase
 
         $this->artisan('packages:sync', ['--queue' => true])->assertSuccessful();
 
+        // The dispatcher job never touches GitHub, so it succeeds and leaves
+        // the discovery job on the queue.
+        $this->artisan('queue:work', ['--once' => true])->assertSuccessful();
+
         // The worker exits 0 whether or not the job it ran threw; the outcome
         // is recorded on the job, so that is where to look.
         $this->artisan('queue:work', ['--once' => true])->assertSuccessful();
 
-        // One attempt of three: the job goes back to the queue, not to the floor.
+        // One attempt of three: the discovery goes back to the queue, not to
+        // the floor.
         $this->assertDatabaseCount('failed_jobs', 0);
         $this->assertSame(1, DB::table('jobs')->value('attempts'));
         $this->assertStringContainsString('Bad credentials', (string) $package->refresh()->sync_error);

--- a/tests/Feature/SyncPackageJobTest.php
+++ b/tests/Feature/SyncPackageJobTest.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 use RuntimeException;
 use Tests\TestCase;
@@ -37,6 +38,9 @@ class SyncPackageJobTest extends TestCase
      */
     private function fakeGitHub(): void
     {
+        // A successful sync stores each version's archive on the dist disk.
+        Storage::fake(config('filesystems.dists'));
+
         Http::fake([
             'api.github.com/repos/acme/widgets/tags*' => Http::response([
                 ['name' => 'v1.0.0', 'commit' => ['sha' => str_repeat('a', 40)]],
@@ -48,6 +52,9 @@ class SyncPackageJobTest extends TestCase
             ]),
             'api.github.com/repos/acme/widgets/commits/*' => Http::response([
                 'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'api.github.com/repos/acme/widgets/zipball/*' => fn () => Http::response('zip-bytes', 200, [
+                'Content-Type' => 'application/zip',
             ]),
         ]);
     }

--- a/tests/Feature/UserAccessScopingTest.php
+++ b/tests/Feature/UserAccessScopingTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\TokenAbility;
+use App\Filament\Resources\Packages\PackageResource;
+use App\Filament\Resources\Packages\Pages\ListPackages;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Token;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Row-level access for users without Unscoped:Package: public repositories
+ * plus explicit grants, in the panel and through their personal tokens alike.
+ */
+class UserAccessScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $internal;
+
+    private Repository $other;
+
+    private Package $widgets;
+
+    private Package $gadgets;
+
+    private Package $secret;
+
+    private Package $open;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->internal = Repository::factory()->create(['path' => 'internal', 'public' => false]);
+        $this->other = Repository::factory()->create(['path' => 'other', 'public' => false]);
+
+        $this->widgets = $this->makeServedPackage('acme/widgets', $this->internal);
+        $this->gadgets = $this->makeServedPackage('acme/gadgets', $this->internal);
+        $this->secret = $this->makeServedPackage('acme/secret', $this->other);
+        $this->open = $this->makeServedPackage('acme/open', Repository::default());
+    }
+
+    private function makeServedPackage(string $name, Repository $repository): Package
+    {
+        $package = Package::factory()->create(['name' => $name, 'repository_id' => $repository->id]);
+
+        $package->versions()->create([
+            'version' => 'v1.0.0',
+            'reference' => sha1($name),
+            'is_dev' => false,
+            'metadata' => ['name' => $name, 'version' => 'v1.0.0'],
+        ]);
+
+        return $package;
+    }
+
+    /**
+     * A panel user whose role can read packages but is not unscoped — the
+     * shape of an external collaborator's account.
+     */
+    private function makeScopedUser(): User
+    {
+        $role = Role::findOrCreate('developer', 'web');
+        $role->givePermissionTo(['ViewAny:Package', 'View:Package']);
+
+        return tap(User::factory()->create())->assignRole($role);
+    }
+
+    public function test_a_scoped_user_sees_public_packages_and_their_grants_only(): void
+    {
+        $user = $this->makeScopedUser();
+        $user->packages()->attach($this->widgets);
+
+        $this->actingAs($user);
+
+        Livewire::test(ListPackages::class)
+            ->assertCanSeeTableRecords([$this->widgets, $this->open])
+            ->assertCanNotSeeTableRecords([$this->gadgets, $this->secret]);
+    }
+
+    public function test_a_repository_grant_covers_all_of_its_packages(): void
+    {
+        $user = $this->makeScopedUser();
+        $user->repositories()->attach($this->internal);
+
+        $this->actingAs($user);
+
+        Livewire::test(ListPackages::class)
+            ->assertCanSeeTableRecords([$this->widgets, $this->gadgets, $this->open])
+            ->assertCanNotSeeTableRecords([$this->secret]);
+    }
+
+    public function test_an_ungranted_package_page_is_out_of_reach_entirely(): void
+    {
+        $this->actingAs($this->makeScopedUser());
+
+        $this->get(PackageResource::getUrl('view', ['record' => $this->gadgets]))
+            ->assertNotFound();
+    }
+
+    public function test_a_super_admin_is_unscoped(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        Livewire::test(ListPackages::class)
+            ->assertCanSeeTableRecords([$this->widgets, $this->gadgets, $this->secret, $this->open]);
+    }
+
+    public function test_a_personal_token_inherits_its_owners_reach(): void
+    {
+        $user = $this->makeScopedUser();
+        $user->packages()->attach($this->widgets);
+
+        $new = Token::issue($user, 'laptop', [TokenAbility::RepositoryRead]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/widgets']]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/other/p2/acme/secret.json')
+            ->assertNotFound();
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/open']]);
+    }
+
+    public function test_a_users_token_without_grants_still_reads_public_repositories(): void
+    {
+        $new = Token::issue($this->makeScopedUser(), 'laptop', [TokenAbility::RepositoryRead]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/open']]);
+
+        $this->withBasicAuth('token', $new->plainText)
+            ->getJson('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => []]);
+    }
+}

--- a/tests/Feature/VersionOrderingTest.php
+++ b/tests/Feature/VersionOrderingTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Support\VersionNormalizer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The /p2 responses sort releases by the normalizer's order string — the
+ * database-friendly fix for string sorts putting 1.10.0 below 1.9.0.
+ */
+class VersionOrderingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_metadata_sorts_releases_semantically(): void
+    {
+        $normalizer = new VersionNormalizer;
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        foreach (['1.9.0', '1.10.0', '1.10.0-RC1'] as $index => $version) {
+            $package->versions()->create([
+                'version' => $version,
+                'order' => $normalizer->order($version),
+                'reference' => sha1($version),
+                'is_dev' => false,
+                'metadata' => ['name' => 'acme/widgets', 'version' => $version],
+            ]);
+        }
+
+        $versions = $this->get('/p2/acme/widgets.json')
+            ->assertOk()
+            ->json('packages.acme/widgets');
+
+        $this->assertSame(
+            ['1.10.0', '1.10.0-RC1', '1.9.0'],
+            array_column($versions, 'version'),
+        );
+    }
+}

--- a/tests/Unit/VersionNormalizerTest.php
+++ b/tests/Unit/VersionNormalizerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\VersionNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class VersionNormalizerTest extends TestCase
+{
+    private VersionNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->normalizer = new VersionNormalizer;
+    }
+
+    public function test_tags_normalize_to_one_spelling(): void
+    {
+        $this->assertSame('1.2.3', $this->normalizer->version('v1.2.3'));
+        $this->assertSame('1.2', $this->normalizer->version('1.2'));
+        $this->assertSame('1.2.3.4', $this->normalizer->version('1.2.3.4'));
+        $this->assertSame('1.0.0-beta2', $this->normalizer->version('1.0.0-beta.2'));
+        $this->assertSame('2.0.0-RC1', $this->normalizer->version('v2.0.0-RC.1'));
+        $this->assertSame('1.0.0-alpha3', $this->normalizer->version('1.0.0-alpha3'));
+    }
+
+    public function test_dev_versions_pass_through_untouched(): void
+    {
+        $this->assertSame('dev-main', $this->normalizer->version('dev-main'));
+        $this->assertSame('2.x-dev', $this->normalizer->version('2.x-dev'));
+    }
+
+    public function test_branches_map_to_packagist_style_dev_versions(): void
+    {
+        $this->assertSame('dev-main', $this->normalizer->devVersion('main'));
+        $this->assertSame('dev-develop', $this->normalizer->devVersion('develop'));
+        $this->assertSame('2.x-dev', $this->normalizer->devVersion('2.x'));
+        $this->assertSame('2.x-dev', $this->normalizer->devVersion('2'));
+        $this->assertSame('2.0.x-dev', $this->normalizer->devVersion('2.0'));
+        $this->assertSame('dev-feature/tokens', $this->normalizer->devVersion('feature/tokens'));
+    }
+
+    public function test_order_sorts_1_10_above_1_9(): void
+    {
+        $this->assertGreaterThan(
+            0,
+            strcmp($this->normalizer->order('1.10.0'), $this->normalizer->order('1.9.0')),
+        );
+    }
+
+    public function test_order_ranks_stability_correctly(): void
+    {
+        $versions = ['1.0.0-alpha1', '1.0.0-beta2', '1.0.0-beta10', '1.0.0-RC2', '1.0.0'];
+
+        $ordered = collect($versions)
+            ->sortByDesc(fn (string $version): string => $this->normalizer->order($version))
+            ->values()
+            ->all();
+
+        $this->assertSame(
+            ['1.0.0', '1.0.0-RC2', '1.0.0-beta10', '1.0.0-beta2', '1.0.0-alpha1'],
+            $ordered,
+        );
+    }
+
+    public function test_order_handles_v_prefixes_and_partial_versions(): void
+    {
+        $this->assertSame(
+            $this->normalizer->order('1.2.0'),
+            $this->normalizer->order('v1.2'),
+        );
+    }
+
+    public function test_dev_versions_keep_their_own_order_string(): void
+    {
+        $this->assertSame('dev-main', $this->normalizer->order('dev-main'));
+        $this->assertSame('2.x-dev', $this->normalizer->order('2.x-dev'));
+    }
+
+    public function test_unparseable_input_sorts_beneath_every_real_version(): void
+    {
+        $this->assertLessThan(
+            0,
+            strcmp($this->normalizer->order('not-a-version'), $this->normalizer->order('0.0.1')),
+        );
+    }
+}


### PR DESCRIPTION
Adds first-class version archives by storing zipballs during package sync, recording `archive_path`/`shasum`, validating downloaded content type, and serving `/dist` directly from the configured dist disk with metadata checksums. Introduces `archives:clean` (with `--dry-run`) to prune orphaned files, updates docs/tests for the new archive lifecycle, and improves package creation by preselecting source context, adding a source-scoped “New package” action, and queuing an immediate first sync after create.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Composer authentication, authorization scoping, SSO provisioning, and the sync/download path that every consumer depends on; misconfiguration could lock out clients or serve wrong packages across repository mounts.
> 
> **Overview**
> This PR turns the registry from a single open Composer endpoint with on-demand GitHub zip proxying into a **multi-repository** product: named mounts under `/r/{path}` (plus the default root), **public vs private** repositories, and **scoped visibility** for panel users and deploy tokens.
> 
> **Composer clients** now authenticate with **access tokens** (personal or deploy-scoped) via HTTP Basic or bearer credentials; reads can be anonymous on public repos, while installs/uploads require the right **read/write** abilities. **Dist downloads** come from **archives written during sync** (`archive_path` / `shasum` in metadata), with download events feeding **analytics** widgets and `downloads:recalculate`. **CI artifact upload** (`POST …/upload/…`) can publish zips without a VCS URL.
> 
> **Package sync** is reworked as a **job batch** (discover → per-ref imports → finalize), with panel **rebuild**, **sync progress**, and console commands (`package:rebuild`, `archives:clean`, etc.). **GitLab** joins GitHub as a source (webhooks, clients); Gitea/Bitbucket enum stubs remain.
> 
> **Admin auth** gains runtime **SSO login providers** (GitHub/Google/GitLab/OIDC) with domain allowlists and default roles. Filament adds **Composer repositories**, **deploy tokens**, **login providers**, self-service **API tokens**, bulk **import from source**, and user/package/repository grants. README and ops notes describe archive storage and `archives:clean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff82d68b654bf268f2ff4d5635c5cad3123a8652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->