### PR TITLE
Rename package vendor and add admin download functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ must act on are collected under **Upgrading from 0.9.x** at the end.
   packages and versions carry each license, and — the number worth watching —
   how many versions declare none at all. Each version's declaration is kept in
   a column of its own, derived from its manifest.
+- **Download a version's archive from the panel**, from the versions list on a
+  package's page or from the version's own detail modal — the stored zip a
+  Composer client would install, without configuring one. Scoped to the
+  admin's own grants, and served straight off the dist disk — or as a redirect
+  to it, on a disk that pre-signs its own URLs. It counts as a download like
+  any other, in the counters and in the download history, carrying no token
+  prefix because none was presented.
 - **CycloneDX 1.6 SBOM export**, registry-wide or per package, from the panel
   and from `sbom:export`. One component per package version, streamed, and cut
   to the caller's own grants. See [docs/licensing.md](docs/licensing.md).

--- a/app/Filament/Resources/Packages/Actions/DownloadArchiveAction.php
+++ b/app/Filament/Resources/Packages/Actions/DownloadArchiveAction.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Resources\Packages\Actions;
+
+use App\Http\Controllers\VersionArchiveController;
+use App\Models\PackageVersion;
+use Filament\Actions\Action;
+use Filament\Support\Icons\Heroicon;
+
+/**
+ * Download the stored zip for one version — the bytes Composer would install,
+ * rather than what the panel says about them.
+ *
+ * A link rather than an action returning a file, for the reason the exports
+ * are links: Livewire delivers a file by base64-encoding it into its response,
+ * which for a package archive means holding the whole zip in memory to send a
+ * file the disk could have streamed — or handed to the client itself, when the
+ * dist disk signs its own URLs.
+ *
+ * @see VersionArchiveController
+ */
+class DownloadArchiveAction
+{
+    public static function make(string $name = 'downloadArchive'): Action
+    {
+        return Action::make($name)
+            ->label('Download')
+            ->icon(Heroicon::OutlinedArrowDownTray)
+            ->color('gray')
+            ->tooltip('The stored zip for this version.')
+            // Only the path is checked, not the file: asking the disk whether
+            // the object is really there would be a metadata call per row on
+            // every render of the table. A path that has outlived its file is
+            // rare and the route says so plainly, which is the right place to
+            // spend that call.
+            ->visible(fn (PackageVersion $record): bool => $record->archive_path !== null)
+            ->url(fn (PackageVersion $record): string => route('downloads.version', $record))
+            ->openUrlInNewTab();
+    }
+}

--- a/app/Filament/Resources/Packages/RelationManagers/VersionsRelationManager.php
+++ b/app/Filament/Resources/Packages/RelationManagers/VersionsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\Packages\RelationManagers;
 
+use App\Filament\Resources\Packages\Actions\DownloadArchiveAction;
 use App\Models\Package;
 use App\Models\PackageVersion;
 use Filament\Actions\DeleteAction;
