### PR TITLE
Carry toasts in the response, not the session

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,6 +17,11 @@ use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
+use Livewire\Component;
+use Livewire\Livewire;
+
+use function Livewire\on;
+use function Livewire\store;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -39,6 +44,8 @@ class AppServiceProvider extends ServiceProvider
         // One per request, so that the credential a token-authenticated write
         // is attributed to cannot outlive the request that presented it.
         $this->app->scoped(ActingCredential::class);
+
+        $this->carryToastsInTheMessageRatherThanTheSession();
     }
 
     /**
@@ -62,6 +69,77 @@ class AppServiceProvider extends ServiceProvider
         AboutCommand::add('Registry', fn (): array => [
             'Scheduler locking' => $this->schedulerLocking(),
         ]);
+    }
+
+    /**
+     * Hand a toast to the browser in the response that raised it.
+     *
+     * Filament's own delivery is a relay through the session: `send()` writes
+     * the notification to it, a dehydrate hook moves it to
+     * `filament.claimed_notifications` and dispatches `notificationsSent` with
+     * no payload, and the notifications component then makes a *second*
+     * request whose only job is to read that key back out.
+     *
+     * Which asks the session to carry a value between two requests the browser
+     * fires back to back — and Laravel saves the session in `terminate()`,
+     * after the response has already gone out. Locally the write always wins
+     * that race. Behind a load balancer it does not: the second request reads
+     * the session before the first has written it, finds nothing, and then
+     * saves its own stale copy over the top — so the toast is not merely late,
+     * it is gone, and no later page load shows it either. An action that
+     * redirects is unaffected, which is why creating a token announced itself
+     * in production while rolling one did so only in development.
+     *
+     * So we read the notification before Filament's hook does and dispatch it
+     * *with* its payload, to the `notificationSent` listener the component
+     * already carries for client-side notifications. There is still a second
+     * request — Filament renders a notification server side, so there has to
+     * be — but it now arrives holding the toast instead of going looking for
+     * it, and nothing has to survive in between. Filament's relay is left
+     * running alongside rather than replaced; the two cannot double up,
+     * for the reason given below.
+     *
+     * Registered from `register()` rather than `boot()`, and that is
+     * load-bearing: dehydrate hooks fire in registration order, and a listener
+     * added after Filament's dispatches too late to be serialised into the
+     * response — the event is simply dropped. Registering before it puts this
+     * in the slot that works.
+     *
+     * Nothing here is specific to tokens: it is every toast raised by an
+     * action that stays on the page.
+     */
+    private function carryToastsInTheMessageRatherThanTheSession(): void
+    {
+        on('dehydrate', function (Component $component): void {
+            if (! Livewire::isLivewireRequest()) {
+                return;
+            }
+
+            // A redirect is the one case where the session relay is sound —
+            // the next page load pulls it — and dispatching into a response
+            // the browser is about to navigate away from would lose it.
+            if (store($component)->has('redirect')) {
+                return;
+            }
+
+            // Read, not taken. Filament's relay still runs and still clears
+            // these keys on its own schedule, so a deployment where it works
+            // keeps working and `assertNotified()` still has something to
+            // assert on. A toast arriving down both routes is not shown twice:
+            // the component keys them by id, so the second put replaces the
+            // first.
+            //
+            // Both keys, so the order this lands in stops mattering: whichever
+            // hook ran first, what it left behind is picked up here.
+            $notifications = array_merge(
+                session()->get('filament.notifications') ?? [],
+                session()->get('filament.claimed_notifications') ?? [],
+            );
+
+            foreach ($notifications as $notification) {
+                $component->dispatch('notificationSent', notification: $notification);
+            }
+        });
     }
 
     /**

--- a/tests/Feature/DeployTokenTest.php
+++ b/tests/Feature/DeployTokenTest.php
@@ -10,6 +10,7 @@ use App\Models\Package;
 use App\Models\Repository;
 use App\Models\Token;
 use App\Models\User;
+use App\Providers\AppServiceProvider;
 use App\Support\NewToken;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -219,6 +220,38 @@ class DeployTokenTest extends TestCase
         }
 
         $this->assertSame($one, $this->renderDeployTokenList());
+    }
+
+    /**
+     * Rolling stays on the list page, so its toast is the case Filament
+     * delivers by leaving the notification in the session for a second request
+     * to collect — the hand-off that does not survive a deployment where those
+     * two requests race. The notification has to ride in the response instead.
+     *
+     * @see AppServiceProvider::carryToastsInTheMessageRatherThanTheSession()
+     */
+    public function test_rolling_a_token_sends_the_new_one_to_the_browser_rather_than_the_session(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $deployToken = DeployToken::factory()->create();
+        $this->issueFor($deployToken);
+
+        Livewire::test(ListDeployTokens::class)
+            ->callTableAction('roll', $deployToken)
+            ->assertDispatched(
+                'notificationSent',
+                fn (string $event, array $params): bool => str_contains(
+                    $params['notification']['body'] ?? '',
+                    (string) $deployToken->refresh()->token->token_prefix,
+                ),
+            );
+
+        // Filament's session relay is left running underneath, so a
+        // deployment where it does work keeps its second route to the screen.
+        $this->assertNotNull(
+            session('filament.notifications') ?? session('filament.claimed_notifications'),
+        );
     }
 
     private function scopedToken(): DeployToken


### PR DESCRIPTION
Filament delivers stay-on-page notifications via a session relay: one request writes the toast, a second reads it. Behind a load balancer those two requests can race, causing the toast to be silently dropped.

Fix by hooking into Livewire's dehydrate lifecycle to dispatch the notification payload directly in the same response that raised it, using the `notificationSent` event the notifications component already handles. Filament's session relay is left intact so environments where it works keep a second delivery route, and the component's id-keyed deduplication prevents double display.

Adds a regression test asserting the toast is dispatched with its payload (including the new token prefix) rather than deferred to the session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global Livewire dehydrate behavior for all in-page Filament notifications; logic is narrow (skips redirects, merges both session keys) but affects every admin toast that does not redirect.
> 
> **Overview**
> Fixes **stay-on-page Filament toasts** (e.g. rolling a deploy token) disappearing in production when two back-to-back Livewire requests hit different app instances and the session write from the first request loses the race.
> 
> **`AppServiceProvider`** registers a Livewire **`dehydrate`** hook early in `register()` so it runs before Filament’s. On non-redirect Livewire requests it reads pending notifications from `filament.notifications` / `filament.claimed_notifications` and **`dispatch`es `notificationSent` with the full payload** in the same response. Redirect actions still use the session path; Filament’s session relay stays enabled so deduplication by notification id avoids double toasts.
> 
> Adds a **regression test** on deploy token roll that asserts `notificationSent` includes the new token prefix and that session keys are still populated for Filament’s relay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d6bc00de1a5b3b916455520b5c723188854ebc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->