@@ -146,7 +147,15 @@ class VersionsRelationManager extends RelationManager
             ])
             ->recordActions([
                 ViewAction::make()
-                    ->modalHeading(fn (PackageVersion $record): string => "Version {$record->version}"),
+                    ->modalHeading(fn (PackageVersion $record): string => "Version {$record->version}")
+                    // The same download offered again from inside the detail
+                    // modal, so an operator who opened a version to check what
+                    // it declares does not have to close it again to take the
+                    // artifact that declaration describes.
+                    ->extraModalFooterActions([
+                        DownloadArchiveAction::make('downloadArchiveFromDetail'),
+                    ]),
+                DownloadArchiveAction::make(),
                 DeleteAction::make()
                     // PackageVersion has no policy of its own — the rows are
                     // the package's contents, so deleting one is an edit to

--- a/app/Http/Controllers/VersionArchiveController.php
+++ b/app/Http/Controllers/VersionArchiveController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\PackageDownloaded;
+use App\Filament\Resources\Packages\Actions\DownloadArchiveAction;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\User;
+use App\Services\ArchiveStore;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Hands the signed-in admin the stored zip for one package version.
+ *
+ * The panel already shows what a version declares; this is the rest of that
+ * question — the bytes Composer would actually install — for the times when
+ * reading the manifest is not enough: checking what a build actually shipped,
+ * reproducing a report against the exact artifact, or lifting a release out of
+ * the registry without configuring a Composer client for it.
+ *
+ * Not the Composer dist endpoint: that one is addressed by commit reference
+ * and authenticated by a repository token, where this is addressed by version
+ * row and authenticated by the panel session. It counts the same, though — an
+ * archive that left the registry is a download whoever asked for it, and a
+ * counter that quietly omitted the ones an operator took would be a different
+ * number than the one it claims to be.
+ *
+ * Outside the panel's own `/admin` paths so it cannot race Filament's route
+ * registration, as the download and SBOM exports are.
+ *
+ * @see DownloadArchiveAction
+ */
+class VersionArchiveController extends Controller
+{
+    public function __construct(private readonly ArchiveStore $archives) {}
+
+    public function __invoke(Request $request, PackageVersion $version): StreamedResponse|RedirectResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user instanceof User, 403);
+
+        // Resolved through the caller's own visibility, so a package they may
+        // not see and one that does not exist read alike — the same rule the
+        // exports follow. The permission check is the package's `view`,
+        // because an archive is the package's published content and nothing
+        // that could not open its page has any business pulling it.
+        $package = Package::query()
+            ->visibleToUser($user)
+            ->whereKey($version->package_id)
+            ->first();
+
+        abort_unless($package instanceof Package && $user->can('view', $package), 404);
+
+        abort_if(
+            $version->archive_path === null,
+            404,
+            "No archive is stored for {$package->name}@{$version->version}; syncing the package will build it.",
+        );
+
+        $disk = $this->archives->disk();
+
+        // A row's path can outlive its file — storage lost on a redeploy, an
+        // object deleted out from under us — and handing over a link to
+        // nothing is worse than saying so. One metadata call against a
+        // transfer orders of magnitude larger, exactly as the dist endpoint
+        // spends it.
+        abort_unless(
+            $disk->exists($version->archive_path),
+            404,
+            "The stored archive for {$package->name}@{$version->version} is missing from the dist disk.",
+        );
+
+        $filename = $this->filename($package, $version);
+
+        // Only an archive actually being served counts; every 404 above
+        // returned before reaching this line.
+        //
+        // A HEAD is not one of them. Laravel answers HEAD on every GET route
+        // and drops the body far below this method, so a link checker or a
+        // proxy probing the URL would otherwise land in total_downloads as a
+        // download that took no bytes.
+        //
+        // No token prefix, because none was presented: this request carried a
+        // panel session instead, and inventing a value for that column would
+        // put something in the download export that no token will ever match.
+        if ($request->isMethod('GET')) {
+            PackageDownloaded::dispatch($package->id, $version->id, $version->version, null);
+        }
+
+        // A disk that can issue its own URLs takes the transfer, rather than
+        // pinning a PHP worker for the length of it. The URL is a bearer
+        // credential for this one object until it expires minutes later, and
+        // it is minted only after the visibility check above has passed — the
+        // same bargain the dist endpoint makes, and only ever in that shape.
+        $url = $this->archives->temporaryUrl($version->archive_path);
+
+        if ($url !== null) {
+            // The archive is immutable; this response is not — it carries a
+            // URL that stops working in minutes.
+            return redirect()->away($url, headers: ['Cache-Control' => 'no-store']);
+        }
+
+        return $disk->download($version->archive_path, $filename, [
+            'Content-Type' => 'application/zip',
+            // Who may have these bytes depends on the session that asked, so
+            // no shared cache is party to the decision, and nothing addressed
+            // by row id may be replayed as though it were immutable.
+            'Cache-Control' => 'no-store, private',
+        ]);
+    }
+
+    /**
+     * What the browser saves the archive as: vendor-package-version.zip.
+     *
+     * A version is free-form enough to be a filename hazard — a branch build
+     * is stored as `dev-feat/enhance`, and Composer allows more besides — so
+     * everything outside a conservative set becomes a hyphen rather than being
+     * trusted to survive a Content-Disposition header intact.
+     */
+    private function filename(Package $package, PackageVersion $version): string
+    {
+        $stem = preg_replace('/[^A-Za-z0-9._-]+/', '-', "{$package->name}-{$version->version}") ?? 'archive';
+
+        return trim($stem, '-.').'.zip';
+    }
+}

--- a/app/Services/SbomExport.php
+++ b/app/Services/SbomExport.php
@@ -188,7 +188,7 @@ class SbomExport
                 'tools' => [
                     'components' => [[
                         'type' => 'application',
-                        'group' => 'always-curious',
+                        'group' => 'alwayscurious',
                         'name' => 'package-pipeline',
                     ]],
                 ],

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
-    "name": "always-curious/package-pipeline",
+    "name": "alwayscurious/package-pipeline",
     "type": "project",
     "description": "Package Pipeline — a self-hosted private Composer registry with a Filament admin panel.",
     "keywords": ["composer", "registry", "packages", "laravel", "filament"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43026db3bf5ad5f11edcd09fc69ce98e",
+    "content-hash": "95f3c9a22d33eebadb279625370945f9",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/docs/download-analytics.md
+++ b/docs/download-analytics.md
@@ -29,7 +29,9 @@ downloaded_at,package,repository,version,token_prefix
 `repository` is the Composer repository's URL path; the default repository is
 served at the registry root and is written `(root)`. `token_prefix` is the
 credential's prefix, which stays meaningful after the token is revoked — a
-download served anonymously from a public repository is `(anonymous)`.
+download served anonymously from a public repository is `(anonymous)`, and so
+is one an admin took from the panel's versions list, which presents a session
+rather than a token.
 
 Dates are ISO 8601 with an offset, so they read the same whichever database the
 registry is deployed on.

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\PasswordSetupController;
 use App\Http\Controllers\SbomExportController;
 use App\Http\Controllers\SourceConnectionController;
 use App\Http\Controllers\SsoController;
+use App\Http\Controllers\VersionArchiveController;
 use Illuminate\Support\Facades\Route;
 
 // The app is administered entirely through Filament, so the root URL lands on
@@ -80,6 +81,13 @@ Route::get('/exports/downloads', DownloadExportController::class)
 Route::get('/exports/sbom', SbomExportController::class)
     ->middleware('auth')
     ->name('exports.sbom');
+
+// The stored zip for one package version, for an admin who needs the artifact
+// itself rather than what the panel says about it. Scoped to the signed-in
+// admin's own grants, and outside /admin for the same reason the exports are.
+Route::get('/downloads/versions/{version}', VersionArchiveController::class)
+    ->middleware('auth')
+    ->name('downloads.version');
 
 // The GitHub App install handshake for connecting a source. Both legs are
 // admin-only: the callback attaches an installation to a source, so it must

--- a/tests/Feature/VersionArchiveDownloadTest.php
+++ b/tests/Feature/VersionArchiveDownloadTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Packages\Pages\ViewPackage;
+use App\Filament\Resources\Packages\RelationManagers\VersionsRelationManager;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Models\User;
+use App\Support\VersionNormalizer;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Taking a version's stored zip out of the panel: who may, what they get, and
+ * what happens when the row's path has outlived its file.
+ */
+class VersionArchiveDownloadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Package $package;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake(config('filesystems.dists'));
+
+        $this->package = Package::factory()->create(['name' => 'acme/widgets']);
+    }
+
+    private function version(string $version, ?string $path = 'packages/acme/widgets/one.zip'): PackageVersion
+    {
+        if ($path !== null) {
+            Storage::disk(config('filesystems.dists'))->put($path, 'zip-bytes');
+        }
+
+        return $this->package->versions()->create([
+            'version' => $version,
+            'order' => (new VersionNormalizer)->order($version),
+            'reference' => sha1($version),
+            'is_dev' => str_starts_with($version, 'dev-'),
+            'archive_path' => $path,
+            'metadata' => ['name' => 'acme/widgets', 'version' => $version],
+        ]);
+    }
+
+    public function test_an_admin_downloads_the_stored_zip(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('1.5.0');
+
+        $response = $this->get(route('downloads.version', $version));
+
+        $response->assertOk();
+        $response->assertHeader('content-type', 'application/zip');
+        $response->assertDownload('acme-widgets-1.5.0.zip');
+        $this->assertSame('zip-bytes', $response->streamedContent());
+    }
+
+    /**
+     * A branch build is stored as `dev-feat/enhance`, and Composer allows more
+     * besides — none of which belongs in a Content-Disposition header as it
+     * stands.
+     */
+    public function test_a_branch_versions_filename_is_reduced_to_something_saveable(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('dev-feat/enhance');
+
+        $this->get(route('downloads.version', $version))
+            ->assertDownload('acme-widgets-dev-feat-enhance.zip');
+    }
+
+    /**
+     * An archive that left the registry is a download whoever asked for it, so
+     * this lands in the same counters and the same history the dist endpoint
+     * writes — with no token prefix, because none was presented.
+     */
+    public function test_an_archive_taken_from_the_panel_counts_as_a_download(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('1.5.0');
+
+        $this->get(route('downloads.version', $version))->assertOk();
+
+        $this->assertSame(1, (int) $version->refresh()->total_downloads);
+        $this->assertSame(1, (int) $this->package->refresh()->total_downloads);
+        $this->assertDatabaseHas('downloads', [
+            'package_id' => $this->package->getKey(),
+            'package_version_id' => $version->getKey(),
+            'version' => '1.5.0',
+            'token_prefix' => null,
+        ]);
+    }
+
+    /**
+     * Laravel answers HEAD on every GET route and drops the body far below the
+     * controller, so a link checker or an uptime probe must not land in the
+     * counters as a download that took no bytes.
+     */
+    public function test_a_head_request_is_not_counted(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('1.5.0');
+
+        $this->head(route('downloads.version', $version))->assertOk();
+
+        $this->assertSame(0, (int) $version->refresh()->total_downloads);
+        $this->assertDatabaseCount('downloads', 0);
+    }
+
+    /**
+     * The counters must not move for a request the archive never came back
+     * from — a 404 is not a download.
+     */
+    public function test_a_missing_archive_is_not_counted(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('1.5.0', path: null);
+
+        $this->get(route('downloads.version', $version))->assertNotFound();
+
+        $this->assertDatabaseCount('downloads', 0);
+    }
+
+    public function test_a_version_with_no_stored_archive_is_a_404(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('1.5.0', path: null);
+
+        $this->get(route('downloads.version', $version))->assertNotFound();
+    }
+
+    /**
+     * A path can outlive its file — storage lost on a redeploy, an object
+     * deleted out from under us. Saying so beats handing over a link to
+     * nothing.
+     */
+    public function test_a_path_whose_file_has_gone_is_a_404_rather_than_an_empty_zip(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $version = $this->version('1.5.0');
+
+        Storage::disk(config('filesystems.dists'))->delete((string) $version->archive_path);
+
+        $this->get(route('downloads.version', $version))->assertNotFound();
+    }
+
+    public function test_an_anonymous_request_gets_no_archive(): void
+    {
+        $version = $this->version('1.5.0');
+
+        $this->get(route('downloads.version', $version))->assertRedirect();
+    }
+
+    /**
+     * The route is addressed by row id, so it has to make the same visibility
+     * decision the package table does — otherwise it is a way to read the
+     * contents of every private package by counting upwards.
+     */
+    public function test_a_package_the_admin_cannot_see_reads_as_missing(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole(Role::create(['name' => 'observer', 'guard_name' => 'web']));
+        $user->givePermissionTo('View:Package');
+
+        $this->actingAs($user);
+
+        $this->package->composerRepository()->associate(
+            Repository::factory()->create(['public' => false]),
+        )->save();
+
+        $version = $this->version('1.5.0');
+
+        $this->get(route('downloads.version', $version))->assertNotFound();
+    }
+
+    public function test_the_versions_table_offers_the_download_only_when_an_archive_is_stored(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $stored = $this->version('1.5.0');
+        $unbuilt = $this->version('1.4.1', path: null);
+
+        Livewire::test(VersionsRelationManager::class, [
+            'ownerRecord' => $this->package,
+            'pageClass' => ViewPackage::class,
+        ])
+            ->assertActionVisible(TestAction::make('downloadArchive')->table($stored))
+            ->assertActionHidden(TestAction::make('downloadArchive')->table($unbuilt));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature that allows admins to download the stored zip archive for any package version directly from the panel, matching the artifact a Composer client would install. The implementation ensures proper access control, accurate download tracking, and robust error handling for missing files. It also updates documentation and tests to cover this new functionality.

**New Feature: Downloading Package Archives**

* Added a new route and controller (`VersionArchiveController`) to serve the stored zip for a package version, scoped to the admin's grants and counting as a download in analytics. The controller handles permission checks, missing files, and supports both direct streaming and redirecting to pre-signed URLs. [[1]](diffhunk://#diff-5712954b60c5cf0980e062cd494bf60eb20e3537d8c3285ce2d03081dd1a3f6dR1-R130) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR10) [[3]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR85-R91)
* Introduced a `DownloadArchiveAction` for the Filament admin panel, allowing admins to download the archive from both the versions list and the version detail modal, only when an archive is present. [[1]](diffhunk://#diff-c9c2d5d566408ad579bc58fd478b6709e97ca34cc9be210aaf34a53bd8403d1dR1-R40) [[2]](diffhunk://#diff-b69ea4cc37f4f77eccee68d7dd14f495ff5de4f15c7cf6111531982b00ecc092R5) [[3]](diffhunk://#diff-b69ea4cc37f4f77eccee68d7dd14f495ff5de4f15c7cf6111531982b00ecc092L149-R158)

**Testing and Documentation**

* Added comprehensive feature tests (`VersionArchiveDownloadTest`) to verify permissions, download counting, filename sanitization, and error cases (e.g., missing files, unauthorized access).
* Updated documentation to clarify that downloads from the panel are counted as anonymous (no token prefix) and described in the download analytics. [[1]](diffhunk://#diff-1f2c0ef4300a94a0cf8453784e5413afbe66d30b7e8b83e31efa63840df7a75aL32-R34) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR56-R62)

**Miscellaneous**

* Updated the package name and group from `always-curious` to `alwayscurious` in `composer.json` and SBOM export logic for consistency. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L3-R3) [[2]](diffhunk://#diff-afcc09f6a4afd8323c13dfe1ead1eb96f3f319f74a70305f58a39dde3029b2d1L191-R191)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New endpoint serves package archive bytes with visibility and auth checks; incorrect scoping could leak private packages, though it follows the existing dist/export patterns and is well covered by tests.
> 
> **Overview**
> Admins can now **download a version's stored zip** from the panel — the same artifact Composer would install — without configuring a client.
> 
> A new authenticated `/downloads/versions/{version}` route serves the archive (streamed, or redirected to a pre-signed URL when the dist disk supports it). Access is scoped to the caller's package grants; missing paths/files return 404. Successful GETs count as downloads with no token prefix. A **Download** action appears on the versions table and inside the version detail modal when an archive is stored.
> 
> Also renames the Composer package vendor from `always-curious` to `alwayscurious` (including SBOM metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 614aa0830612bdc79e8704dafe8a4ce7e282fa90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->