### PR TITLE
Implement public package pages and refresh functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,4 +192,18 @@ SLACK_BOT_USER_DEFAULT_CHANNEL=
 METRICS_ENABLED=false
 METRICS_TOKEN=
 
+# Public pages — a readable page for a package or a repository, at the same
+# URL Composer already speaks to. Nothing here publishes anything: a page is
+# enabled per package and per repository in the panel, and a registry with none
+# behaves exactly as it did before. PAGE_IMAGE is the social preview card every
+# page falls back to when it sets none of its own (an absolute URL or a path
+# relative to this app, around 1200x630) — worth setting, because a link with
+# no card beside it is a link most people do not click. PAGE_SITEMAP=false
+# leaves the pages reachable but unlisted, and answers /robots.txt with a
+# blanket disallow. See docs/public-pages.md.
+PAGE_IMAGE=
+PAGE_SITEMAP=true
+# PAGE_MARKDOWN_CACHE_MINUTES=1440
+# PAGE_MAX_BODY_KB=512
+
 VITE_APP_NAME="${APP_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ must act on are collected under **Upgrading from 0.9.x** at the end.
 
 ### Added
 
+- **Public pages.** A package or a repository can publish a page anyone can read
+  — no account, no token, no Composer. A package page shows the description, the
+  repository's `package-page.md` or `README.md`, the install commands, the
+  version history and, when switched on, a download for the latest release or
+  for every version; a repository's landing page is served at the same URL its
+  Composer endpoints hang off (`/` for the default repository) and lists the
+  packages publishing pages of their own. Off until enabled, per package and per
+  repository. A page on a private repository still describes the package but
+  withholds the archives and the install commands, showing an access notice in
+  their place. Markdown from a repository is rendered with raw HTML escaped and
+  relative links resolved against the repository it came from. Every page
+  carries Open Graph and Twitter card tags, JSON-LD and a canonical URL, and
+  `/sitemap.xml` and `/robots.txt` list them (`PAGE_SITEMAP=false` to publish
+  neither). See [docs/public-pages.md](docs/public-pages.md).
+
 - The [Composer v2 repository API](https://getcomposer.org/doc/05-repositories.md#composer):
   `packages.json`, `search.json`, `list.json`, per-package `p2` metadata, and
   `dist` zipballs. A consuming project needs one `repositories` entry and no
@@ -348,7 +363,7 @@ release looks after itself.
   change, but a rollback that reaches it has already unwound the migrations
   after it. Restoring the backup is the recovery path; plan the upgrade that
   way.
-- **Run `php artisan migrate`.** Twenty migrations, all safe on a populated
+- **Run `php artisan migrate`.** Twenty-one migrations, all safe on a populated
   database, and none of them rewrites a row except the name normalization
   below. Two are worth knowing about: `notifications.data` becomes a json
   column, which is what stops the panel answering `500` on every page under
@@ -388,8 +403,15 @@ release looks after itself.
   generated from `app/Filament` and `resources/views/filament` — registered with
   `->viteTheme()`. `composer run setup` runs the build; CI and deploy pipelines
   need `npm ci && npm run build` added.
-- Nothing new is enabled by default. Upstream mirroring, the Prometheus
-  endpoint, outgoing webhooks and vendor reservations all start off, and a
-  registry that ignores them behaves as it did before.
+- **`public/robots.txt` has been removed**, so that `/robots.txt` can be
+  answered by the app — it now points crawlers at `/sitemap.xml` and keeps them
+  off `/admin`, `/p2/` and `/dist/`, or answers a blanket disallow when
+  `PAGE_SITEMAP=false`. A deployment that restores the static file shadows the
+  route, and the setting then does nothing.
+- Nothing new is enabled by default. Public pages, upstream mirroring, the
+  Prometheus endpoint, outgoing webhooks and vendor reservations all start off,
+  and a registry that ignores them behaves as it did before. In particular the
+  registry root goes on redirecting to `/admin/login` until a page is published
+  for the default repository.
 
 [Unreleased]: https://github.com/AlwaysCuriousCo/package-pipeline/compare/v0.9.4...HEAD

--- a/README.md
+++ b/README.md
@@ -218,6 +218,16 @@ Two things to know before enabling it. The disk grows without a ceiling of its o
 
 **[docs/mirroring.md](docs/mirroring.md)** covers all of it: what consumers see, the freshness and failure behaviour, the access-control rule and its sharp edges, and what it costs in disk.
 
+### Public pages
+
+A package or a repository can publish a page anyone can read — no account, no token, no Composer. It shows what the package is, its `README.md` (or a `package-page.md` written for the purpose) out of the repository, the install commands, and — if you switch it on — a download for the latest release or for every version.
+
+The URL you hand a project is the first thing somebody pastes into a browser, and before this it answered a redirect to a login form for an account they do not have. Now the default repository can answer a landing page there instead, and each package can answer one at `/p/vendor/name`.
+
+Off until you enable one, per package and per repository. A page on a **private** repository still describes the package and shows its version history, but withholds the archives and the install commands and shows an access notice in their place. Every page carries Open Graph and Twitter card tags, JSON-LD and a canonical URL, and `/sitemap.xml` lists them.
+
+**[docs/public-pages.md](docs/public-pages.md)** covers all of it: enabling a page, where its content comes from, how untrusted markdown is rendered, what private packages withhold, and the SEO and social-preview tags.
+
 ## Configuration reference
 
 Everything lives in `.env`, and `.env.example` carries the same notes in situ. Below are the knobs that belong to this app rather than to a stock Laravel one; the stock ones that matter most in production — `QUEUE_CONNECTION`, `CACHE_STORE`, `FILESYSTEM_DISK`, `AWS_*` — are covered under [Recommended drivers](docs/deployment.md#recommended-drivers).
@@ -254,6 +264,17 @@ None of these turns mirroring on — that is a per-repository decision made in t
 | `MIRROR_ADVISORY_TTL_MINUTES` | How long an upstream's `composer audit` answer is reused (default `10`). |
 | `MIRROR_FAILURE_BACKOFF_MINUTES` | How long an upstream that has just failed is left alone, serving only what is already cached (default `5`). Without it an outage costs every lookup a connect timeout. |
 | `MIRROR_MAX_ARCHIVE_MB` / `MIRROR_MAX_METADATA_KB` | Ceilings on what will be cached from an upstream (default `256` / `8192`). `ARTIFACT_UPLOAD_MAX_MB` bounds what one of your own tokens may spend; these bound what a stranger's published package can. |
+
+**Public pages**
+
+None of these publishes anything — a page is a per-package or per-repository decision made in the panel. These apply once one is enabled. Full explanations in [docs/public-pages.md](docs/public-pages.md#configuration).
+
+| Variable | Purpose |
+| --- | --- |
+| `PAGE_IMAGE` | Social preview image used by every page that has not set one of its own — an absolute URL or a path relative to the app root, around 1200×630. Worth setting: a link with no card beside it is a link most people do not click. |
+| `PAGE_SITEMAP` | Publish `/sitemap.xml` and an indexing `/robots.txt` (default `true`). `false` leaves pages reachable and unlisted, and answers robots.txt with a blanket disallow. |
+| `PAGE_MARKDOWN_CACHE_MINUTES` | How long a rendered page body is reused (default `1440`). Keyed by a hash of the markdown itself, so a sync that changes the file changes the key. `0` turns it off. |
+| `PAGE_MAX_BODY_KB` | Largest page body stored or rendered (default `512`). The body comes out of somebody else's repository; a file orders of magnitude past this is a generated artifact or a mistake. |
 
 **Queue timing**
 
@@ -420,6 +441,7 @@ After adding new Filament resources, re-run both `php artisan shield:generate --
 - [docs/monorepos.md](docs/monorepos.md) — publishing several packages from one repository: the subdirectory field, how a dist for part of a repository is built, and what a push to a monorepo syncs.
 - [docs/mirroring.md](docs/mirroring.md) — serving packagist.org's packages through this registry: enabling it, what consumers see, failure behaviour, and what it costs in disk.
 - [docs/outgoing-webhooks.md](docs/outgoing-webhooks.md) — telling a deploy pipeline or a non-Slack chat tool that a version published or a sync failed: the events, the payloads, and how to verify a signature.
+- [docs/public-pages.md](docs/public-pages.md) — publishing a readable page for a package or a repository: the toggles, where the content comes from, what a private package withholds, and the social-preview and search tags.
 - [docs/teams.md](docs/teams.md) — granting access to a group rather than a person: what a team holds, how effective access composes, and what it costs on the Composer hot path.
 - [docs/webhooks.md](docs/webhooks.md) — auto-syncing on push: the two GitHub delivery paths, GitLab's per-project hooks, and how to tell whether a package is actually covered.
 - [CHANGELOG.md](CHANGELOG.md) — what changed in each release and what it asks of the operator.

--- a/app/Enums/PageDownloads.php
+++ b/app/Enums/PageDownloads.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Enums;
+
+use App\Models\Package;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * How much of a package's archive history its public page hands out.
+ *
+ * Three states rather than a boolean because the middle one is the point: a
+ * page can offer the current release as a download without also publishing
+ * every version that came before it, which is the difference between "here is
+ * the thing" and "here is everything we have ever shipped".
+ *
+ * This decides what the *page* offers, never what the Composer endpoints do.
+ * Those are governed by the repository's own public flag and the tokens
+ * granted against it, and nothing here widens them — a page on a private
+ * repository offers no archive whatever this says.
+ *
+ * @see Package::pageDownloads()
+ */
+enum PageDownloads: string implements HasLabel
+{
+    /** The page describes the package and links no archives at all. */
+    case None = 'none';
+
+    /** One button, for the latest release. */
+    case Latest = 'latest';
+
+    /** Every stored version, newest first. */
+    case All = 'all';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::None => 'No downloads',
+            self::Latest => 'Latest release only',
+            self::All => 'Every version',
+        };
+    }
+
+    /**
+     * The helper text the panel prints beside each choice, so the difference
+     * between the two "yes" answers is decided in front of the admin rather
+     * than discovered on the published page.
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::None => 'The page describes the package; visitors install it with Composer.',
+            self::Latest => 'A download button for the current release.',
+            self::All => 'A download link on every version in the history table.',
+        };
+    }
+
+    public function offersAny(): bool
+    {
+        return $this !== self::None;
+    }
+}

--- a/app/Enums/SourceProvider.php
+++ b/app/Enums/SourceProvider.php
@@ -58,6 +58,53 @@ enum SourceProvider: string implements HasLabel
     }
 
     /**
+     * Where this provider serves a *view* of a file in a repository, as a
+     * base URL a path hangs off — or null when the provider has no client
+     * here and so no URL shape worth guessing at.
+     *
+     * The public page needs this because a README's links are relative to
+     * the repository it was written in: "docs/install.md" has to become a
+     * link to that file on the provider, or it becomes a 404 on this
+     * registry. @see \App\Support\PageMarkdown
+     *
+     * "HEAD" rather than a branch name on purpose. The alternative is asking
+     * the provider for the default branch, which is a request per package per
+     * sync to learn something every one of these providers already resolves
+     * for us — and which would go stale the day a project renames master.
+     */
+    public function browseUrl(string $repositoryUrl): ?string
+    {
+        $repositoryUrl = rtrim($repositoryUrl, '/');
+
+        return match ($this) {
+            self::Github => "{$repositoryUrl}/blob/HEAD",
+            self::Gitlab => "{$repositoryUrl}/-/blob/HEAD",
+            self::Bitbucket => "{$repositoryUrl}/src/HEAD",
+            // Gitea addresses a ref by type — /src/branch/{name} — so there
+            // is no "whatever the default branch is" form to build without
+            // asking it, and no client here to ask with.
+            self::Gitea => null,
+        };
+    }
+
+    /**
+     * Where this provider serves the file's *bytes*, which is what an image
+     * in a README has to point at — a link to GitHub's file viewer renders
+     * as a broken image, not as a screenshot.
+     */
+    public function rawUrl(string $repositoryUrl): ?string
+    {
+        $repositoryUrl = rtrim($repositoryUrl, '/');
+
+        return match ($this) {
+            self::Github => "{$repositoryUrl}/raw/HEAD",
+            self::Gitlab => "{$repositoryUrl}/-/raw/HEAD",
+            self::Bitbucket => "{$repositoryUrl}/raw/HEAD",
+            self::Gitea => null,
+        };
+    }
+
+    /**
      * The provider a repository host most likely belongs to. Self-hosted
      * instances follow the conventional naming often enough for this to be
      * the right default; a package under a connected source never asks.

--- a/app/Filament/Resources/Packages/Actions/RefreshPageContentAction.php
+++ b/app/Filament/Resources/Packages/Actions/RefreshPageContentAction.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Filament\Resources\Packages\Actions;
+
+use App\Models\Package;
+use App\Services\PackagePage;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+
+/**
+ * Re-read the package's page body from its repository, now.
+ *
+ * A sync does this already, so this action is for the gap between the two:
+ * somebody has just edited the README — usually because the published page
+ * was wrong — and the alternative is a full sync that re-reads every ref, or
+ * an hour's wait. Reading one file is neither.
+ *
+ * It runs inline rather than on the queue, which is the whole point: the
+ * question being asked is "which file does this page get, and did my edit
+ * land", and an answer that arrives after the page has been navigated away
+ * from is no answer. It costs at most one request per candidate filename, and
+ * usually one.
+ */
+class RefreshPageContentAction
+{
+    public static function make(): Action
+    {
+        return Action::make('refreshPageContent')
+            ->label('Refresh page')
+            ->icon(Heroicon::OutlinedArrowDownOnSquare)
+            ->color('gray')
+            // Only where there is both a page to refresh and a repository to
+            // refresh it from. A package published by artifact upload has no
+            // file to read, and its page body is whatever was typed in the
+            // panel.
+            ->visible(fn (Package $record): bool => $record->hasPage() && filled($record->repository))
+            ->action(function (Package $record): void {
+                $found = app(PackagePage::class)->refresh($record);
+
+                $record->refresh();
+
+                if (! $found) {
+                    // Deliberately not a failure: a repository with no README
+                    // is a fact about the repository, and the page renders
+                    // the package's metadata and install commands without one.
+                    Notification::make()
+                        ->warning()
+                        ->title('No page content found')
+                        ->body(sprintf(
+                            'Looked for %s in %s. The page will show %s description and install commands alone.',
+                            implode(', ', Package::PAGE_FILES),
+                            $record->hasSubdirectory() ? "{$record->subdirectory}/" : 'the repository root',
+                            $record->name,
+                        ))
+                        ->send();
+
+                    return;
+                }
+
+                // Said out loud, because which file won is the thing an admin
+                // is usually here to find out — a repository with both a
+                // package-page.md and a README publishes only the first.
+                $body = "Read {$record->page_source_path} from the repository.";
+
+                if (filled($record->page_body)) {
+                    // The content was refreshed and the page will not show it,
+                    // which is a confusing enough result to name.
+                    $body .= ' The page still shows the content written here, which takes precedence — clear it to publish the file instead.';
+                }
+
+                Notification::make()
+                    ->success()
+                    ->title('Page content refreshed')
+                    ->body($body)
+                    ->send();
+            });
+    }
+}

--- a/app/Filament/Resources/Packages/Pages/ViewPackage.php
+++ b/app/Filament/Resources/Packages/Pages/ViewPackage.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Packages\Pages;
 use App\Filament\Resources\Packages\Actions\CreateWebhookAction;
 use App\Filament\Resources\Packages\Actions\ExportSbomAction;
 use App\Filament\Resources\Packages\Actions\RebuildPackageAction;
+use App\Filament\Resources\Packages\Actions\RefreshPageContentAction;
 use App\Filament\Resources\Packages\Actions\SyncPackageAction;
 use App\Filament\Resources\Packages\PackageResource;
 use App\Filament\Resources\Packages\Widgets\PackageDownloadsChart;
@@ -21,6 +22,7 @@ class ViewPackage extends ViewRecord
         return [
             SyncPackageAction::make(),
             RebuildPackageAction::make(),
+            RefreshPageContentAction::make(),
             CreateWebhookAction::make(),
             ExportSbomAction::make(),
             EditAction::make(),

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -2,18 +2,24 @@
 
 namespace App\Filament\Resources\Packages\Schemas;
 
+use App\Enums\PageDownloads;
 use App\Enums\WebhookCoverage;
 use App\Models\Package;
 use App\Models\Repository;
 use App\Models\ReservedVendor;
 use App\Models\Source;
 use Closure;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\HtmlString;
 use Illuminate\Validation\Rules\Unique;
 
 /**
@@ -42,7 +48,145 @@ class PackageForm
                 self::abandoned(),
                 self::replacementPackage(),
                 self::description(),
+                self::page(),
             ]);
+    }
+
+    /**
+     * The public page: whether this package has one, and what it shows.
+     *
+     * A section rather than a handful of toggles among the sync settings,
+     * because these are the only fields on this form that decide what a
+     * stranger can see. Grouping them is what makes "is this package
+     * published to the world" answerable at a glance rather than by reading
+     * every field.
+     *
+     * Collapsed until the page is switched on, so the form does not grow four
+     * fields for the packages — most of them — that will never have one.
+     */
+    public static function page(): Section
+    {
+        return Section::make('Public page')
+            ->description('A page anyone can read, at the package\'s own URL — no account and no token.')
+            ->icon(Heroicon::OutlinedGlobeAlt)
+            ->columnSpanFull()
+            ->schema([
+                self::pageEnabled(),
+                self::pageUrl(),
+                self::pageDownloadsSelect(),
+                self::pageInstall(),
+                self::pageVersions(),
+                self::pageImage(),
+                self::pageBody(),
+            ]);
+    }
+
+    /**
+     * The switch itself. Live, because every field under it is hidden until
+     * this is on — a page's options are not a decision until there is a page.
+     */
+    public static function pageEnabled(): Toggle
+    {
+        return Toggle::make('page_enabled')
+            ->label('Publish a public page')
+            ->live()
+            ->helperText(fn (?Package $record): string => match (true) {
+                $record?->composerRepository?->public === false => 'The page will describe this package and show its version history, '
+                    .'but not hand out archives or print install commands — this package is served from a private repository. '
+                    .'Visitors are shown how to ask for access instead.',
+                default => 'The page shows the package\'s description, its README from the repository, and whatever is switched on below.',
+            });
+    }
+
+    /**
+     * Where the page answers, as a link — the one thing an admin wants
+     * immediately after switching it on, and the thing they would otherwise
+     * have to construct by hand from the repository's mount.
+     */
+    public static function pageUrl(): Placeholder
+    {
+        return Placeholder::make('page_url')
+            ->label('Page URL')
+            ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+            ->content(fn (?Package $record): string|HtmlString => $record instanceof Package && filled($record->name)
+                ? new HtmlString(sprintf(
+                    '<a href="%1$s" target="_blank" rel="noopener" class="underline">%1$s</a>',
+                    e($record->pageUrl()),
+                ))
+                : 'Available once the package has been saved.');
+    }
+
+    /**
+     * Which archives the page hands out. A radio rather than a select: three
+     * options whose difference is the point, each carrying the sentence that
+     * explains it.
+     */
+    public static function pageDownloadsSelect(): Radio
+    {
+        return Radio::make('page_downloads')
+            ->label('Downloads')
+            ->options(PageDownloads::class)
+            ->descriptions(collect(PageDownloads::cases())
+                ->mapWithKeys(fn (PageDownloads $case): array => [$case->value => $case->description()])
+                ->all())
+            ->default(PageDownloads::None)
+            ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+            // The setting is kept rather than disabled on a private
+            // repository, so that making the repository public restores what
+            // was chosen here — but it is said plainly that it does nothing
+            // meanwhile, rather than being discovered on the published page.
+            ->helperText(fn (?Package $record): ?string => $record?->composerRepository?->public === false
+                ? 'No effect while this package is served from a private repository: the page offers no archives to anonymous visitors.'
+                : null);
+    }
+
+    public static function pageInstall(): Toggle
+    {
+        return Toggle::make('page_install')
+            ->label('Show install commands')
+            ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+            ->helperText('The two `composer config` and `composer require` lines, exactly as the panel shows them.');
+    }
+
+    public static function pageVersions(): Toggle
+    {
+        return Toggle::make('page_versions')
+            ->label('Show the version history')
+            ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+            ->helperText('A table of the released versions and their dates, most recent first.');
+    }
+
+    /**
+     * The image a social platform shows when the page's URL is pasted into a
+     * post. Optional, and worth being optional: an installation that sets
+     * PAGE_IMAGE once gets a card on every page without touching this.
+     */
+    public static function pageImage(): TextInput
+    {
+        return TextInput::make('page_image')
+            ->label('Social preview image')
+            ->url()
+            ->maxLength(255)
+            ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+            ->placeholder('https://example.com/package-card.png')
+            ->helperText('Shown when the page is linked in Slack, a post or a chat. Around 1200×630 works everywhere. '
+                .'Empty uses the registry-wide default.');
+    }
+
+    /**
+     * The body written here, which wins over the repository's own file.
+     */
+    public static function pageBody(): Textarea
+    {
+        return Textarea::make('page_body')
+            ->label('Page content')
+            ->rows(10)
+            ->columnSpanFull()
+            ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+            ->helperText(fn (?Package $record): string => match (true) {
+                $record?->page_source_path !== null => "Markdown. Leave empty to publish the repository's {$record->page_source_path}, which is what the page shows now.",
+                default => 'Markdown. Leave empty to publish the repository\'s package-page.md or README.md, read on the next sync.',
+            });
     }
 
     /**

--- a/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
@@ -96,6 +96,31 @@ class PackageInfolist
                     ->placeholder(fn (Package $record): string => $record->webhookCoverage()->isActive()
                         ? 'Nothing pushed yet'
                         : 'Never'),
+                TextEntry::make('page_enabled')
+                    ->label('Public page')
+                    // The URL rather than the boolean: "on" is not the answer
+                    // an admin wants here, "here is the page, go and look at
+                    // it" is. Off, the answer is the state.
+                    ->state(fn (Package $record): string => $record->hasPage() ? $record->pageUrl() : 'Not published')
+                    ->url(fn (Package $record): ?string => $record->hasPage() ? $record->pageUrl() : null)
+                    ->openUrlInNewTab()
+                    ->color(fn (Package $record): string => $record->hasPage() ? 'primary' : 'gray')
+                    ->helperText(fn (Package $record): ?string => match (true) {
+                        ! $record->hasPage() => null,
+                        $record->pageRequiresAccess() => 'Readable by anyone. Archives and install commands are withheld — this package is served from a private repository.',
+                        default => 'Readable by anyone, with '.mb_strtolower($record->pageDownloads()->getLabel()).'.',
+                    }),
+                TextEntry::make('page_source_path')
+                    ->label('Page content')
+                    ->visible(fn (Package $record): bool => $record->hasPage())
+                    ->state(fn (Package $record): string => match ($record->pageContent()['source']) {
+                        'panel' => 'Written here, in the package\'s edit form',
+                        'none' => 'None yet — no package-page.md or README.md found in the repository',
+                        default => $record->page_source_path.', read from the repository',
+                    })
+                    ->helperText(fn (Package $record): ?string => $record->page_source_synced_at === null
+                        ? null
+                        : 'Last read '.$record->page_source_synced_at->diffForHumans()),
                 TextEntry::make('description')
                     ->placeholder('-')
                     ->columnSpanFull(),

--- a/app/Filament/Resources/Repositories/Schemas/RepositoryForm.php
+++ b/app/Filament/Resources/Repositories/Schemas/RepositoryForm.php
@@ -84,6 +84,10 @@ class RepositoryForm
                         : 'Off, this URL answers 404 to anything but the Composer endpoints under it.'),
                 Toggle::make('page_lists_packages')
                     ->label('List the packages served here')
+                    // On by default, as the column is: a landing page that
+                    // names nothing is the rarer want, and a hidden toggle
+                    // left unset would otherwise save as off.
+                    ->default(true)
                     ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
                     // Only packages that publish a page of their own are ever
                     // listed, whatever this says — naming a package the

--- a/app/Filament/Resources/Repositories/Schemas/RepositoryForm.php
+++ b/app/Filament/Resources/Repositories/Schemas/RepositoryForm.php
@@ -9,7 +9,9 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Validation\Rules\Unique;
 
 class RepositoryForm
@@ -51,8 +53,56 @@ class RepositoryForm
                 Textarea::make('description')
                     ->rows(3)
                     ->columnSpanFull(),
+                self::page(),
                 self::reservedVendors(),
                 self::upstreams(),
+            ]);
+    }
+
+    /**
+     * The repository's own landing page, served at the URL its Composer
+     * endpoints hang off — which for the default repository is the site root.
+     *
+     * The page an operator wants when they hand somebody a registry URL: what
+     * this is, the one line that points a project at it, and which packages
+     * it publishes pages for.
+     */
+    public static function page(): Section
+    {
+        return Section::make('Public page')
+            ->description(fn (?Repository $record): string => $record?->isDefault()
+                ? 'Served at the registry root, in place of the redirect to the admin login.'
+                : 'Served at this repository\'s own URL, the one projects are pointed at.')
+            ->icon(Heroicon::OutlinedGlobeAlt)
+            ->columnSpanFull()
+            ->schema([
+                Toggle::make('page_enabled')
+                    ->label('Publish a landing page')
+                    ->live()
+                    ->helperText(fn (?Repository $record): string => $record?->isDefault()
+                        ? 'Off, the registry root goes on redirecting to the admin login, exactly as it does today.'
+                        : 'Off, this URL answers 404 to anything but the Composer endpoints under it.'),
+                Toggle::make('page_lists_packages')
+                    ->label('List the packages served here')
+                    ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+                    // Only packages that publish a page of their own are ever
+                    // listed, whatever this says — naming a package the
+                    // registry will not describe is how a private package's
+                    // existence leaks out of a public landing page.
+                    ->helperText('Only packages that publish a page of their own are listed. Off leaves the page describing the repository alone.'),
+                TextInput::make('page_image')
+                    ->label('Social preview image')
+                    ->url()
+                    ->maxLength(255)
+                    ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+                    ->placeholder('https://example.com/registry-card.png')
+                    ->helperText('Shown when this page is linked in Slack, a post or a chat. Empty uses the registry-wide default.'),
+                Textarea::make('page_body')
+                    ->label('Page content')
+                    ->rows(8)
+                    ->columnSpanFull()
+                    ->visible(fn (Get $get): bool => (bool) $get('page_enabled'))
+                    ->helperText('Markdown, shown above the package list. There is no repository to read a README from here, so this is the only body.'),
             ]);
     }
 

--- a/app/Http/Controllers/Pages/PackageArchiveController.php
+++ b/app/Http/Controllers/Pages/PackageArchiveController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Controllers\Pages;
+
+use App\Enums\PageDownloads;
+use App\Events\PackageDownloaded;
+use App\Http\Controllers\Controller;
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Services\ArchiveStore;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * The download button on a public page.
+ *
+ * A third way to the same bytes, alongside the Composer dist endpoint and the
+ * panel's own archive route, and it exists because the other two are no use
+ * to the visitor this one is for: they have no token and no account, and they
+ * are addressing the package by version rather than by commit reference.
+ *
+ * What it will hand over is decided entirely on the package row:
+ *
+ *  - the page must be enabled, or nothing here exists;
+ *  - the repository must be public, or Package::pageDownloads() reads as None
+ *    however the package was configured — an archive is the package's content
+ *    and a private repository exists to refuse it to anonymous callers;
+ *  - "latest release only" means exactly that: any other version is a 404,
+ *    so a page offering one current artifact cannot be walked backwards
+ *    through the release history by editing the URL.
+ *
+ * Counted like every other archive that leaves the registry, so the download
+ * numbers mean one thing across all three routes.
+ */
+class PackageArchiveController extends Controller
+{
+    public function __construct(private readonly ArchiveStore $archives) {}
+
+    public function __invoke(
+        Request $request,
+        string $vendor,
+        string $package,
+        ?string $version = null,
+    ): StreamedResponse|RedirectResponse {
+        /** @var Repository $repository */
+        $repository = $request->attributes->get('composerRepository');
+
+        $found = $repository->packages()
+            ->withPage()
+            ->where('name', mb_strtolower("{$vendor}/{$package}"))
+            ->with('composerRepository')
+            ->first();
+
+        abort_unless($found instanceof Package, 404, 'No package page is published at this address.');
+
+        $offered = $found->pageDownloads();
+
+        abort_if(
+            $offered === PageDownloads::None,
+            404,
+            "The page for {$found->name} does not offer downloads.",
+        );
+
+        $release = $this->release($found, $offered, $version);
+
+        $disk = $this->archives->disk();
+
+        // A row's path can outlive its file — storage lost on a redeploy, an
+        // object deleted out from under us. One metadata call against a
+        // transfer orders of magnitude larger, exactly as the dist endpoint
+        // and the panel's route both spend it.
+        abort_unless(
+            $release->archive_path !== null && $disk->exists($release->archive_path),
+            404,
+            "No archive is stored for {$found->name}@{$release->version}.",
+        );
+
+        $filename = ArchiveStore::downloadFilename($found->name, $release->version);
+
+        // Only an archive actually being served counts, and only a GET:
+        // Laravel answers HEAD on every GET route and drops the body far below
+        // this line, so a link checker or a social platform fetching the page's
+        // links would otherwise land in total_downloads as a download that
+        // took no bytes.
+        //
+        // No token prefix, because none was presented — this request carried
+        // no credential at all, which is what a public page means.
+        if ($request->isMethod('GET')) {
+            PackageDownloaded::dispatch($found->id, $release->id, $release->version, null);
+        }
+
+        $url = $this->archives->temporaryUrl($release->archive_path, $filename);
+
+        if ($url !== null) {
+            // The archive is immutable; this response is not — it carries a
+            // URL that stops working in minutes.
+            return redirect()->away($url, headers: ['Cache-Control' => 'no-store']);
+        }
+
+        return $disk->download($release->archive_path, $filename, [
+            'Content-Type' => 'application/zip',
+            // Public bytes at a stable address, so a shared cache is welcome
+            // to keep them: a version's archive never changes, and the URL
+            // names the version rather than a row id.
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    /**
+     * The version this URL addresses.
+     *
+     * No version segment means the current release, which is the link the
+     * page's own button carries — a URL that goes on meaning "the latest" as
+     * releases come and go, and therefore the one worth putting in a
+     * changelog or a chat message.
+     */
+    private function release(Package $package, PageDownloads $offered, ?string $version): PackageVersion
+    {
+        if ($version === null) {
+            $latest = $package->pageLatestVersion();
+
+            abort_unless(
+                $latest instanceof PackageVersion,
+                404,
+                "{$package->name} has no released version to download.",
+            );
+
+            return $latest;
+        }
+
+        abort_if(
+            $offered !== PageDownloads::All,
+            404,
+            "The page for {$package->name} offers its latest release only.",
+        );
+
+        $release = $package->versions()->where('version', $version)->first();
+
+        abort_unless(
+            $release instanceof PackageVersion,
+            404,
+            "{$package->name} has no version {$version}.",
+        );
+
+        return $release;
+    }
+}

--- a/app/Http/Controllers/Pages/PackagePageController.php
+++ b/app/Http/Controllers/Pages/PackagePageController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Pages;
+
+use App\Http\Controllers\Controller;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Services\PackagePage;
+use App\Support\PageSchema;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+/**
+ * The public page for one package.
+ *
+ * Anonymous by design and by definition: this is the surface an admin
+ * switches on so that a package can be linked to, read about and — where the
+ * repository is public — installed from, by somebody who has no account here
+ * and never will.
+ *
+ * Everything it will show is decided on the package row and its repository's
+ * public flag, never on the request. A page that is not enabled is a 404
+ * rather than a 403: the registry has nothing to say about a package it does
+ * not publish a page for, including whether it exists.
+ */
+class PackagePageController extends Controller
+{
+    public function __construct(private readonly PackagePage $pages) {}
+
+    public function __invoke(Request $request, string $vendor, string $package): View
+    {
+        /** @var Repository $repository */
+        $repository = $request->attributes->get('composerRepository');
+
+        $package = $this->resolve($repository, $vendor, $package);
+
+        return view('pages.package', [
+            'repository' => $repository,
+            'package' => $package,
+            'body' => $this->pages->render($package),
+            'downloads' => $downloads = $package->pageDownloads(),
+            'latest' => $downloads->offersAny() ? $package->pageLatestVersion() : null,
+            'versions' => $package->page_versions ? $package->pageVersions() : collect(),
+            'commands' => $package->pageShowsInstall() ? $package->installCommands() : null,
+            'schema' => PageSchema::package($package),
+        ]);
+    }
+
+    /**
+     * The package this URL addresses, or a 404.
+     *
+     * Scoped to the repository the mount resolved, because names are unique
+     * per repository rather than per registry — /r/internal/p/acme/widgets
+     * and /p/acme/widgets are allowed to be different packages, and must
+     * never be able to resolve to each other's.
+     *
+     * The name is normalized the same way the stored one was, so a link
+     * someone typed in mixed case reaches the page rather than a 404.
+     */
+    private function resolve(Repository $repository, string $vendor, string $package): Package
+    {
+        // Lowercased for the reason the metadata endpoint lowercases: that is
+        // how the column is stored, and folding the input rather than the
+        // column keeps the lookup on the index while still resolving a URL
+        // somebody typed or a link written in the name's original casing.
+        $name = mb_strtolower("{$vendor}/{$package}");
+
+        $found = $repository->packages()
+            ->withPage()
+            ->where('name', $name)
+            ->with('composerRepository')
+            ->first();
+
+        abort_unless($found instanceof Package, 404, 'No package page is published at this address.');
+
+        return $found;
+    }
+}

--- a/app/Http/Controllers/Pages/RepositoryPageController.php
+++ b/app/Http/Controllers/Pages/RepositoryPageController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers\Pages;
+
+use App\Http\Controllers\Controller;
+use App\Models\Repository;
+use App\Services\PackagePage;
+use App\Support\PageSchema;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+/**
+ * A repository's own landing page, served at the URL its Composer endpoints
+ * hang off — "/" for the default repository, "/r/{path}" for a named one.
+ *
+ * Deliberately the same URL, because it is the one an operator is already
+ * handing out: a project is told to run `composer config repositories.x
+ * composer https://packages.example.com`, and the first thing a person does
+ * with that URL is open it. Before this it answered a redirect to a login
+ * form for an account they do not have.
+ *
+ * Which is still what it answers when no page is enabled — the root has
+ * always landed on the panel, and a registry that has not opted into
+ * publishing anything keeps that behaviour exactly.
+ */
+class RepositoryPageController extends Controller
+{
+    public function __construct(private readonly PackagePage $pages) {}
+
+    public function __invoke(Request $request): View|RedirectResponse
+    {
+        /** @var Repository $repository */
+        $repository = $request->attributes->get('composerRepository');
+
+        if (! $repository->hasPage()) {
+            // The default repository's mount is the site root, whose long-
+            // standing answer is the panel's login page. A named repository's
+            // mount has never answered anything, and a 404 is what it should
+            // go on saying rather than sending a stranger to a login form.
+            abort_unless($repository->isDefault(), 404, 'No page is published for this repository.');
+
+            return redirect('/admin/login');
+        }
+
+        $packages = $repository->pagePackages();
+
+        return view('pages.repository', [
+            'repository' => $repository,
+            'body' => $this->pages->renderRepository($repository),
+            'packages' => $packages,
+            'schema' => PageSchema::repository($repository, $packages),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Pages/SitemapController.php
+++ b/app/Http/Controllers/Pages/SitemapController.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Http\Controllers\Pages;
+
+use App\Http\Controllers\Controller;
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Response as ResponseFactory;
+
+/**
+ * /sitemap.xml and /robots.txt, listing exactly the pages this registry has
+ * been told to publish.
+ *
+ * A page nobody links to is a page nobody finds, and a private registry's
+ * pages are usually linked from nowhere at all — so without this the feature
+ * is a URL to paste into chat and nothing more. With it, a public repository's
+ * packages are discoverable the ordinary way.
+ *
+ * Which is also why it is a setting rather than a given: an installation whose
+ * pages are for people who were sent the link should not be advertising the
+ * list of them. Off, both documents still answer — robots.txt with a blanket
+ * disallow, the sitemap with an empty index — because a 404 on robots.txt is
+ * read by some crawlers as permission to crawl everything.
+ */
+class SitemapController extends Controller
+{
+    /**
+     * How many URLs one sitemap may name. The protocol's own ceiling is
+     * 50,000; a registry past that wants a sitemap index, and until one exists
+     * naming the first ten thousand is the honest limit — see the comment in
+     * the loop.
+     */
+    private const MAX_URLS = 10000;
+
+    public function sitemap(): Response
+    {
+        $urls = $this->enabled() ? $this->urls() : [];
+
+        $xml = ['<?xml version="1.0" encoding="UTF-8"?>'];
+        $xml[] = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+        foreach ($urls as $url) {
+            $xml[] = '  <url>';
+            $xml[] = '    <loc>'.htmlspecialchars($url['loc'], ENT_XML1).'</loc>';
+
+            if ($url['lastmod'] !== null) {
+                $xml[] = '    <lastmod>'.$url['lastmod'].'</lastmod>';
+            }
+
+            $xml[] = '  </url>';
+        }
+
+        $xml[] = '</urlset>';
+
+        return ResponseFactory::make(implode("\n", $xml)."\n", 200, [
+            'Content-Type' => 'application/xml',
+            // A crawler is not a visitor: an hour of staleness costs nothing
+            // and spares the registry a full scan per crawl.
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    public function robots(): Response
+    {
+        $lines = $this->enabled()
+            ? [
+                'User-agent: *',
+                // The panel, the Composer API and the download routes are all
+                // things a crawler can do nothing useful with — and the
+                // download routes it can do something actively unwanted with,
+                // namely spend the registry's bandwidth and inflate every
+                // package's download count.
+                'Disallow: /admin',
+                'Disallow: /p2/',
+                'Disallow: /dist/',
+                'Allow: /',
+                '',
+                'Sitemap: '.Repository::default()->pageRootUrl().'/sitemap.xml',
+            ]
+            : [
+                'User-agent: *',
+                'Disallow: /',
+            ];
+
+        return ResponseFactory::make(implode("\n", $lines)."\n", 200, [
+            'Content-Type' => 'text/plain; charset=UTF-8',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    private function enabled(): bool
+    {
+        return (bool) config('registry.pages.sitemap');
+    }
+
+    /**
+     * Every page this registry publishes: the repositories with a landing
+     * page, and the packages with one.
+     *
+     * A package in a private repository is listed too, and deliberately: its
+     * page exists, says so, and is where somebody asks for access. What it
+     * will not do is hand out an archive — see PackageArchiveController.
+     *
+     * @return list<array{loc: string, lastmod: ?string}>
+     */
+    private function urls(): array
+    {
+        $urls = [];
+
+        foreach (Repository::query()->where('page_enabled', true)->get() as $repository) {
+            $urls[] = ['loc' => $repository->pageUrl(), 'lastmod' => $repository->updated_at?->toAtomString()];
+        }
+
+        Package::query()
+            ->withPage()
+            ->with('composerRepository')
+            ->orderBy('id')
+            // Chunked because this is one query over a table that is allowed
+            // to be enormous, answered for an anonymous request.
+            ->limit(self::MAX_URLS)
+            ->each(function (Package $package) use (&$urls): void {
+                $urls[] = [
+                    'loc' => $package->pageUrl(),
+                    // What a crawler asks this for is "has the thing at that
+                    // URL changed", and for a package page the answer is a
+                    // release or an edit — not the hourly sync that writes
+                    // `last_synced_at` whether or not anything moved.
+                    'lastmod' => $package->updated_at?->toAtomString(),
+                ];
+            });
+
+        return $urls;
+    }
+}

--- a/app/Http/Controllers/Pages/SitemapController.php
+++ b/app/Http/Controllers/Pages/SitemapController.php
@@ -74,6 +74,14 @@ class SitemapController extends Controller
                 'Disallow: /admin',
                 'Disallow: /p2/',
                 'Disallow: /dist/',
+                // A page's own download button, under both mounts. The
+                // wildcards are RFC 9309's, and they are spelled out to the
+                // vendor and package segments rather than as a bare
+                // `/*/download` so that a package actually named "download"
+                // keeps its page indexed. A longer match wins over the
+                // `Allow: /` below, which is why these come first.
+                'Disallow: /p/*/*/download',
+                'Disallow: /r/*/p/*/*/download',
                 'Allow: /',
                 '',
                 'Sitemap: '.Repository::default()->pageRootUrl().'/sitemap.xml',

--- a/app/Jobs/RefreshPackagePage.php
+++ b/app/Jobs/RefreshPackagePage.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Package;
+use App\Services\PackagePage;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Read a package's page markdown out of its repository, off the request.
+ *
+ * Dispatched when an admin switches a page on, because that is the moment
+ * they expect to see one — and waiting for the next sync would show them an
+ * empty page and no explanation. Off the request because this is up to five
+ * calls to a provider's API, which is not something a form submission should
+ * be holding a browser open for.
+ *
+ * A sync does the same work inline instead (PackageSynchronizer::finalize):
+ * it is already talking to the provider, already knows which ref describes
+ * the package, and has nothing to return to a waiting person.
+ */
+class RefreshPackagePage implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 2;
+
+    /**
+     * A page whose package was deleted before the job ran is not a failure.
+     */
+    public bool $deleteWhenMissingModels = true;
+
+    public function __construct(public Package $package) {}
+
+    public function handle(PackagePage $pages): void
+    {
+        // The default branch rather than the release's ref: this runs outside
+        // a sync, so there is nothing here that knows which ref described the
+        // package, and the provider resolving its own default is the right
+        // answer until the next sync replaces it with the release's.
+        $pages->refresh($this->package);
+    }
+}

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -1071,7 +1071,7 @@ class Package extends Model
      */
     public function pageLinkBase(): ?string
     {
-        return $this->pageRepositoryBase(fn (SourceProvider $provider, string $url): ?string => $provider->browseUrl($url));
+        return $this->pageRepositoryBase($this->browseResolver());
     }
 
     /**
@@ -1079,17 +1079,55 @@ class Package extends Model
      */
     public function pageImageBase(): ?string
     {
-        return $this->pageRepositoryBase(fn (SourceProvider $provider, string $url): ?string => $provider->rawUrl($url));
+        return $this->pageRepositoryBase($this->rawResolver());
+    }
+
+    /**
+     * The same two, without the package's subdirectory — the repository root.
+     *
+     * Where a link written with a leading slash points: in a README, and so
+     * on every provider that renders one, `/docs/install.md` means the
+     * repository root rather than the directory the file sits in. For a
+     * package that is the whole repository the two bases are identical; for a
+     * monorepo package they are not, and resolving a root-relative link
+     * against the subdirectory base produces a link to a path that does not
+     * exist.
+     */
+    public function pageLinkRootBase(): ?string
+    {
+        return $this->pageRepositoryBase($this->browseResolver(), subdirectory: false);
+    }
+
+    public function pageImageRootBase(): ?string
+    {
+        return $this->pageRepositoryBase($this->rawResolver(), subdirectory: false);
+    }
+
+    /**
+     * @return callable(SourceProvider, string): ?string
+     */
+    private function browseResolver(): callable
+    {
+        return fn (SourceProvider $provider, string $url): ?string => $provider->browseUrl($url);
+    }
+
+    /**
+     * @return callable(SourceProvider, string): ?string
+     */
+    private function rawResolver(): callable
+    {
+        return fn (SourceProvider $provider, string $url): ?string => $provider->rawUrl($url);
     }
 
     /**
      * The subdirectory-aware base for either of the two above. A monorepo
      * package's README lives in its own directory, and its relative links are
-     * relative to that directory rather than to the repository root.
+     * relative to that directory rather than to the repository root — except
+     * for the root-relative ones, which is what $subdirectory: false is for.
      *
      * @param  callable(SourceProvider, string): ?string  $resolve
      */
-    private function pageRepositoryBase(callable $resolve): ?string
+    private function pageRepositoryBase(callable $resolve, bool $subdirectory = true): ?string
     {
         if (blank($this->repository)) {
             return null;
@@ -1101,7 +1139,9 @@ class Package extends Model
             return null;
         }
 
-        return $this->hasSubdirectory() ? $base.'/'.trim((string) $this->subdirectory, '/') : $base;
+        return $subdirectory && $this->hasSubdirectory()
+            ? $base.'/'.trim((string) $this->subdirectory, '/')
+            : $base;
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -2,9 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\PageDownloads;
 use App\Enums\SourceProvider;
 use App\Enums\WebhookCoverage;
 use App\Exceptions\VendorReserved;
+use App\Jobs\RefreshPackagePage;
 use App\Models\Concerns\LogsAuditableChanges;
 use App\Notifications\PackageAbandoned;
 use App\Services\AdminNotifier;
@@ -28,7 +30,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
-#[Fillable(['repository_id', 'source_id', 'repository', 'subdirectory', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error', 'webhook_enabled', 'abandoned', 'replacement_package'])]
+#[Fillable(['repository_id', 'source_id', 'repository', 'subdirectory', 'latest_version', 'name', 'description', 'type', 'token', 'last_synced_at', 'sync_error', 'webhook_enabled', 'abandoned', 'replacement_package', 'page_enabled', 'page_downloads', 'page_install', 'page_versions', 'page_body', 'page_image'])]
 class Package extends Model
 {
     /** @use HasFactory<PackageFactory> */
@@ -49,6 +51,14 @@ class Package extends Model
     protected $attributes = [
         'webhook_enabled' => true,
         'abandoned' => false,
+        // The page columns, restated for the same reason `abandoned` is: the
+        // form reads them off a record it has just built, and a null where
+        // the column says false is a toggle that renders indeterminate and an
+        // audit entry for a change nobody made.
+        'page_enabled' => false,
+        'page_downloads' => PageDownloads::None,
+        'page_install' => true,
+        'page_versions' => true,
         // The column's default, restated for the same reason: a package built
         // in memory is asked where in its repository it lives — by the wizard
         // reading a composer.json, by the client factories — before it has
@@ -68,6 +78,13 @@ class Package extends Model
         return [
             'name', 'repository', 'subdirectory', 'repository_id', 'source_id', 'type',
             'abandoned', 'replacement_package', 'webhook_enabled',
+            // Publishing a page is a publishing decision like any other, and
+            // the one on this list a reader can see without a token — so an
+            // audit that recorded who made this package private again, and
+            // when, is worth more here than anywhere else on the row. The
+            // bodies are left off: they are content, and the log is a record
+            // of decisions, not a revision history for markdown.
+            'page_enabled', 'page_downloads', 'page_install', 'page_versions',
         ];
     }
 
@@ -83,6 +100,11 @@ class Package extends Model
             'abandoned' => 'boolean',
             'last_synced_at' => 'datetime',
             'webhook_received_at' => 'datetime',
+            'page_enabled' => 'boolean',
+            'page_install' => 'boolean',
+            'page_versions' => 'boolean',
+            'page_downloads' => PageDownloads::class,
+            'page_source_synced_at' => 'datetime',
         ];
     }
 
@@ -153,6 +175,17 @@ class Package extends Model
         static::saved(function (self $package): void {
             if ($package->wasChanged('abandoned') && $package->abandoned) {
                 app(AdminNotifier::class)->send(new PackageAbandoned($package));
+            }
+
+            // A page switched on has nothing to show until the repository's
+            // README has been read, and the next sync may be an hour away —
+            // so the read is queued the moment the switch is saved. Only in
+            // the off → on direction, and only when the body has never been
+            // read: syncs keep it current afterwards, and re-reading it every
+            // time an admin saves an unrelated field would spend a provider
+            // request per edit.
+            if ($package->wasChanged('page_enabled') && $package->page_enabled && $package->page_source_synced_at === null) {
+                RefreshPackagePage::dispatch($package);
             }
         });
 
@@ -847,27 +880,6 @@ class Package extends Model
      */
     public function installCommands(): array
     {
-        $repository = $this->composerRepository;
-
-        // A configured key is used exactly as it was typed: whoever set it has
-        // decided what the entry in the consumer's composer.json is called, and
-        // that includes taking on the collision below.
-        $repositoryKey = (string) config('registry.composer_repository_key');
-
-        if ($repositoryKey === '') {
-            // Otherwise it is derived. A package in a named repository is
-            // reached through that mount, and the derived key carries the path
-            // so two repositories on the same registry never fight over one
-            // entry in the consumer's composer.json.
-            $repositoryKey = Str::slug(config('app.name')) ?: 'private';
-
-            if (! $repository->isDefault()) {
-                $repositoryKey .= "-{$repository->path}";
-            }
-        }
-
-        $repositoryUrl = rtrim($repository->url(), '/');
-
         $require = $this->name;
 
         if ($constraint = $this->suggestedConstraint()) {
@@ -875,7 +887,10 @@ class Package extends Model
         }
 
         return [
-            'repository' => "composer config repositories.{$repositoryKey} composer {$repositoryUrl}",
+            // Which entry in the consumer's composer.json this repository
+            // claims, and what it is pointed at, is the repository's own
+            // decision — the same line its landing page prints.
+            'repository' => $this->composerRepository->configureCommand(),
             'require' => "composer require {$require}",
         ];
     }
@@ -920,6 +935,268 @@ class Package extends Model
             ->last();
 
         $this->forceFill(['latest_version' => $latest])->save();
+    }
+
+    /**
+     * The filenames a package page's body is looked for in, in order.
+     *
+     * `package-page.md` first, because a project that has written one has
+     * written it for this: a README is addressed to contributors — how to run
+     * the test suite, how to open a pull request — where a registry page is
+     * addressed to whoever is deciding whether to install the thing. The
+     * README is the fallback because almost every repository has one and
+     * almost none has the other.
+     *
+     * The case variants are not decoration: a case-sensitive provider serves
+     * "Readme.md" and "README.md" as different files, and which one a project
+     * committed is not something an admin should have to find out by
+     * publishing a blank page.
+     *
+     * @var list<string>
+     */
+    public const PAGE_FILES = [
+        'package-page.md',
+        'PACKAGE-PAGE.md',
+        'README.md',
+        'readme.md',
+        'Readme.md',
+    ];
+
+    /**
+     * Whether this package answers at a public URL.
+     *
+     * The switch alone decides it. A package in a private repository still
+     * gets a page when one is enabled — it just cannot hand out archives (see
+     * pageDownloads()) — because "here is what this is, ask us for access" is
+     * exactly the page a private package wants, and because a registry that
+     * refused to publish anything about a private package would have nowhere
+     * to put the access request that follows.
+     */
+    public function hasPage(): bool
+    {
+        return (bool) $this->page_enabled;
+    }
+
+    /**
+     * The public URL of this package's page.
+     *
+     * Inside the repository's own mount, exactly as its Composer endpoints
+     * are — "/p/vendor/name" at the root, "/r/internal/p/vendor/name" for a
+     * named repository. Package names are unique per repository rather than
+     * per registry, so a single rooted /p/ namespace would be ambiguous the
+     * first time two repositories on one installation published the same
+     * name, which is a thing repositories exist to allow.
+     *
+     * Absolute, and built from the configured application URL rather than
+     * from the request, because this is what goes in a canonical link, a
+     * sitemap and an og:url — all three read by machines that will not be
+     * visiting from the host that generated them.
+     */
+    public function pageUrl(): string
+    {
+        [$vendor, $name] = explode('/', (string) $this->name, 2) + ['', ''];
+
+        return $this->composerRepository->url('/p/'.$vendor.'/'.$name);
+    }
+
+    /**
+     * The markdown this page renders, and where it came from.
+     *
+     * The panel's own body wins outright: an admin who has written one has
+     * said what this page should say, and a sync that then overwrote it with
+     * the repository's README would be the app arguing with its operator.
+     *
+     * @return array{body: ?string, source: string}
+     */
+    public function pageContent(): array
+    {
+        if (filled($this->page_body)) {
+            return ['body' => (string) $this->page_body, 'source' => 'panel'];
+        }
+
+        return filled($this->page_source_body)
+            ? ['body' => (string) $this->page_source_body, 'source' => (string) $this->page_source_path]
+            : ['body' => null, 'source' => 'none'];
+    }
+
+    /**
+     * What the page may actually offer, as against what it was configured to.
+     *
+     * The configured value is capped by the repository's own public flag,
+     * because an archive is the package's content and handing it to an
+     * anonymous visitor is precisely what a private repository exists to
+     * refuse. A page on a private repository therefore reads as "no
+     * downloads" however it was set — and the setting is kept rather than
+     * cleared, so making the repository public again restores what the admin
+     * chose rather than silently leaving it off.
+     */
+    public function pageDownloads(): PageDownloads
+    {
+        if (! $this->composerRepository->public) {
+            return PageDownloads::None;
+        }
+
+        return $this->page_downloads ?? PageDownloads::None;
+    }
+
+    /**
+     * Whether the page prints install commands a visitor can run as they
+     * stand.
+     *
+     * The same cap, for the same reason with a smaller consequence: the two
+     * lines a private package needs are the ones with a token in them, and
+     * printing the tokenless pair to an anonymous visitor sends them to a 401
+     * that reads as the registry being broken. The page shows the access
+     * notice in their place instead.
+     */
+    public function pageShowsInstall(): bool
+    {
+        return (bool) $this->page_install && $this->composerRepository->public;
+    }
+
+    /**
+     * Whether this page is one where the visitor has to ask for access before
+     * anything on it is usable — the notice that stands in for the download
+     * buttons and the install commands, and where a token request will go.
+     */
+    public function pageRequiresAccess(): bool
+    {
+        return ! $this->composerRepository->public;
+    }
+
+    /**
+     * Where a relative link in the page's markdown points: the repository's
+     * file browser, or null for a package with no repository to point at —
+     * one published entirely by artifact upload.
+     */
+    public function pageLinkBase(): ?string
+    {
+        return $this->pageRepositoryBase(fn (SourceProvider $provider, string $url): ?string => $provider->browseUrl($url));
+    }
+
+    /**
+     * Where a relative image points: the same file, served as bytes.
+     */
+    public function pageImageBase(): ?string
+    {
+        return $this->pageRepositoryBase(fn (SourceProvider $provider, string $url): ?string => $provider->rawUrl($url));
+    }
+
+    /**
+     * The subdirectory-aware base for either of the two above. A monorepo
+     * package's README lives in its own directory, and its relative links are
+     * relative to that directory rather than to the repository root.
+     *
+     * @param  callable(SourceProvider, string): ?string  $resolve
+     */
+    private function pageRepositoryBase(callable $resolve): ?string
+    {
+        if (blank($this->repository)) {
+            return null;
+        }
+
+        $base = $resolve($this->provider(), (string) $this->repository);
+
+        if ($base === null) {
+            return null;
+        }
+
+        return $this->hasSubdirectory() ? $base.'/'.trim((string) $this->subdirectory, '/') : $base;
+    }
+
+    /**
+     * The image a social platform shows when this page's URL is pasted into a
+     * post: the package's own, or the registry-wide default, or none.
+     *
+     * Absolute, because that is what og:image requires — a relative one is
+     * dropped by every platform that reads it.
+     */
+    public function pageImageUrl(): ?string
+    {
+        $image = filled($this->page_image)
+            ? (string) $this->page_image
+            : (string) config('registry.page_image', '');
+
+        if ($image === '') {
+            return null;
+        }
+
+        return str_starts_with($image, 'http://') || str_starts_with($image, 'https://')
+            ? $image
+            : $this->composerRepository->pageRootUrl().'/'.ltrim($image, '/');
+    }
+
+    /**
+     * The one-line summary the page's <meta name="description"> and its
+     * og:description carry.
+     *
+     * Composed rather than taken from the description column alone, because
+     * a third of packages describe themselves in three words and a preview
+     * card with three words in it tells a reader nothing. The name and the
+     * current version are facts this app always has.
+     */
+    public function pageSummary(): string
+    {
+        $described = trim((string) $this->description);
+
+        $summary = $described !== ''
+            ? $described
+            : "The {$this->name} package.";
+
+        if ($this->latest_version !== null) {
+            $summary .= " Latest release: {$this->latest_version}.";
+        }
+
+        // Search engines truncate around 160 characters and social cards
+        // sooner; cut on a word so the result reads as a sentence that ended
+        // rather than one that was severed.
+        return Str::limit($summary, 155, preserveWords: true);
+    }
+
+    /**
+     * The versions this page lists, newest first.
+     *
+     * Capped, because a package that has been released weekly for five years
+     * has several hundred and a page is not an API — the whole history is
+     * what /p2 is for, and what the version table exists to summarize.
+     *
+     * @return Collection<int, PackageVersion>
+     */
+    public function pageVersions(int $limit = 50): Collection
+    {
+        return $this->versions()
+            ->orderByDesc('order')
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * The release this page's "latest" download hands over: the stable
+     * version the package names as current, and nothing when it has none.
+     * A page will not quietly offer a dev branch as though it were a release.
+     */
+    public function pageLatestVersion(): ?PackageVersion
+    {
+        if ($this->latest_version === null) {
+            return null;
+        }
+
+        return $this->versions()
+            ->where('version', $this->latest_version)
+            ->whereNotNull('archive_path')
+            ->first();
+    }
+
+    /**
+     * The packages with pages, for the sitemap and a repository's own page.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeWithPage(Builder $query): Builder
+    {
+        return $query->where('page_enabled', true);
     }
 
     /**

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -29,6 +29,19 @@ class Repository extends Model
     use HasFactory, LogsAuditableChanges;
 
     /**
+     * The page columns' database defaults, restated for the same reason
+     * Package restates its own: the form reads them off a record it has just
+     * built, and a null where the column says false is a toggle that renders
+     * indeterminate and an audit entry for a change nobody made.
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'page_enabled' => false,
+        'page_lists_packages' => true,
+    ];
+
+    /**
      * Where a repository is served and whether it is readable without a
      * token — the switch that turns private packages public.
      *

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Support\Str;
 
 /**
  * A named Composer repository this registry serves.
@@ -21,7 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
  * so one installation can serve independent registries — a public one and an
  * internal one, say — with independent access rules.
  */
-#[Fillable(['name', 'path', 'description', 'public'])]
+#[Fillable(['name', 'path', 'description', 'public', 'page_enabled', 'page_body', 'page_image', 'page_lists_packages'])]
 class Repository extends Model
 {
     /** @use HasFactory<RepositoryFactory> */
@@ -35,7 +36,7 @@ class Repository extends Model
      */
     protected function auditedAttributes(): array
     {
-        return ['name', 'path', 'public'];
+        return ['name', 'path', 'public', 'page_enabled', 'page_lists_packages'];
     }
 
     /**
@@ -45,6 +46,8 @@ class Repository extends Model
     {
         return [
             'public' => 'boolean',
+            'page_enabled' => 'boolean',
+            'page_lists_packages' => 'boolean',
         ];
     }
 
@@ -252,6 +255,117 @@ class Repository extends Model
     public function pathPrefix(): string
     {
         return $this->isDefault() ? '' : "/r/{$this->path}";
+    }
+
+    /**
+     * Whether this repository publishes a landing page.
+     */
+    public function hasPage(): bool
+    {
+        return (bool) $this->page_enabled;
+    }
+
+    /**
+     * Where this repository's page answers — which is the same URL its
+     * Composer endpoints hang off, with nothing after it.
+     *
+     * That is the whole point of putting it there: the URL a project pastes
+     * into `composer config repositories.x composer <url>` is the URL a
+     * person pastes into a browser afterwards, and Composer itself only ever
+     * asks for /packages.json and the paths under it. So the two never
+     * collide, and the address an operator is already handing out becomes the
+     * page describing what is behind it.
+     */
+    public function pageUrl(): string
+    {
+        return $this->url();
+    }
+
+    /**
+     * The registry's root URL, for the page routes that build a URL which is
+     * not inside this repository's mount — a package page lives at /p/... at
+     * the root however many repositories the registry serves.
+     *
+     * Public where rootUrl() is private because that is exactly the
+     * distinction: this is the same deployment fact, asked for by callers
+     * outside the model. @see url()
+     */
+    public function pageRootUrl(): string
+    {
+        return $this->rootUrl();
+    }
+
+    /**
+     * The packages this repository's page lists — those that publish a page
+     * of their own, alphabetically.
+     *
+     * A package without a page is left off rather than listed as plain text:
+     * the list exists to be clicked, and naming a package this registry will
+     * not describe is how a private package's existence leaks out of a
+     * public landing page.
+     *
+     * @return Collection<int, Package>
+     */
+    public function pagePackages(): Collection
+    {
+        if (! $this->page_lists_packages) {
+            return new Collection;
+        }
+
+        return $this->packages()
+            ->withPage()
+            ->orderBy('name')
+            ->get(['id', 'repository_id', 'name', 'description', 'type', 'latest_version', 'abandoned']);
+    }
+
+    /**
+     * The summary the page's meta description and og:description carry.
+     */
+    public function pageSummary(): string
+    {
+        $described = trim((string) $this->description);
+
+        return Str::limit($described !== ''
+            ? $described
+            : "{$this->name} — a Composer repository served by ".config('app.name').'.', 155, preserveWords: true);
+    }
+
+    /**
+     * The social preview image for this page, absolute, or none.
+     */
+    public function pageImageUrl(): ?string
+    {
+        $image = filled($this->page_image)
+            ? (string) $this->page_image
+            : (string) config('registry.page_image', '');
+
+        if ($image === '') {
+            return null;
+        }
+
+        return str_starts_with($image, 'http://') || str_starts_with($image, 'https://')
+            ? $image
+            : $this->pageRootUrl().'/'.ltrim($image, '/');
+    }
+
+    /**
+     * The one `composer config` line that points a project at this
+     * repository — the same line the package pages print, without a package
+     * to require afterwards.
+     */
+    public function configureCommand(): string
+    {
+        $key = (string) config('registry.composer_repository_key');
+
+        if ($key === '') {
+            $key = Str::slug(config('app.name')) ?: 'private';
+
+            if (! $this->isDefault()) {
+                $key .= "-{$this->path}";
+            }
+        }
+
+        return "composer config repositories.{$key} composer ".rtrim($this->url(), '/');
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -299,6 +299,15 @@ class AppServiceProvider extends ServiceProvider
         // Per address rather than per credential because the token is optional
         // and there is nothing else to key on.
         RateLimiter::for('metrics', fn (Request $request) => Limit::perMinute(60)->by($request->ip()));
+
+        // The public pages, which are the only surface here that anonymous
+        // traffic is *invited* to — a link in a chat, a search result, a
+        // social card being generated. Generous enough that a person clicking
+        // through a repository's package list never meets it, and low enough
+        // that a scraper walking every page and every download link is
+        // bounded. Keyed by address alone, because there is no credential on
+        // this surface to key by.
+        RateLimiter::for('pages', fn (Request $request) => Limit::perMinute(120)->by($request->ip()));
     }
 
     /**

--- a/app/Services/GitHub/GitHubClient.php
+++ b/app/Services/GitHub/GitHubClient.php
@@ -84,11 +84,28 @@ class GitHubClient implements RepositoryClient
      */
     public function composerJson(?string $ref = null, string $directory = ''): ?array
     {
+        $decoded = json_decode((string) $this->file('composer.json', $ref, $directory), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * The raw contents of one file in the repository.
+     *
+     * The same contents endpoint composer.json is read through, asked for a
+     * file the caller names — which is what the public page needs, and what
+     * makes the two callers share one idea of how a path is built and what a
+     * missing file looks like.
+     *
+     * @param  string  $directory  the package's subdirectory, empty for the root
+     */
+    public function file(string $path, ?string $ref = null, string $directory = ''): ?string
+    {
         // The contents endpoint takes the file path in the URL, so the
         // segments are encoded individually — a path is not one component.
         $path = implode('/', array_map(rawurlencode(...), array_filter([
             ...explode('/', $directory),
-            'composer.json',
+            ...explode('/', $path),
         ], fn (string $segment): bool => $segment !== '')));
 
         $response = $this->request()
@@ -99,9 +116,7 @@ class GitHubClient implements RepositoryClient
             return null;
         }
 
-        $decoded = json_decode($this->ok($response)->body(), true);
-
-        return is_array($decoded) ? $decoded : null;
+        return $this->ok($response)->body();
     }
 
     /**

--- a/app/Services/GitLab/GitLabClient.php
+++ b/app/Services/GitLab/GitLabClient.php
@@ -74,6 +74,19 @@ class GitLabClient implements RepositoryClient
      */
     public function composerJson(?string $ref = null, string $directory = ''): ?array
     {
+        $decoded = json_decode((string) $this->file('composer.json', $ref, $directory), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * The raw contents of one file in the repository — the same endpoint
+     * composer.json is read through, for a file the caller names.
+     *
+     * @param  string  $directory  the package's subdirectory, empty for the root
+     */
+    public function file(string $path, ?string $ref = null, string $directory = ''): ?string
+    {
         // GitLab's raw-file endpoint requires a ref; "the default branch" has
         // to be asked for by name first.
         $ref ??= $this->defaultBranch();
@@ -85,7 +98,7 @@ class GitLabClient implements RepositoryClient
         // Unlike GitHub's, this endpoint takes the whole file path as a single
         // URL segment, so the separators are encoded along with everything
         // else — "packages/foo/composer.json" travels as one component.
-        $path = rawurlencode(ltrim("{$directory}/composer.json", '/'));
+        $path = rawurlencode(trim("{$directory}/{$path}", '/'));
 
         $response = $this->request()->get(
             "/projects/{$this->projectId()}/repository/files/{$path}/raw",
@@ -96,9 +109,7 @@ class GitLabClient implements RepositoryClient
             return null;
         }
 
-        $decoded = json_decode($this->ok($response)->body(), true);
-
-        return is_array($decoded) ? $decoded : null;
+        return $this->ok($response)->body();
     }
 
     public function commitDate(string $ref): ?CarbonImmutable

--- a/app/Services/PackagePage.php
+++ b/app/Services/PackagePage.php
@@ -141,6 +141,8 @@ class PackagePage
             $body,
             $package->pageLinkBase(),
             $package->pageImageBase(),
+            $package->pageLinkRootBase(),
+            $package->pageImageRootBase(),
         );
     }
 
@@ -159,19 +161,24 @@ class PackagePage
     /**
      * Render, through the cache.
      */
-    private function cached(string $body, ?string $linkBase, ?string $imageBase): HtmlString
-    {
+    private function cached(
+        string $body,
+        ?string $linkBase,
+        ?string $imageBase,
+        ?string $linkRootBase = null,
+        ?string $imageRootBase = null,
+    ): HtmlString {
         $body = $this->bounded($body);
 
         $minutes = (int) config('registry.pages.markdown_cache_minutes');
 
-        $render = fn (): string => $this->markdown->render($body, $linkBase, $imageBase);
+        $render = fn (): string => $this->markdown->render($body, $linkBase, $imageBase, $linkRootBase, $imageRootBase);
 
         if ($minutes <= 0) {
             return new HtmlString($render());
         }
 
-        $key = 'page-markdown:'.hash('xxh128', $body."\0".$linkBase."\0".$imageBase);
+        $key = 'page-markdown:'.hash('xxh128', implode("\0", [$body, $linkBase, $imageBase, $linkRootBase, $imageRootBase]));
 
         return new HtmlString(Cache::remember($key, now()->addMinutes($minutes), $render));
     }

--- a/app/Services/PackagePage.php
+++ b/app/Services/PackagePage.php
@@ -37,7 +37,8 @@ class PackagePage
      * a page that shows what it had last time — or no body at all, which the
      * page renders as the package's metadata alone.
      *
-     * @param  string|null  $ref  the ref to read at, or null for the default branch
+     * @param  string|null  $ref  the ref to read at, or null to read at the
+     *                            release the package's own metadata came from
      * @return bool whether a body was found
      */
     public function refresh(Package $package, ?string $ref = null): bool
@@ -48,6 +49,13 @@ class PackagePage
 
         try {
             $client = $package->client();
+
+            // So that a refresh asked for outside a sync — the panel action,
+            // the job that runs when a page is switched on — stores what the
+            // next sync would store. Reading the default branch instead would
+            // publish a document describing a version that has not shipped,
+            // and would be reverted by the next sync anyway.
+            $ref ??= $this->describingRef($package);
 
             foreach (Package::PAGE_FILES as $path) {
                 $body = $client->file($path, $ref, (string) $package->subdirectory);
@@ -87,6 +95,30 @@ class PackagePage
 
             return false;
         }
+    }
+
+    /**
+     * The ref whose contents describe this package: the current release, or
+     * the version that arrived last for a package that has none, or null for
+     * one with no stored versions at all — where null means "the default
+     * branch", which is the only thing known about a repository that has
+     * never been synced.
+     */
+    private function describingRef(Package $package): ?string
+    {
+        if ($package->latest_version !== null) {
+            $reference = $package->versions()
+                ->where('version', $package->latest_version)
+                ->value('reference');
+
+            if (filled($reference)) {
+                return (string) $reference;
+            }
+        }
+
+        $reference = $package->versions()->orderByDesc('id')->value('reference');
+
+        return filled($reference) ? (string) $reference : null;
     }
 
     /**

--- a/app/Services/PackagePage.php
+++ b/app/Services/PackagePage.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Package;
+use App\Models\Repository;
+use App\Support\PageMarkdown;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\HtmlString;
+use Throwable;
+
+/**
+ * The body of a public page: where it comes from and what it renders to.
+ *
+ * Two jobs that belong together because they are two halves of one decision —
+ * a page's markdown is read from the repository at sync time and rendered at
+ * request time, and both need to agree about which file won and how big is
+ * too big.
+ *
+ * Reading is deliberately not done per request. A page is served to anonymous
+ * visitors, so a fetch on the render path would put somebody else's traffic
+ * in front of this installation's GitHub rate limit and make the page's
+ * latency depend on a third party being up. So the markdown is stored on the
+ * package and refreshed when something happens that could have changed it: a
+ * sync, or an admin switching the page on.
+ */
+class PackagePage
+{
+    public function __construct(private readonly PageMarkdown $markdown = new PageMarkdown) {}
+
+    /**
+     * Read this package's page markdown out of its repository and store it.
+     *
+     * Never throws: this runs inside a sync, and a README that could not be
+     * read is not a reason to fail the sync that published the release. It is
+     * a page that shows what it had last time — or no body at all, which the
+     * page renders as the package's metadata alone.
+     *
+     * @param  string|null  $ref  the ref to read at, or null for the default branch
+     * @return bool whether a body was found
+     */
+    public function refresh(Package $package, ?string $ref = null): bool
+    {
+        if (blank($package->repository)) {
+            return false;
+        }
+
+        try {
+            $client = $package->client();
+
+            foreach (Package::PAGE_FILES as $path) {
+                $body = $client->file($path, $ref, (string) $package->subdirectory);
+
+                if ($body === null || trim($body) === '') {
+                    continue;
+                }
+
+                $package->recordBookkeeping([
+                    'page_source_body' => $this->bounded($body),
+                    'page_source_path' => $path,
+                    'page_source_synced_at' => now(),
+                ]);
+
+                return true;
+            }
+
+            // Nothing found is a result, not a failure — and it is recorded as
+            // one. Without the timestamp, every later sync would walk the
+            // whole candidate list again against a repository that has none of
+            // them, which on GitHub is five requests per package per sync.
+            $package->recordBookkeeping([
+                'page_source_body' => null,
+                'page_source_path' => null,
+                'page_source_synced_at' => now(),
+            ]);
+
+            return false;
+        } catch (Throwable $exception) {
+            // Logged rather than surfaced: the sync's own `sync_error` column
+            // is about whether this registry can serve the package, and a
+            // missing README is not that.
+            Log::warning('Could not read the page content for a package.', [
+                'package' => $package->name,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * The rendered HTML for a package's page body, or null when it has none.
+     *
+     * Cached on a key derived from the markdown itself, so a body that
+     * changes renders again and a body that has not is never re-parsed. The
+     * bases are in the key too: moving a package to a different repository
+     * URL changes where its relative links point.
+     */
+    public function render(Package $package): ?HtmlString
+    {
+        ['body' => $body] = $package->pageContent();
+
+        if ($body === null) {
+            return null;
+        }
+
+        return $this->cached(
+            $body,
+            $package->pageLinkBase(),
+            $package->pageImageBase(),
+        );
+    }
+
+    /**
+     * The same for a repository's landing page, whose body is only ever
+     * written in the panel — so there is no repository to resolve relative
+     * links against, and a relative link is dropped.
+     */
+    public function renderRepository(Repository $repository): ?HtmlString
+    {
+        $body = (string) $repository->page_body;
+
+        return trim($body) === '' ? null : $this->cached($body, null, null);
+    }
+
+    /**
+     * Render, through the cache.
+     */
+    private function cached(string $body, ?string $linkBase, ?string $imageBase): HtmlString
+    {
+        $body = $this->bounded($body);
+
+        $minutes = (int) config('registry.pages.markdown_cache_minutes');
+
+        $render = fn (): string => $this->markdown->render($body, $linkBase, $imageBase);
+
+        if ($minutes <= 0) {
+            return new HtmlString($render());
+        }
+
+        $key = 'page-markdown:'.hash('xxh128', $body."\0".$linkBase."\0".$imageBase);
+
+        return new HtmlString(Cache::remember($key, now()->addMinutes($minutes), $render));
+    }
+
+    /**
+     * The body, cut to the configured ceiling.
+     *
+     * Cut on a line rather than mid-character, and marked, because a page that
+     * silently stops halfway through a sentence reads as a bug in this app
+     * rather than as a file that was too long to publish.
+     */
+    private function bounded(string $body): string
+    {
+        $limit = max(0, (int) config('registry.pages.max_body_kilobytes')) * 1024;
+
+        if ($limit === 0 || strlen($body) <= $limit) {
+            return $body;
+        }
+
+        $cut = substr($body, 0, $limit);
+        $lastBreak = strrpos($cut, "\n");
+
+        if ($lastBreak !== false) {
+            $cut = substr($cut, 0, $lastBreak);
+        }
+
+        return $cut."\n\n*This document was truncated.*\n";
+    }
+}

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -39,6 +39,7 @@ class PackageSynchronizer
         private readonly ArchiveStore $archives,
         private readonly ArchiveSubtree $subtrees = new ArchiveSubtree,
         private readonly VersionNormalizer $normalizer = new VersionNormalizer,
+        private readonly PackagePage $pages = new PackagePage,
     ) {}
 
     /**
@@ -298,8 +299,9 @@ class PackageSynchronizer
         // metadata is read, so only that one is fetched.
         $describes = $latest ?? (string) $versions->last()->version;
 
-        $newest = $package->versions()->where('version', $describes)->value('metadata');
-        $newest = is_array($newest) ? $newest : [];
+        $describing = $package->versions()->where('version', $describes)->first(['metadata', 'reference']);
+
+        $newest = is_array($describing?->metadata) ? $describing->metadata : [];
 
         $declared = $newest['name'] ?? null;
 
@@ -327,6 +329,18 @@ class PackageSynchronizer
         $package->isClean(self::PUBLISHED_COLUMNS)
             ? $package->recordBookkeeping($bookkeeping)
             : $package->forceFill($bookkeeping)->save();
+
+        // The public page's body, read at the same ref that described the
+        // package above — so the page and the metadata beside it are the same
+        // release talking, rather than a README from the default branch
+        // describing a version that has not shipped.
+        //
+        // Only for a package that publishes a page: this is up to five
+        // provider requests per package per sync, and a registry serving
+        // thousands of packages with no pages should spend none of them.
+        if ($package->page_enabled) {
+            $this->pages->refresh($package, $describing?->reference);
+        }
 
         return $this->outcome($known, $versions->pluck('is_dev', 'version')->all());
     }

--- a/app/Sources/RepositoryClient.php
+++ b/app/Sources/RepositoryClient.php
@@ -44,6 +44,20 @@ interface RepositoryClient
     public function composerJson(?string $ref = null, string $directory = ''): ?array;
 
     /**
+     * The raw contents of a text file in the repository, at the given ref or
+     * at the default branch when none is given. Null when the file is
+     * missing, out of reach, or is not text this app can render.
+     *
+     * Added for the public page, which reads a package-page.md or a README
+     * out of the repository — so unlike composerJson() the caller names the
+     * file, and unlike a zipball it wants one file rather than the tree.
+     *
+     * @param  string  $path  the file's path relative to $directory, e.g. "README.md"
+     * @param  string  $directory  the package's subdirectory, empty for the root
+     */
+    public function file(string $path, ?string $ref = null, string $directory = ''): ?string;
+
+    /**
      * The commit date of the given ref, or null when the provider does not
      * report one.
      */

--- a/app/Sources/StubClient.php
+++ b/app/Sources/StubClient.php
@@ -36,6 +36,11 @@ class StubClient implements RepositoryClient, SourceClient
         throw $this->unsupported();
     }
 
+    public function file(string $path, ?string $ref = null, string $directory = ''): ?string
+    {
+        throw $this->unsupported();
+    }
+
     public function commitDate(string $ref): ?CarbonImmutable
     {
         throw $this->unsupported();

--- a/app/Support/PageMarkdown.php
+++ b/app/Support/PageMarkdown.php
@@ -58,9 +58,21 @@ class PageMarkdown
      *                                  providers serve the file and a view of
      *                                  the file at different hosts: an <img>
      *                                  wants raw bytes, an <a> wants the page.
+     * @param  string|null  $linkRootBase  what a link written with a leading
+     *                                     slash resolves against — the
+     *                                     repository root, which for a
+     *                                     monorepo package is not the same
+     *                                     place as $linkBase. Null means the
+     *                                     two are the same.
+     * @param  string|null  $imageRootBase  the same, for images.
      */
-    public function render(string $markdown, ?string $linkBase = null, ?string $imageBase = null): string
-    {
+    public function render(
+        string $markdown,
+        ?string $linkBase = null,
+        ?string $imageBase = null,
+        ?string $linkRootBase = null,
+        ?string $imageRootBase = null,
+    ): string {
         $environment = new Environment([
             // The two settings this class exists for. `escape` renders raw
             // HTML as visible text; `allow_unsafe_links: false` drops
@@ -94,7 +106,13 @@ class PageMarkdown
         // link extension then judges are the absolute ones this resolves to.
         $environment->addEventListener(
             DocumentParsedEvent::class,
-            fn (DocumentParsedEvent $event) => $this->resolveRelativeUrls($event->getDocument(), $linkBase, $imageBase),
+            fn (DocumentParsedEvent $event) => $this->resolveRelativeUrls(
+                $event->getDocument(),
+                $linkBase,
+                $imageBase,
+                $linkRootBase ?? $linkBase,
+                $imageRootBase ?? $imageBase,
+            ),
             // A higher priority than the external-link extension's own
             // listener (0), which decides what is external by looking at the
             // host — and a relative URL has none until this has run.
@@ -115,8 +133,13 @@ class PageMarkdown
      * that does not exist, and `![](logo.png)` becomes a broken image that
      * costs a request and a 404 log line on every page view.
      */
-    private function resolveRelativeUrls(Document $document, ?string $linkBase, ?string $imageBase): void
-    {
+    private function resolveRelativeUrls(
+        Document $document,
+        ?string $linkBase,
+        ?string $imageBase,
+        ?string $linkRootBase,
+        ?string $imageRootBase,
+    ): void {
         foreach ($document->iterator() as $node) {
             if (! $node instanceof Link && ! $node instanceof Image) {
                 continue;
@@ -134,7 +157,14 @@ class PageMarkdown
                 continue;
             }
 
-            $base = $node instanceof Image ? $imageBase : $linkBase;
+            // A leading slash is the one relative form that is not relative
+            // to the document: it means the repository root, so it resolves
+            // against the root base rather than the package's own directory.
+            $root = str_starts_with($url, '/');
+
+            $base = $node instanceof Image
+                ? ($root ? $imageRootBase : $imageBase)
+                : ($root ? $linkRootBase : $linkBase);
 
             $node->setUrl($base === null ? '' : $this->join($base, $url));
         }

--- a/app/Support/PageMarkdown.php
+++ b/app/Support/PageMarkdown.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Support;
+
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
+use League\CommonMark\Extension\Strikethrough\StrikethroughExtension;
+use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\Extension\TaskList\TaskListExtension;
+use League\CommonMark\MarkdownConverter;
+use League\CommonMark\Node\Block\Document;
+
+/**
+ * Renders the markdown behind a public page.
+ *
+ * The input is a README out of somebody else's repository, published by this
+ * app at this app's origin, to anonymous visitors. That is the whole reason
+ * this class exists rather than a call to Str::markdown():
+ *
+ *  - Raw HTML in the source is escaped, not passed through. A README is
+ *    allowed to contain a `<script>` and frequently contains a `<div>`; on
+ *    GitHub both are sanitized, and here the origin they would run at is the
+ *    one holding the admin panel's session cookie. Escaping rather than
+ *    stripping is deliberate: it is visible, so an admin can see that their
+ *    HTML did not render, where stripping looks like the file was truncated.
+ *  - `javascript:` and `data:` URLs are refused by the converter.
+ *  - Relative links and images — which is how every README references its own
+ *    screenshots — are resolved against the repository they came from, so
+ *    they point at the file on GitHub rather than at a 404 here.
+ *  - External links carry rel="nofollow noopener ugc": the content is not
+ *    ours, and the registry should not be lending its ranking to whatever a
+ *    package's README links to.
+ *
+ * Rendering is not cached here. The caller caches, because only the caller
+ * knows what invalidates it — see App\Services\PackagePage.
+ */
+class PageMarkdown
+{
+    /**
+     * How deep a document may nest before the parser gives up, which bounds
+     * what a pathological README costs to render. CommonMark's own default;
+     * restated because it is a limit this surface depends on rather than a
+     * detail of the library.
+     */
+    private const MAX_NESTING_LEVEL = 500;
+
+    /**
+     * @param  string|null  $linkBase  absolute URL a relative link resolves
+     *                                 against — the repository's file browser
+     *                                 — or null to drop relative links.
+     * @param  string|null  $imageBase  absolute URL a relative image resolves
+     *                                  against. Separate from $linkBase because
+     *                                  providers serve the file and a view of
+     *                                  the file at different hosts: an <img>
+     *                                  wants raw bytes, an <a> wants the page.
+     */
+    public function render(string $markdown, ?string $linkBase = null, ?string $imageBase = null): string
+    {
+        $environment = new Environment([
+            // The two settings this class exists for. `escape` renders raw
+            // HTML as visible text; `allow_unsafe_links: false` drops
+            // javascript:, vbscript: and non-image data: URLs.
+            'html_input' => 'escape',
+            'allow_unsafe_links' => false,
+            'max_nesting_level' => self::MAX_NESTING_LEVEL,
+            'external_link' => [
+                // Every link is external here — the document did not come
+                // from this host, so nothing in it is a link home.
+                'internal_hosts' => [],
+                'open_in_new_window' => true,
+                'html_class' => 'external',
+                'nofollow' => 'external',
+                'noopener' => 'all',
+                'noreferrer' => 'all',
+            ],
+        ]);
+
+        $environment
+            ->addExtension(new CommonMarkCoreExtension)
+            // A README is written for GitHub, so it is read as GitHub reads
+            // it: tables, task lists, strikethrough and bare URLs.
+            ->addExtension(new TableExtension)
+            ->addExtension(new TaskListExtension)
+            ->addExtension(new StrikethroughExtension)
+            ->addExtension(new AutolinkExtension)
+            ->addExtension(new ExternalLinkExtension);
+
+        // Runs before rendering, on the parsed tree, so the URLs the external
+        // link extension then judges are the absolute ones this resolves to.
+        $environment->addEventListener(
+            DocumentParsedEvent::class,
+            fn (DocumentParsedEvent $event) => $this->resolveRelativeUrls($event->getDocument(), $linkBase, $imageBase),
+            // A higher priority than the external-link extension's own
+            // listener (0), which decides what is external by looking at the
+            // host — and a relative URL has none until this has run.
+            priority: 10,
+        );
+
+        return (new MarkdownConverter($environment))->convert($markdown)->getContent();
+    }
+
+    /**
+     * Point every relative link and image at the repository it was written
+     * against.
+     *
+     * A URL that cannot be resolved — because no base was given, as for a
+     * body typed in the panel or a package with no repository — is emptied
+     * rather than left relative. Left alone it would address this app: a
+     * README's `docs/install.md` becomes a link to a page on the registry
+     * that does not exist, and `![](logo.png)` becomes a broken image that
+     * costs a request and a 404 log line on every page view.
+     */
+    private function resolveRelativeUrls(Document $document, ?string $linkBase, ?string $imageBase): void
+    {
+        foreach ($document->iterator() as $node) {
+            if (! $node instanceof Link && ! $node instanceof Image) {
+                continue;
+            }
+
+            $url = $node->getUrl();
+
+            // A fragment is the one relative form that means something here:
+            // README anchors link within the rendered document itself.
+            if ($url === '' || str_starts_with($url, '#')) {
+                continue;
+            }
+
+            if ($this->isAbsolute($url)) {
+                continue;
+            }
+
+            $base = $node instanceof Image ? $imageBase : $linkBase;
+
+            $node->setUrl($base === null ? '' : $this->join($base, $url));
+        }
+    }
+
+    /**
+     * Whether a URL already names where it points. Protocol-relative URLs
+     * ("//host/path") count: they resolve against the page's own scheme, not
+     * against the repository.
+     */
+    private function isAbsolute(string $url): bool
+    {
+        return str_starts_with($url, '//') || (bool) preg_match('#^[a-z][a-z0-9+.\-]*:#i', $url);
+    }
+
+    /**
+     * Hang a repository-relative path off a base URL.
+     *
+     * Only the path is joined. A README that reaches out of its own
+     * repository with "../" is left pointing at whatever that resolves to on
+     * the provider, which is the provider's business — but the leading "./"
+     * and "/" forms are normalized here, because a leading slash in a README
+     * means the repository root and would otherwise escape the base entirely.
+     */
+    private function join(string $base, string $url): string
+    {
+        // Anything after the path is the author's, not ours to re-encode:
+        // "?raw=true" and "#heading" both survive verbatim.
+        [$path, $suffix] = $this->splitSuffix($url);
+
+        $path = ltrim($path, '/');
+
+        while (str_starts_with($path, './')) {
+            $path = substr($path, 2);
+        }
+
+        // Each segment individually, since a path is not one component — the
+        // same reason the provider clients encode composer.json's path that
+        // way. Already-encoded segments are left as they are, or "%20" would
+        // travel as "%2520".
+        $encoded = implode('/', array_map(
+            fn (string $segment): string => rawurlencode(rawurldecode($segment)),
+            explode('/', $path),
+        ));
+
+        return rtrim($base, '/').'/'.$encoded.$suffix;
+    }
+
+    /**
+     * The path, and the query string and fragment trailing it.
+     *
+     * @return array{string, string}
+     */
+    private function splitSuffix(string $url): array
+    {
+        $cut = strcspn($url, '?#');
+
+        return [substr($url, 0, $cut), substr($url, $cut)];
+    }
+}

--- a/app/Support/PageSchema.php
+++ b/app/Support/PageSchema.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Package;
+use App\Models\Repository;
+
+/**
+ * The JSON-LD a public page carries.
+ *
+ * Structured data is how a search engine learns what a page *is* rather than
+ * what words it contains — and a package page is exactly the case where the
+ * prose is somebody's README and the facts are in this database. Naming the
+ * version, the license, the source repository and the publisher explicitly is
+ * what earns a rich result rather than a blue link.
+ *
+ * Built here rather than in the Blade template so the documents have one
+ * shape, tested in one place, instead of being assembled inside a view where
+ * a missing key is a silent omission.
+ */
+class PageSchema
+{
+    /**
+     * schema.org/SoftwareSourceCode for a package page.
+     *
+     * SoftwareSourceCode rather than SoftwareApplication: a Composer package
+     * is source somebody builds against, not an application a reader
+     * installs and runs — and the vocabulary is what tells the two apart.
+     *
+     * @return array<string, mixed>
+     */
+    public static function package(Package $package): array
+    {
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'SoftwareSourceCode',
+            'name' => $package->name,
+            'description' => $package->pageSummary(),
+            'url' => $package->pageUrl(),
+            'programmingLanguage' => 'PHP',
+            'publisher' => [
+                '@type' => 'Organization',
+                'name' => (string) config('app.name'),
+                'url' => $package->composerRepository->pageRootUrl(),
+            ],
+        ];
+
+        if ($package->latest_version !== null) {
+            $schema['softwareVersion'] = $package->latest_version;
+        }
+
+        if (filled($package->repository)) {
+            $schema['codeRepository'] = (string) $package->repository;
+        }
+
+        // The license of the release the page describes, which is the one a
+        // reader is deciding about — already reduced to a single SPDX
+        // expression on the version row.
+        $license = $package->versions()
+            ->where('version', $package->latest_version)
+            ->value('license');
+
+        if (filled($license)) {
+            $schema['license'] = (string) $license;
+        }
+
+        if ($image = $package->pageImageUrl()) {
+            $schema['image'] = $image;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * schema.org/CollectionPage for a repository's landing page, with the
+     * packages it lists as its items — which is what makes the list itself
+     * eligible to be understood as a list rather than as a run of links.
+     *
+     * @param  iterable<int, Package>  $packages
+     * @return array<string, mixed>
+     */
+    public static function repository(Repository $repository, iterable $packages): array
+    {
+        $items = [];
+
+        foreach ($packages as $position => $package) {
+            $items[] = [
+                '@type' => 'ListItem',
+                'position' => $position + 1,
+                'name' => $package->name,
+                'url' => $package->pageUrl(),
+            ];
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'CollectionPage',
+            'name' => $repository->name,
+            'description' => $repository->pageSummary(),
+            'url' => $repository->pageUrl(),
+        ];
+
+        if ($items !== []) {
+            $schema['mainEntity'] = [
+                '@type' => 'ItemList',
+                'numberOfItems' => count($items),
+                'itemListElement' => $items,
+            ];
+        }
+
+        if ($image = $repository->pageImageUrl()) {
+            $schema['image'] = $image;
+        }
+
+        return $schema;
+    }
+}

--- a/config/registry.php
+++ b/config/registry.php
@@ -267,6 +267,48 @@ return [
         'cache_seconds' => (int) env('METRICS_CACHE_SECONDS', 10),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Public Package Pages
+    |--------------------------------------------------------------------------
+    |
+    | Nothing here publishes anything. A page exists because an admin switched
+    | one on for a package or a repository; these are the numbers and the
+    | defaults that apply once one has.
+    |
+    | `page_image` is the social preview image used for every page that has not
+    | set one of its own — an absolute URL, or a path relative to this app's
+    | root. It is what appears when a page's URL is pasted into Slack, a post
+    | or a chat, so an installation that sets nothing else should set this: a
+    | link with no card beside it is a link most people do not click.
+    |
+    | `pages.markdown_cache_minutes` is how long a rendered README is reused.
+    | Rendering is CommonMark over a document nobody edits between syncs, so
+    | this is pure repetition avoided; entries are keyed by a hash of the
+    | markdown itself, so a sync that changes the file changes the key and
+    | nothing has to remember to clear anything. Zero turns the cache off.
+    |
+    | `pages.max_body_kilobytes` refuses to store or render a page body past
+    | this size. The body comes out of somebody else's repository, and a
+    | README is prose — a file orders of magnitude past that is a generated
+    | artifact, a vendored document or a mistake, and rendering it costs this
+    | app's memory per visitor rather than per sync.
+    |
+    | `pages.sitemap` publishes /sitemap.xml and /robots.txt listing every
+    | enabled page, which is what gets them indexed. Off leaves the pages
+    | reachable and unlisted — the right answer for a registry whose pages are
+    | for people who were sent the link rather than for search.
+    |
+    */
+
+    'page_image' => env('PAGE_IMAGE'),
+
+    'pages' => [
+        'markdown_cache_minutes' => (int) env('PAGE_MARKDOWN_CACHE_MINUTES', 1440),
+        'max_body_kilobytes' => (int) env('PAGE_MAX_BODY_KB', 512),
+        'sitemap' => (bool) env('PAGE_SITEMAP', true),
+    ],
+
     'mirror' => [
         'metadata_ttl_minutes' => (int) env('MIRROR_METADATA_TTL_MINUTES', 60),
         'missing_ttl_minutes' => (int) env('MIRROR_MISSING_TTL_MINUTES', 10),

--- a/database/migrations/2026_08_12_000000_add_public_pages_to_packages_and_repositories.php
+++ b/database/migrations/2026_08_12_000000_add_public_pages_to_packages_and_repositories.php
@@ -1,0 +1,120 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The public page a package or repository can publish for a person rather
+     * than for Composer.
+     *
+     * Everything here is off by default and stays off through the upgrade:
+     * a registry that publishes private packages must not start serving pages
+     * describing them because it was migrated. Enabling one is a decision an
+     * admin makes per package, which is why the switch is a column and not a
+     * setting.
+     */
+    public function up(): void
+    {
+        Schema::table('packages', function (Blueprint $table) {
+            // The switch itself. Indexed because the public routes look a
+            // package up by name and then ask this, and a registry with a
+            // handful of pages among thousands of packages should not read a
+            // row to find out it has no page.
+            $table->boolean('page_enabled')->default(false)->index();
+
+            // Which archives the page offers, as App\Enums\PageDownloads:
+            // none, the latest release alone, or every stored version. Stored
+            // as a string rather than a boolean pair because "latest only" is
+            // the interesting middle — a page that hands out one current
+            // artifact without publishing the release history with it.
+            $table->string('page_downloads', 16)->default('none');
+
+            // Whether the page prints the two `composer config` / `composer
+            // require` lines. On by default: a page that names a package
+            // without saying how to install it is the one thing every visitor
+            // came for.
+            $table->boolean('page_install')->default(true);
+
+            // Whether the version history table is rendered.
+            $table->boolean('page_versions')->default(true);
+
+            // Markdown written in the panel, which wins over anything the
+            // repository carries. The escape hatch for a package whose README
+            // is written for contributors rather than consumers, and the only
+            // body available for a package published by artifact upload,
+            // which has no repository to read one from.
+            $table->longText('page_body')->nullable();
+
+            // The image social platforms show when the page's URL is pasted
+            // into a post — an absolute URL, because that is what an og:image
+            // has to be and because the file usually lives wherever the
+            // project already publishes its logo. Empty falls back to the
+            // registry-wide default in config/registry.php, so an
+            // installation sets one image once rather than per package.
+            $table->string('page_image')->nullable();
+
+            // The markdown last read out of the repository, and which file it
+            // came from — `package-page.md` or a README. Stored rather than
+            // fetched per request: rendering a page must not depend on
+            // GitHub's API being reachable, and must not spend a request of
+            // the installation's rate limit per visitor.
+            $table->longText('page_source_body')->nullable();
+            $table->string('page_source_path')->nullable();
+            $table->timestamp('page_source_synced_at')->nullable();
+        });
+
+        Schema::table('repositories', function (Blueprint $table) {
+            // The repository's own landing page, served at the same URL its
+            // Composer endpoints hang off — "/" for the default repository,
+            // "/r/{path}" for a named one. Off by default for the same reason
+            // the package switch is.
+            $table->boolean('page_enabled')->default(false);
+
+            // Markdown shown above the package list. There is no repository
+            // equivalent of a README to read, so this is the only body.
+            $table->longText('page_body')->nullable();
+
+            // As on packages: the social preview image for this repository's
+            // landing page, falling back to the registry-wide default.
+            $table->string('page_image')->nullable();
+
+            // Whether the page lists the packages this repository serves.
+            // Off leaves a page that describes the repository and prints the
+            // one `composer config` line to point a project at it, which is
+            // what a private repository can publish without naming what it
+            // holds.
+            $table->boolean('page_lists_packages')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * Lossy in one direction only: the page bodies written in the panel are
+     * dropped with the columns. The repository-sourced ones are not a loss —
+     * the next sync reads them again from the file they came from.
+     */
+    public function down(): void
+    {
+        Schema::table('packages', function (Blueprint $table) {
+            $table->dropColumn([
+                'page_enabled',
+                'page_downloads',
+                'page_install',
+                'page_versions',
+                'page_body',
+                'page_image',
+                'page_source_body',
+                'page_source_path',
+                'page_source_synced_at',
+            ]);
+        });
+
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->dropColumn(['page_enabled', 'page_body', 'page_image', 'page_lists_packages']);
+        });
+    }
+};

--- a/docs/public-pages.md
+++ b/docs/public-pages.md
@@ -1,0 +1,174 @@
+# Public pages
+
+A package or a repository can publish a page anyone can read — no account, no
+token, no Composer. It shows what the package is, the `README.md` (or a
+`package-page.md` written for the purpose) out of its repository, the two
+commands that install it, and, if you switch it on, a download for the latest
+release or for every version.
+
+Nothing is published until you enable a page. A registry upgraded to this
+release serves exactly what it served before.
+
+## What a page is for
+
+The URL you hand a project — `composer config repositories.acme composer
+https://packages.example.com` — is the first thing anyone pastes into a
+browser, and before this it answered a redirect to a login form for an account
+they do not have. Now it can answer a page describing what is behind it.
+
+Three cases it covers:
+
+- **An open-source package published from your own registry.** The page is the
+  package's home on the web: readable, linkable, indexable, with the install
+  commands right there.
+- **A private package somebody has been told about.** The page describes it and
+  says access is required, rather than 404ing at a colleague who was sent the
+  name.
+- **A repository landing page**, listing the packages it publishes pages for.
+
+## Enabling one
+
+**A package:** open it in the panel, **Edit → Public page**, and turn
+**Publish a public page** on. Four settings appear:
+
+| Setting | What it does |
+| --- | --- |
+| **Downloads** | `No downloads` (default), `Latest release only`, or `Every version`. The middle one hands out the current artifact without publishing the release history with it. |
+| **Show install commands** | The `composer config` and `composer require` lines, exactly as the panel shows them. |
+| **Show the version history** | A table of released versions and their dates. |
+| **Social preview image** | The card image shown when the page is linked. Empty uses `PAGE_IMAGE`. |
+| **Page content** | Markdown written here, which wins over anything in the repository. Leave it empty to publish the repository's own file. |
+
+The page answers at the package's own URL inside its repository's mount:
+
+```
+https://packages.example.com/p/acme/widgets              # default repository
+https://packages.example.com/r/internal/p/acme/widgets   # a named repository
+```
+
+Package names are unique per repository rather than per registry, which is why
+the page lives under the mount rather than at one rooted `/p/` namespace.
+
+**A repository:** **Repositories → (the repository) → Public page**. Its page is
+served at the URL its Composer endpoints already hang off — `/` for the default
+repository, `/r/{path}` for a named one — and lists the packages that publish
+pages of their own. A package with no page is not named: naming one the registry
+will not describe is how a private package's existence leaks out of a public
+landing page.
+
+Turning the default repository's page off puts the root back to redirecting to
+`/admin/login`, which is what it has always done.
+
+## Where the content comes from
+
+In order:
+
+1. **Page content** written in the panel, if you have written any.
+2. **`package-page.md`** in the repository, at the package's subdirectory. A
+   project that has written one has written it for this — a README is addressed
+   to contributors, a registry page to whoever is deciding whether to install
+   the thing.
+3. **`README.md`** (also `readme.md`, `Readme.md`).
+4. Nothing, in which case the page is the package's metadata and install
+   commands alone.
+
+The file is read **at sync time**, at the ref of the release the package's
+metadata came from, and stored on the package. Enabling a page queues that read
+straight away so you do not have to wait for the next sync. Nothing is fetched
+while somebody is looking at the page: an anonymous visitor must not put your
+GitHub rate limit or GitHub's uptime in front of the page rendering.
+
+A package with no page enabled costs nothing — the files are never looked for.
+
+### How the markdown is rendered
+
+The body is somebody else's file, published at your origin, so:
+
+- **Raw HTML is escaped, not passed through.** A README is allowed to contain a
+  `<script>`, and the origin it would run at is the one holding your panel's
+  session cookie. Escaping rather than stripping is deliberate: it is visible.
+- `javascript:` and `data:` URLs are refused.
+- **Relative links and images are resolved against the repository**, so a
+  README's `docs/install.md` links to that file on GitHub and
+  `![](art/logo.png)` renders the image from the repository rather than 404ing
+  here. Monorepo packages resolve against their own subdirectory.
+- External links carry `rel="nofollow noopener noreferrer"` — the content is not
+  yours, and the registry should not lend its ranking to whatever it links to.
+- A body past `PAGE_MAX_BODY_KB` is cut on a line and marked as truncated.
+
+## Private packages
+
+A page on a package whose repository is **not** public still renders — that is
+the point of publishing one — but everything on it that would need a credential
+is withheld:
+
+- no download links, whatever **Downloads** is set to;
+- no install commands, because the tokenless pair sends a visitor to a `401`
+  that reads as the registry being broken;
+- an **Access required** notice in their place.
+
+The **Downloads** setting is kept rather than cleared, so making the repository
+public later restores what you chose.
+
+> A token-request form belongs in that notice and is not built yet. The page,
+> the block and the wording are shaped for it.
+
+## Downloads
+
+A page's download link is a third route to the archive, alongside the Composer
+dist endpoint and the panel's own:
+
+```
+/p/acme/widgets/download            # the current release — a link worth pasting anywhere
+/p/acme/widgets/download/v1.0.0     # one version, only when "Every version" is set
+```
+
+With **Latest release only**, any other version is a `404`: the history cannot be
+walked by editing the URL. Downloads are counted exactly like every other
+archive that leaves the registry, so the numbers mean one thing across all three
+routes. `HEAD` is not counted.
+
+## Search and social previews
+
+Every page carries what a machine reads about it, built from facts the registry
+already holds:
+
+- a canonical URL;
+- Open Graph and Twitter card tags — `og:title`, `og:description`, `og:url`,
+  `og:image`, and `twitter:card` set to `summary_large_image` when there is an
+  image and `summary` when there is not, since asking for the large card without
+  one renders as a broken panel;
+- JSON-LD: `SoftwareSourceCode` for a package (with its version, license and
+  source repository), `CollectionPage` for a repository, with its packages as an
+  `ItemList`.
+
+`/sitemap.xml` lists every published page and `/robots.txt` points at it, keeping
+crawlers off `/admin`, `/p2/` and `/dist/`. Set `PAGE_SITEMAP=false` to publish
+neither — pages stay reachable and unlisted, which is the right answer for a
+registry whose pages are for people who were sent the link. Both documents still
+answer in that case, robots.txt with a blanket disallow, because a `404` there is
+read by some crawlers as permission to crawl everything.
+
+> [!NOTE]
+> Laravel ships a static `public/robots.txt`, which would shadow this route. It
+> is removed in this release. If your deployment restores it, the file wins and
+> the setting does nothing.
+
+## Configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `PAGE_IMAGE` | Social preview image for every page that has not set one of its own. An absolute URL or a path relative to the app root. Around 1200×630. |
+| `PAGE_SITEMAP` | Publish `/sitemap.xml` and an indexing `/robots.txt` (default `true`). |
+| `PAGE_MARKDOWN_CACHE_MINUTES` | How long a rendered body is reused (default `1440`). Keyed by a hash of the markdown, so a sync that changes the file changes the key. `0` turns it off. |
+| `PAGE_MAX_BODY_KB` | Largest body stored or rendered (default `512`). |
+
+Public pages are rate limited to 120 requests a minute per address.
+
+## What a page never does
+
+- It never widens Composer access. The repository's `public` flag and the tokens
+  granted against it decide what installs; a page can only ever offer less.
+- It never lists a package that does not publish a page.
+- It never renders HTML from a repository.
+- It never fetches from a provider while answering a request.

--- a/docs/public-pages.md
+++ b/docs/public-pages.md
@@ -80,6 +80,15 @@ GitHub rate limit or GitHub's uptime in front of the page rendering.
 
 A package with no page enabled costs nothing — the files are never looked for.
 
+**Refresh page** on a package's view page re-reads the file straight away and
+tells you which one it found. It is for the gap between syncs: somebody has just
+edited the README, usually because the published page was wrong, and the
+alternative is a full sync that re-reads every ref or an hour's wait. It reads at
+the ref of the release the page describes, which is exactly what the next sync
+would store — so the answer does not flip between the two. If a **Page content**
+body is written in the panel, the refresh still runs and says that the page goes
+on showing what you wrote.
+
 ### How the markdown is rendered
 
 The body is somebody else's file, published at your origin, so:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow:

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -7,3 +7,119 @@
     --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
         'Segoe UI Symbol', 'Noto Color Emoji';
 }
+
+/*
+ * The rendered README on a public package page.
+ *
+ * Plain CSS rather than Tailwind's typography plugin: the HTML this styles is
+ * generated from somebody else's markdown, so there is no template to hang
+ * utility classes on — and adding a build-time plugin to style one document
+ * would put a node dependency between this app and its own pages.
+ *
+ * @see App\Support\PageMarkdown, which decides what elements can appear here
+ * at all: raw HTML in a README is escaped, so this list is the whole of it.
+ */
+.markdown {
+    line-height: 1.7;
+    color: var(--color-zinc-700);
+}
+
+.markdown > * + * {
+    margin-top: 1rem;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4 {
+    margin-top: 2rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--color-zinc-900);
+}
+
+.markdown h1 { font-size: 1.5rem; }
+.markdown h2 { font-size: 1.25rem; }
+.markdown h3 { font-size: 1.125rem; }
+
+.markdown a {
+    color: var(--color-zinc-900);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.markdown ul,
+.markdown ol {
+    padding-left: 1.5rem;
+}
+
+.markdown ul { list-style: disc; }
+.markdown ol { list-style: decimal; }
+.markdown li + li { margin-top: 0.25rem; }
+
+.markdown code {
+    border-radius: 0.25rem;
+    background: var(--color-zinc-100);
+    padding: 0.125rem 0.375rem;
+    font-size: 0.875em;
+}
+
+.markdown pre {
+    overflow-x: auto;
+    border-radius: 0.5rem;
+    background: var(--color-zinc-900);
+    padding: 1rem;
+    color: var(--color-zinc-100);
+}
+
+.markdown pre code {
+    background: transparent;
+    padding: 0;
+    font-size: 0.875rem;
+}
+
+.markdown blockquote {
+    border-left: 3px solid var(--color-zinc-200);
+    padding-left: 1rem;
+    color: var(--color-zinc-500);
+}
+
+.markdown table {
+    display: block;
+    overflow-x: auto;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+}
+
+.markdown th,
+.markdown td {
+    border: 1px solid var(--color-zinc-200);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+}
+
+.markdown img {
+    max-width: 100%;
+    height: auto;
+}
+
+.markdown hr {
+    border-color: var(--color-zinc-200);
+}
+
+@media (prefers-color-scheme: dark) {
+    .markdown { color: var(--color-zinc-300); }
+    .markdown h1,
+    .markdown h2,
+    .markdown h3,
+    .markdown h4,
+    .markdown a { color: var(--color-white); }
+    .markdown code { background: var(--color-zinc-900); }
+    .markdown blockquote {
+        border-color: var(--color-zinc-800);
+        color: var(--color-zinc-400);
+    }
+    .markdown th,
+    .markdown td,
+    .markdown hr { border-color: var(--color-zinc-800); }
+}

--- a/resources/views/components/page-layout.blade.php
+++ b/resources/views/components/page-layout.blade.php
@@ -1,0 +1,100 @@
+@props([
+    // The repository the page belongs to — its name badges the header and its
+    // URL is where the header links home.
+    'repository',
+    'title',
+    'summary',
+    'canonical',
+    'image' => null,
+    'ogType' => 'website',
+    // The JSON-LD document, already an array, or null. Built in the view data
+    // rather than here so its shape can be asserted in a test.
+    'schema' => null,
+])
+
+{{--
+    The shell every public page renders into.
+
+    Two jobs: the page itself, and everything a machine reads about the page.
+    The second half is not decoration — a registry's packages are found
+    through search and shared through links, and a link with no card beside it
+    is a link most people do not click. So the Open Graph and Twitter tags,
+    the canonical URL and the JSON-LD block are part of the page rather than a
+    later addition, and each one is filled from facts this app already holds.
+
+    Deliberately independent of the Filament panel's own layout: this is
+    served to anonymous visitors, and it should not carry the panel's assets,
+    its Livewire runtime or anything that reads a session.
+--}}
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="h-full">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>{{ $title }}</title>
+    <meta name="description" content="{{ $summary }}">
+
+    {{-- The one URL this page is to be indexed under. The pages are reachable
+         at one address only, but a crawler that arrived with a tracking query
+         string should still be told which address that is. --}}
+    <link rel="canonical" href="{{ $canonical }}">
+
+    <meta property="og:type" content="{{ $ogType }}">
+    <meta property="og:site_name" content="{{ config('app.name') }}">
+    <meta property="og:title" content="{{ $title }}">
+    <meta property="og:description" content="{{ $summary }}">
+    <meta property="og:url" content="{{ $canonical }}">
+    <meta property="og:locale" content="{{ str_replace('-', '_', app()->getLocale()) }}">
+    @if ($image)
+        <meta property="og:image" content="{{ $image }}">
+        <meta property="og:image:alt" content="{{ $title }}">
+    @endif
+
+    {{-- The large card only when there is an image to fill it: asking for one
+         and giving nothing renders as a broken panel, where `summary` renders
+         as a tidy text card. --}}
+    <meta name="twitter:card" content="{{ $image ? 'summary_large_image' : 'summary' }}">
+    <meta name="twitter:title" content="{{ $title }}">
+    <meta name="twitter:description" content="{{ $summary }}">
+    @if ($image)
+        <meta name="twitter:image" content="{{ $image }}">
+    @endif
+
+    {{-- What a search engine reads instead of guessing from the prose. The
+         array is built in the controller's view data so the shapes stay in
+         PHP, where they can be tested. --}}
+    @if ($schema)
+        <script type="application/ld+json">{!! json_encode($schema, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}</script>
+    @endif
+
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
+
+    @vite('resources/css/app.css')
+</head>
+<body class="min-h-full bg-white text-zinc-800 antialiased dark:bg-zinc-950 dark:text-zinc-200">
+    <div class="mx-auto flex min-h-full max-w-4xl flex-col px-6 py-10 sm:py-16">
+        <header class="mb-10 flex items-center justify-between gap-4">
+            <a href="{{ $repository->pageUrl() }}" class="flex items-center gap-3 text-sm font-medium text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100">
+                <img src="/images/logo.png" alt="" class="h-7 w-auto" width="28" height="28">
+                <span>{{ config('app.name') }}</span>
+            </a>
+
+            @if (! $repository->isDefault())
+                <span class="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-600 dark:bg-zinc-900 dark:text-zinc-400">
+                    {{ $repository->name }}
+                </span>
+            @endif
+        </header>
+
+        <main class="flex-1">
+            {{ $slot }}
+        </main>
+
+        <footer class="mt-16 border-t border-zinc-200 pt-6 text-xs text-zinc-500 dark:border-zinc-800 dark:text-zinc-500">
+            Served by {{ config('app.name') }} — a private Composer registry.
+        </footer>
+    </div>
+</body>
+</html>

--- a/resources/views/pages/package.blade.php
+++ b/resources/views/pages/package.blade.php
@@ -1,0 +1,146 @@
+<x-page-layout
+    :repository="$repository"
+    :title="$package->name.' — '.config('app.name')"
+    :summary="$package->pageSummary()"
+    :canonical="$package->pageUrl()"
+    :image="$package->pageImageUrl()"
+    og-type="website"
+    :schema="$schema"
+>
+    <article>
+        <header class="mb-10">
+            <div class="flex flex-wrap items-center gap-3">
+                <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
+                    {{ $package->name }}
+                </h1>
+
+                @if ($package->latest_version)
+                    <span class="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+                        {{ $package->latest_version }}
+                    </span>
+                @endif
+
+                @if ($package->abandoned)
+                    {{-- The one badge that is a warning rather than a fact.
+                         Composer tells a consumer this at install time; a page
+                         that did not would be quietly recruiting new users to
+                         something nobody is maintaining. --}}
+                    <span class="rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300">
+                        Abandoned{{ $package->replacement_package ? ' — use '.$package->replacement_package : '' }}
+                    </span>
+                @endif
+            </div>
+
+            @if (filled($package->description))
+                <p class="mt-4 text-lg text-zinc-600 dark:text-zinc-400">{{ $package->description }}</p>
+            @endif
+
+            <dl class="mt-6 flex flex-wrap gap-x-8 gap-y-3 text-sm text-zinc-500 dark:text-zinc-400">
+                @if ($package->type)
+                    <div><dt class="inline font-medium text-zinc-700 dark:text-zinc-300">Type:</dt> <dd class="inline">{{ $package->type }}</dd></div>
+                @endif
+
+                @if (filled($package->repository))
+                    <div>
+                        <dt class="inline font-medium text-zinc-700 dark:text-zinc-300">Source:</dt>
+                        <dd class="inline"><a class="underline underline-offset-2 hover:text-zinc-900 dark:hover:text-zinc-100" href="{{ $package->repository }}" rel="noopener">{{ $package->repository }}</a></dd>
+                    </div>
+                @endif
+            </dl>
+        </header>
+
+        @if ($package->pageRequiresAccess())
+            {{-- What stands in for the install commands and the download
+                 buttons on a package whose repository is private. The page
+                 still describes the package — that is the whole point of
+                 publishing one — but everything on it that would need a
+                 credential says so plainly instead of sending a visitor to a
+                 401 that reads as the registry being broken.
+
+                 This block is where a "request access" form will go. --}}
+            <section class="mb-10 rounded-xl border border-amber-200 bg-amber-50/60 p-5 dark:border-amber-900 dark:bg-amber-950/40">
+                <h2 class="text-sm font-semibold text-amber-900 dark:text-amber-200">Access required</h2>
+                <p class="mt-1 text-sm text-amber-800 dark:text-amber-300">
+                    This package is served from a private repository. Installing it needs an access token
+                    for {{ config('app.name') }}; ask whoever administers this registry for one.
+                </p>
+            </section>
+        @endif
+
+        @if ($commands)
+            <section class="mb-10 rounded-xl border border-zinc-200 dark:border-zinc-800">
+                <h2 class="border-b border-zinc-200 px-5 py-3 text-sm font-semibold text-zinc-900 dark:border-zinc-800 dark:text-white">Install</h2>
+
+                <div class="space-y-4 px-5 py-4">
+                    <div>
+                        <p class="mb-1 text-xs text-zinc-500 dark:text-zinc-400">1. Register this Composer repository (once per project)</p>
+                        <pre class="overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>{{ $commands['repository'] }}</code></pre>
+                    </div>
+                    <div>
+                        <p class="mb-1 text-xs text-zinc-500 dark:text-zinc-400">2. Require the package</p>
+                        <pre class="overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>{{ $commands['require'] }}</code></pre>
+                    </div>
+                </div>
+            </section>
+        @endif
+
+        @if ($latest)
+            <section class="mb-10">
+                <a
+                    href="{{ $repository->url('/p/'.$package->name.'/download') }}"
+                    class="inline-flex items-center gap-2 rounded-lg bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200"
+                    {{-- A download is not a document: nothing should follow
+                         this link to index what is behind it. --}}
+                    rel="nofollow"
+                >
+                    Download {{ $latest->version }}
+                </a>
+            </section>
+        @endif
+
+        @if ($body)
+            <section class="markdown mb-12">{!! $body !!}</section>
+        @endif
+
+        @if ($versions->isNotEmpty())
+            <section>
+                <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">Versions</h2>
+
+                <div class="overflow-x-auto rounded-xl border border-zinc-200 dark:border-zinc-800">
+                    <table class="w-full text-left text-sm">
+                        <thead class="text-xs text-zinc-500 dark:text-zinc-400">
+                            <tr class="border-b border-zinc-200 dark:border-zinc-800">
+                                <th class="px-4 py-2 font-medium">Version</th>
+                                <th class="px-4 py-2 font-medium">Released</th>
+                                @if ($downloads === \App\Enums\PageDownloads::All)
+                                    <th class="px-4 py-2 font-medium"><span class="sr-only">Download</span></th>
+                                @endif
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($versions as $version)
+                                <tr class="border-b border-zinc-100 last:border-0 dark:border-zinc-900">
+                                    <td class="px-4 py-2 font-mono text-xs text-zinc-900 dark:text-zinc-100">{{ $version->version }}</td>
+                                    <td class="px-4 py-2 text-zinc-500 dark:text-zinc-400">
+                                        {{ $version->released_at?->toFormattedDateString() ?? '—' }}
+                                    </td>
+                                    @if ($downloads === \App\Enums\PageDownloads::All)
+                                        <td class="px-4 py-2 text-right">
+                                            @if ($version->archive_path)
+                                                <a
+                                                    href="{{ $repository->url('/p/'.$package->name.'/download/'.rawurlencode($version->version)) }}"
+                                                    class="text-xs underline underline-offset-2 hover:text-zinc-900 dark:hover:text-zinc-100"
+                                                    rel="nofollow"
+                                                >zip</a>
+                                            @endif
+                                        </td>
+                                    @endif
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endif
+    </article>
+</x-page-layout>

--- a/resources/views/pages/repository.blade.php
+++ b/resources/views/pages/repository.blade.php
@@ -1,0 +1,67 @@
+<x-page-layout
+    :repository="$repository"
+    :title="$repository->name.' — '.config('app.name')"
+    :summary="$repository->pageSummary()"
+    :canonical="$repository->pageUrl()"
+    :image="$repository->pageImageUrl()"
+    :schema="$schema"
+>
+    <header class="mb-10">
+        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
+            {{ $repository->name }}
+        </h1>
+
+        @if (filled($repository->description))
+            <p class="mt-4 text-lg text-zinc-600 dark:text-zinc-400">{{ $repository->description }}</p>
+        @endif
+
+        <p class="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+            @if ($repository->public)
+                A public Composer repository — readable without a token.
+            @else
+                A private Composer repository. Installing from it needs an access token.
+            @endif
+        </p>
+    </header>
+
+    <section class="mb-10 rounded-xl border border-zinc-200 dark:border-zinc-800">
+        <h2 class="border-b border-zinc-200 px-5 py-3 text-sm font-semibold text-zinc-900 dark:border-zinc-800 dark:text-white">
+            Point a project at this repository
+        </h2>
+        <div class="px-5 py-4">
+            <pre class="overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>{{ $repository->configureCommand() }}</code></pre>
+        </div>
+    </section>
+
+    @if ($body)
+        <section class="markdown mb-12">{!! $body !!}</section>
+    @endif
+
+    @if ($packages->isNotEmpty())
+        <section>
+            <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">Packages</h2>
+
+            <ul class="divide-y divide-zinc-100 rounded-xl border border-zinc-200 dark:divide-zinc-900 dark:border-zinc-800">
+                @foreach ($packages as $listed)
+                    <li class="px-5 py-4">
+                        <a href="{{ $listed->pageUrl() }}" class="font-medium text-zinc-900 underline-offset-2 hover:underline dark:text-white">
+                            {{ $listed->name }}
+                        </a>
+
+                        @if ($listed->latest_version)
+                            <span class="ml-2 text-xs text-zinc-500 dark:text-zinc-400">{{ $listed->latest_version }}</span>
+                        @endif
+
+                        @if ($listed->abandoned)
+                            <span class="ml-2 text-xs text-amber-700 dark:text-amber-400">abandoned</span>
+                        @endif
+
+                        @if (filled($listed->description))
+                            <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{{ $listed->description }}</p>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        </section>
+    @endif
+</x-page-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,17 +3,68 @@
 use App\Http\Controllers\DownloadExportController;
 use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\GitLabWebhookController;
+use App\Http\Controllers\Pages\PackageArchiveController;
+use App\Http\Controllers\Pages\PackagePageController;
+use App\Http\Controllers\Pages\RepositoryPageController;
+use App\Http\Controllers\Pages\SitemapController;
 use App\Http\Controllers\PasswordSetupController;
 use App\Http\Controllers\SbomExportController;
 use App\Http\Controllers\SourceConnectionController;
 use App\Http\Controllers\SsoController;
 use App\Http\Controllers\VersionArchiveController;
+use App\Http\Middleware\ResolveComposerRepository;
 use Illuminate\Support\Facades\Route;
 
-// The app is administered entirely through Filament, so the root URL lands on
-// the panel's login page. Keep this in sync with the admin panel's path()
-// in App\Providers\Filament\AdminPanelProvider.
-Route::redirect('/', '/admin/login')->name('home');
+/*
+ * The public pages: what this registry publishes to somebody with no account
+ * and no token. Nothing is published until an admin enables a page on a
+ * package or a repository, and the root goes on redirecting to the panel's
+ * login page until one is — see RepositoryPageController.
+ *
+ * Mounted twice for the same reason the Composer API is, and at the same
+ * pair of prefixes: package names are unique per repository, so /p/acme/x
+ * and /r/internal/p/acme/x are allowed to be different packages and must
+ * never resolve to each other's. ResolveComposerRepository is the same
+ * middleware, doing the same job for the same reason.
+ *
+ * Inside the `web` group, unlike the Composer endpoints: these are pages, a
+ * browser is the client, and a session is what it already expects to hold.
+ *
+ * Throttled because every one of them is anonymous and none is cheap — a page
+ * renders markdown and a download moves an archive.
+ */
+$pages = function (): void {
+    Route::get('/', RepositoryPageController::class)->name('repository');
+
+    Route::get('/p/{vendor}/{package}', PackagePageController::class)
+        // Greedy, as the metadata route is: a package name may contain dots.
+        ->where('package', '[^/]+')
+        ->name('package');
+
+    // The archive a page's download button points at. No version segment
+    // means the current release, which is the link worth pasting anywhere:
+    // it goes on meaning "the latest" as releases come and go.
+    Route::get('/p/{vendor}/{package}/download/{version?}', PackageArchiveController::class)
+        ->where('package', '[^/]+')
+        ->where('version', '[^/]+')
+        ->name('download');
+};
+
+Route::middleware(['throttle:pages', ResolveComposerRepository::class])
+    ->name('pages.')
+    ->group($pages);
+
+Route::middleware(['throttle:pages', ResolveComposerRepository::class])
+    ->prefix('r/{repositoryPath}')
+    ->where(['repositoryPath' => '[a-z0-9-]+'])
+    ->name('pages.repository.')
+    ->group($pages);
+
+// Where the pages get found. Both answer whether or not the sitemap is
+// enabled — a 404 on robots.txt is read by some crawlers as permission to
+// crawl everything. See SitemapController.
+Route::get('/sitemap.xml', [SitemapController::class, 'sitemap'])->name('sitemap');
+Route::get('/robots.txt', [SitemapController::class, 'robots'])->name('robots');
 
 // The landing point for the password link `admin:create`, `user:add` and
 // `user:reset-password` print. One opaque segment and no query string, so the

--- a/tests/Feature/PackagePageContentTest.php
+++ b/tests/Feature/PackagePageContentTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\RefreshPackagePage;
+use App\Models\Package;
+use App\Services\PackagePage;
+use App\Services\PackageSynchronizer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\Support\Zipball;
+use Tests\TestCase;
+
+/**
+ * Where a package page's body comes from: which file wins, when it is read,
+ * and what a registry with no pages is made to spend on it.
+ */
+class PackagePageContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake(config('filesystems.dists'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function fakeGitHub(array $overrides = []): void
+    {
+        Http::fake($overrides + [
+            'api.github.com/repos/acme/widgets/tags*' => Http::response([
+                ['name' => 'v1.0.0', 'commit' => ['sha' => str_repeat('a', 40)]],
+            ]),
+            'api.github.com/repos/acme/widgets/branches*' => Http::response([]),
+            'api.github.com/repos/acme/widgets/contents/composer.json*' => Http::response([
+                'name' => 'acme/widgets',
+                'description' => 'Widgets for Acme.',
+                'type' => 'library',
+            ]),
+            'api.github.com/repos/acme/widgets/commits/*' => Http::response([
+                'commit' => ['committer' => ['date' => '2026-02-01T12:00:00Z']],
+            ]),
+            'api.github.com/repos/acme/widgets/zipball/*' => fn () => Http::response(Zipball::bytes(), 200, [
+                'Content-Type' => 'application/zip',
+            ]),
+            // Everything else the page reader might ask for.
+            'api.github.com/repos/acme/widgets/contents/*' => Http::response('Not Found', 404),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function package(array $attributes = []): Package
+    {
+        return Package::factory()->unreleased()->create([
+            'name' => 'acme/widgets-placeholder',
+            'repository' => 'https://github.com/acme/widgets',
+            'token' => 'ghp_secret',
+            ...$attributes,
+        ]);
+    }
+
+    public function test_a_sync_reads_the_page_file_for_a_package_that_publishes_one(): void
+    {
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('# Widgets'),
+        ]);
+
+        $package = $this->package(['page_enabled' => true]);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $package->refresh();
+
+        $this->assertSame('package-page.md', $package->page_source_path);
+        $this->assertSame('# Widgets', $package->page_source_body);
+        $this->assertNotNull($package->page_source_synced_at);
+    }
+
+    public function test_the_readme_is_the_fallback(): void
+    {
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('Not Found', 404),
+            'api.github.com/repos/acme/widgets/contents/README.md*' => Http::response('# From the readme'),
+        ]);
+
+        $package = $this->package(['page_enabled' => true]);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $this->assertSame('README.md', $package->fresh()->page_source_path);
+    }
+
+    public function test_a_package_with_no_page_costs_the_provider_nothing(): void
+    {
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('# Widgets'),
+        ]);
+
+        $package = $this->package(['page_enabled' => false]);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), 'contents/package-page.md'));
+        $this->assertNull($package->fresh()->page_source_body);
+    }
+
+    public function test_a_repository_with_no_page_file_records_that_it_was_looked_for(): void
+    {
+        $this->fakeGitHub();
+
+        $package = $this->package(['page_enabled' => true]);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $package->refresh();
+
+        // Recorded, so the next sync does not walk the whole candidate list
+        // again against a repository that has none of them.
+        $this->assertNull($package->page_source_path);
+        $this->assertNotNull($package->page_source_synced_at);
+    }
+
+    public function test_an_unreadable_repository_does_not_fail_the_sync(): void
+    {
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('Server error', 500),
+            'api.github.com/repos/acme/widgets/contents/README.md*' => Http::response('Server error', 500),
+        ]);
+
+        $package = $this->package(['page_enabled' => true]);
+
+        // A README that could not be read is not a reason to fail the sync
+        // that published the release.
+        app(PackageSynchronizer::class)->sync($package);
+
+        $package->refresh();
+
+        $this->assertNull($package->sync_error);
+        $this->assertSame('1.0.0', $package->latest_version);
+    }
+
+    public function test_switching_a_page_on_queues_a_read_rather_than_waiting_for_the_next_sync(): void
+    {
+        Bus::fake();
+
+        $package = $this->package();
+
+        Bus::assertNotDispatched(RefreshPackagePage::class);
+
+        $package->update(['page_enabled' => true]);
+
+        Bus::assertDispatched(RefreshPackagePage::class);
+    }
+
+    public function test_a_page_already_read_is_not_re_read_on_every_edit(): void
+    {
+        Bus::fake();
+
+        $package = $this->package([
+            'page_enabled' => false,
+            'page_source_path' => 'README.md',
+            'page_source_body' => '# Widgets',
+            'page_source_synced_at' => now(),
+        ]);
+
+        $package->update(['page_enabled' => true]);
+
+        Bus::assertNotDispatched(RefreshPackagePage::class);
+    }
+
+    public function test_a_body_past_the_ceiling_is_cut_and_says_so(): void
+    {
+        config(['registry.pages.max_body_kilobytes' => 1]);
+
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response(
+                str_repeat("A line of a very long document.\n", 200),
+            ),
+        ]);
+
+        $package = $this->package(['page_enabled' => true]);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        $body = (string) $package->fresh()->page_source_body;
+
+        $this->assertLessThan(2048, strlen($body));
+        $this->assertStringContainsString('This document was truncated.', $body);
+    }
+
+    public function test_a_package_published_by_upload_has_nothing_to_read(): void
+    {
+        $package = Package::factory()->create([
+            'name' => 'acme/uploaded',
+            'repository' => null,
+            'page_enabled' => true,
+        ]);
+
+        $this->assertFalse(app(PackagePage::class)->refresh($package));
+    }
+}

--- a/tests/Feature/PackagePageContentTest.php
+++ b/tests/Feature/PackagePageContentTest.php
@@ -2,14 +2,17 @@
 
 namespace Tests\Feature;
 
+use App\Filament\Resources\Packages\Pages\ViewPackage;
 use App\Jobs\RefreshPackagePage;
 use App\Models\Package;
+use App\Models\User;
 use App\Services\PackagePage;
 use App\Services\PackageSynchronizer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
 use Tests\Support\Zipball;
 use Tests\TestCase;
 
@@ -205,5 +208,80 @@ class PackagePageContentTest extends TestCase
         ]);
 
         $this->assertFalse(app(PackagePage::class)->refresh($package));
+    }
+
+    public function test_a_refresh_outside_a_sync_reads_the_release_the_page_describes(): void
+    {
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('# Widgets'),
+        ]);
+
+        $package = $this->package(['page_enabled' => true]);
+
+        app(PackageSynchronizer::class)->sync($package);
+
+        Http::fake([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('# Rewritten'),
+        ]);
+
+        app(PackagePage::class)->refresh($package->fresh());
+
+        // At the release's own ref rather than the default branch: reading the
+        // branch would publish a document describing a version that has not
+        // shipped, and the next sync would revert it anyway.
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'contents/package-page.md')
+            && str_contains($request->url(), 'ref='.str_repeat('a', 40)));
+    }
+
+    public function test_the_panel_action_reports_which_file_it_read(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $this->fakeGitHub([
+            'api.github.com/repos/acme/widgets/contents/package-page.md*' => Http::response('Not Found', 404),
+            'api.github.com/repos/acme/widgets/contents/README.md*' => Http::response('# Widgets'),
+        ]);
+
+        $package = $this->package(['page_enabled' => true]);
+
+        Livewire::test(ViewPackage::class, ['record' => $package->getRouteKey()])
+            ->callAction('refreshPageContent')
+            ->assertNotified('Page content refreshed');
+
+        $this->assertSame('README.md', $package->fresh()->page_source_path);
+    }
+
+    public function test_the_panel_action_says_so_when_the_repository_has_no_page_file(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $this->fakeGitHub();
+
+        $package = $this->package(['page_enabled' => true]);
+
+        // Not a failure: a repository with no README is a fact about the
+        // repository, and the page renders without one.
+        Livewire::test(ViewPackage::class, ['record' => $package->getRouteKey()])
+            ->callAction('refreshPageContent')
+            ->assertNotified('No page content found');
+    }
+
+    public function test_the_panel_action_is_offered_only_where_there_is_a_page_to_refresh(): void
+    {
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $withoutPage = $this->package(['page_enabled' => false]);
+
+        Livewire::test(ViewPackage::class, ['record' => $withoutPage->getRouteKey()])
+            ->assertActionHidden('refreshPageContent');
+
+        $uploaded = Package::factory()->create([
+            'name' => 'acme/uploaded',
+            'repository' => null,
+            'page_enabled' => true,
+        ]);
+
+        Livewire::test(ViewPackage::class, ['record' => $uploaded->getRouteKey()])
+            ->assertActionHidden('refreshPageContent');
     }
 }

--- a/tests/Feature/PackageResourceTest.php
+++ b/tests/Feature/PackageResourceTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Enums\PageDownloads;
 use App\Filament\Resources\Packages\PackageResource;
 use App\Filament\Resources\Packages\Pages\CreatePackage;
 use App\Filament\Resources\Packages\Pages\EditPackage;
 use App\Filament\Resources\Packages\Pages\ListPackages;
+use App\Jobs\RefreshPackagePage;
 use App\Jobs\SyncPackageJob;
 use App\Models\Package;
 use App\Models\Source;
@@ -293,5 +295,49 @@ class PackageResourceTest extends TestCase
         auth()->logout();
 
         $this->get('/admin/packages')->assertRedirect('/admin/login');
+    }
+
+    public function test_an_admin_can_publish_a_public_page_from_the_edit_form(): void
+    {
+        Queue::fake();
+
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getRouteKey()])
+            ->fillForm([
+                'page_enabled' => true,
+                'page_downloads' => 'latest',
+                'page_install' => true,
+                'page_versions' => false,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $package->refresh();
+
+        $this->assertTrue($package->hasPage());
+        $this->assertSame(PageDownloads::Latest, $package->page_downloads);
+        $this->assertFalse($package->page_versions);
+
+        // Enabling a page reads the repository's README straight away rather
+        // than leaving the page blank until the next hourly sync.
+        Queue::assertPushed(RefreshPackagePage::class);
+    }
+
+    public function test_publishing_a_page_is_recorded_in_the_audit_log(): void
+    {
+        Queue::fake();
+
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getRouteKey()])
+            ->fillForm(['page_enabled' => true])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('activity_log', [
+            'subject_type' => Package::class,
+            'subject_id' => $package->id,
+        ]);
     }
 }

--- a/tests/Feature/PublicPackagePageTest.php
+++ b/tests/Feature/PublicPackagePageTest.php
@@ -271,6 +271,26 @@ class PublicPackagePageTest extends TestCase
         $response->assertSee('https://github.com/acme/widgets/raw/HEAD/art/logo.png', false);
     }
 
+    public function test_a_monorepo_readme_resolves_its_links_against_the_right_directory(): void
+    {
+        $this->package([
+            'subdirectory' => 'packages/widgets',
+            'page_source_path' => 'packages/widgets/README.md',
+            'page_source_body' => "See the [guide](docs/install.md) and the [licence](/LICENSE.md).\n\n![logo](/art/logo.png)\n",
+        ]);
+
+        $response = $this->get('/p/acme/widgets');
+
+        // A plain relative link is relative to the package's own directory.
+        $response->assertSee('https://github.com/acme/widgets/blob/HEAD/packages/widgets/docs/install.md', false);
+        // A leading slash means the repository root, as it does on the
+        // provider that rendered this README first.
+        $response->assertSee('https://github.com/acme/widgets/blob/HEAD/LICENSE.md', false);
+        $response->assertSee('https://github.com/acme/widgets/raw/HEAD/art/logo.png', false);
+        $response->assertDontSee('packages/widgets/LICENSE.md', false);
+        $response->assertDontSee('packages/widgets/art/logo.png', false);
+    }
+
     public function test_a_body_written_in_the_panel_wins_over_the_repository(): void
     {
         $this->package([

--- a/tests/Feature/PublicPackagePageTest.php
+++ b/tests/Feature/PublicPackagePageTest.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PageDownloads;
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * The public page for a package: who can see one, what it shows, and what it
+ * refuses to hand over.
+ *
+ * Every assertion here is about an anonymous request — no session, no token —
+ * because that is the only kind this surface answers.
+ */
+class PublicPackagePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function package(array $attributes = [], bool $publicRepository = true): Package
+    {
+        Repository::default()->update(['public' => $publicRepository]);
+
+        $package = Package::factory()->create([
+            'name' => 'acme/widgets',
+            'repository' => 'https://github.com/acme/widgets',
+            'description' => 'Widgets for Acme.',
+            'type' => 'library',
+            'latest_version' => 'v1.1.0',
+            'page_enabled' => true,
+            ...$attributes,
+        ]);
+
+        $package->versions()->create([
+            'version' => 'v1.1.0',
+            'order' => '1.1.0.0',
+            'reference' => str_repeat('b', 40),
+            'is_dev' => false,
+            'released_at' => '2026-02-01 12:00:00',
+            'archive_path' => 'packages/acme/widgets/v110.zip',
+            'shasum' => sha1('zip'),
+            'metadata' => ['name' => 'acme/widgets', 'version' => 'v1.1.0'],
+        ]);
+
+        $package->versions()->create([
+            'version' => 'v1.0.0',
+            'order' => '1.0.0.0',
+            'reference' => str_repeat('a', 40),
+            'is_dev' => false,
+            'released_at' => '2026-01-01 12:00:00',
+            'archive_path' => 'packages/acme/widgets/v100.zip',
+            'shasum' => sha1('older'),
+            'metadata' => ['name' => 'acme/widgets', 'version' => 'v1.0.0'],
+        ]);
+
+        return $package;
+    }
+
+    /**
+     * A dist disk with the two archives on it, so a download that should
+     * succeed can.
+     */
+    private function fakeArchives(): void
+    {
+        $disk = Storage::fake('dists');
+
+        config(['filesystems.dists' => 'dists']);
+
+        $disk->put('packages/acme/widgets/v110.zip', 'zip-bytes');
+        $disk->put('packages/acme/widgets/v100.zip', 'older-bytes');
+    }
+
+    public function test_a_package_without_a_page_is_not_found(): void
+    {
+        $this->package(['page_enabled' => false]);
+
+        $this->get('/p/acme/widgets')->assertNotFound();
+    }
+
+    public function test_an_enabled_page_describes_the_package_to_anyone(): void
+    {
+        $this->package();
+
+        $response = $this->get('/p/acme/widgets');
+
+        $response->assertOk();
+        $response->assertSee('acme/widgets');
+        $response->assertSee('Widgets for Acme.');
+        $response->assertSee('v1.1.0');
+    }
+
+    public function test_a_page_is_reached_however_the_name_was_typed(): void
+    {
+        $this->package();
+
+        $this->get('/p/ACME/Widgets')->assertOk();
+    }
+
+    public function test_a_page_carries_the_tags_a_social_platform_and_a_crawler_read(): void
+    {
+        $this->package(['page_image' => 'https://cdn.example.com/card.png']);
+
+        $response = $this->get('/p/acme/widgets');
+
+        $response->assertSee('<link rel="canonical" href="'.config('app.url').'/p/acme/widgets">', false);
+        $response->assertSee('<meta property="og:title" content="acme/widgets — '.config('app.name').'">', false);
+        $response->assertSee('<meta property="og:url" content="'.config('app.url').'/p/acme/widgets">', false);
+        $response->assertSee('<meta property="og:image" content="https://cdn.example.com/card.png">', false);
+        // The large card only when there is an image to fill it.
+        $response->assertSee('<meta name="twitter:card" content="summary_large_image">', false);
+        $response->assertSee('"@type":"SoftwareSourceCode"', false);
+        $response->assertSee('"codeRepository":"https://github.com/acme/widgets"', false);
+        $response->assertSee('"softwareVersion":"v1.1.0"', false);
+    }
+
+    public function test_a_page_without_an_image_asks_for_the_text_card(): void
+    {
+        $this->package();
+
+        $this->get('/p/acme/widgets')
+            ->assertSee('<meta name="twitter:card" content="summary">', false)
+            ->assertDontSee('og:image', false);
+    }
+
+    public function test_the_registry_wide_image_stands_in_when_a_package_sets_none(): void
+    {
+        config(['registry.page_image' => '/images/icon-512.png']);
+
+        $this->package();
+
+        $this->get('/p/acme/widgets')
+            ->assertSee('<meta property="og:image" content="'.config('app.url').'/images/icon-512.png">', false);
+    }
+
+    public function test_install_commands_are_shown_when_the_switch_is_on(): void
+    {
+        $this->package(['page_install' => true]);
+
+        $this->get('/p/acme/widgets')
+            ->assertSee('composer require acme/widgets:^1.1.0');
+    }
+
+    public function test_install_commands_are_withheld_when_the_switch_is_off(): void
+    {
+        $this->package(['page_install' => false]);
+
+        $this->get('/p/acme/widgets')
+            ->assertOk()
+            ->assertDontSee('composer require acme/widgets');
+    }
+
+    public function test_a_private_repository_publishes_the_page_but_withholds_everything_needing_a_token(): void
+    {
+        $this->package([
+            'page_install' => true,
+            'page_downloads' => PageDownloads::All,
+        ], publicRepository: false);
+
+        $response = $this->get('/p/acme/widgets');
+
+        $response->assertOk();
+        // The page still describes the package — that is the point of one.
+        $response->assertSee('Widgets for Acme.');
+        $response->assertSee('Access required');
+        // Neither of the two things that would need a credential.
+        $response->assertDontSee('composer require acme/widgets');
+        $response->assertDontSee('/p/acme/widgets/download');
+    }
+
+    public function test_a_private_package_hands_out_no_archive_however_it_was_configured(): void
+    {
+        $this->fakeArchives();
+        $this->package(['page_downloads' => PageDownloads::All], publicRepository: false);
+
+        $this->get('/p/acme/widgets/download')->assertNotFound();
+        $this->get('/p/acme/widgets/download/v1.1.0')->assertNotFound();
+    }
+
+    public function test_downloads_are_off_by_default(): void
+    {
+        $this->fakeArchives();
+        $this->package();
+
+        $this->get('/p/acme/widgets')->assertDontSee('/p/acme/widgets/download');
+        $this->get('/p/acme/widgets/download')->assertNotFound();
+    }
+
+    public function test_the_latest_setting_offers_the_current_release_alone(): void
+    {
+        $this->fakeArchives();
+        $this->package(['page_downloads' => PageDownloads::Latest]);
+
+        $this->get('/p/acme/widgets')->assertSee('Download v1.1.0');
+
+        $this->get('/p/acme/widgets/download')
+            ->assertOk()
+            ->assertDownload('widgets-v1.1.0.zip');
+
+        // The history is not reachable by editing the URL.
+        $this->get('/p/acme/widgets/download/v1.0.0')->assertNotFound();
+    }
+
+    public function test_every_version_is_downloadable_when_that_is_what_was_chosen(): void
+    {
+        $this->fakeArchives();
+        $this->package(['page_downloads' => PageDownloads::All]);
+
+        $this->get('/p/acme/widgets/download/v1.0.0')
+            ->assertOk()
+            ->assertDownload('widgets-v1.0.0.zip');
+    }
+
+    public function test_a_download_from_a_page_is_counted_like_any_other(): void
+    {
+        $this->fakeArchives();
+        $package = $this->package(['page_downloads' => PageDownloads::Latest]);
+
+        $this->get('/p/acme/widgets/download')->assertOk();
+
+        $this->assertSame(1, $package->fresh()->total_downloads);
+        $this->assertDatabaseHas('downloads', [
+            'package_id' => $package->id,
+            'version' => 'v1.1.0',
+        ]);
+    }
+
+    public function test_a_head_request_does_not_count_as_a_download(): void
+    {
+        $this->fakeArchives();
+        $package = $this->package(['page_downloads' => PageDownloads::Latest]);
+
+        $this->head('/p/acme/widgets/download')->assertOk();
+
+        $this->assertSame(0, $package->fresh()->total_downloads);
+    }
+
+    public function test_the_version_history_is_shown_or_withheld_on_its_own_switch(): void
+    {
+        $this->package(['page_versions' => false]);
+
+        $this->get('/p/acme/widgets')->assertDontSee('Versions');
+
+        Package::query()->update(['page_versions' => true]);
+
+        $this->get('/p/acme/widgets')
+            ->assertSee('Versions')
+            ->assertSee('v1.0.0');
+    }
+
+    public function test_the_repository_readme_is_rendered_and_its_html_is_escaped(): void
+    {
+        $this->package([
+            'page_source_path' => 'README.md',
+            'page_source_body' => "# Widgets\n\nSee the [docs](docs/install.md).\n\n<script>alert('xss')</script>\n\n![logo](art/logo.png)\n",
+        ]);
+
+        $response = $this->get('/p/acme/widgets');
+
+        $response->assertSee('<h1>Widgets</h1>', false);
+        // Raw HTML in somebody else's README never becomes HTML here.
+        $response->assertDontSee('<script>alert', false);
+        // Relative links resolve against the repository they were written in.
+        $response->assertSee('https://github.com/acme/widgets/blob/HEAD/docs/install.md', false);
+        // Images resolve to the bytes rather than to the provider's viewer.
+        $response->assertSee('https://github.com/acme/widgets/raw/HEAD/art/logo.png', false);
+    }
+
+    public function test_a_body_written_in_the_panel_wins_over_the_repository(): void
+    {
+        $this->package([
+            'page_body' => '# Written here',
+            'page_source_path' => 'README.md',
+            'page_source_body' => '# From the repository',
+        ]);
+
+        $this->get('/p/acme/widgets')
+            ->assertSee('<h1>Written here</h1>', false)
+            ->assertDontSee('From the repository');
+    }
+
+    public function test_a_monorepo_package_resolves_links_against_its_own_directory(): void
+    {
+        $this->package([
+            'subdirectory' => 'packages/widgets',
+            'page_source_path' => 'README.md',
+            'page_source_body' => '![logo](art/logo.png)',
+        ]);
+
+        $this->get('/p/acme/widgets')
+            ->assertSee('https://github.com/acme/widgets/raw/HEAD/packages/widgets/art/logo.png', false);
+    }
+
+    public function test_a_page_is_scoped_to_the_repository_it_is_served_from(): void
+    {
+        $internal = Repository::create(['name' => 'Internal', 'path' => 'internal', 'public' => true]);
+
+        $this->package();
+
+        Package::factory()->create([
+            'repository_id' => $internal->id,
+            'name' => 'acme/widgets',
+            'repository' => 'https://github.com/other/widgets',
+            'description' => 'A different package with the same name.',
+            'page_enabled' => true,
+        ]);
+
+        $this->get('/p/acme/widgets')->assertSee('Widgets for Acme.');
+
+        $this->get('/r/internal/p/acme/widgets')
+            ->assertOk()
+            ->assertSee('A different package with the same name.')
+            ->assertSee('<link rel="canonical" href="'.config('app.url').'/r/internal/p/acme/widgets">', false);
+    }
+
+    public function test_a_page_in_a_repository_that_does_not_exist_is_not_found(): void
+    {
+        $this->package();
+
+        $this->get('/r/nowhere/p/acme/widgets')->assertNotFound();
+    }
+}

--- a/tests/Feature/PublicRepositoryPageTest.php
+++ b/tests/Feature/PublicRepositoryPageTest.php
@@ -130,6 +130,11 @@ class PublicRepositoryPageTest extends TestCase
         $response->assertSee('Sitemap: '.config('app.url').'/sitemap.xml');
         $response->assertSee('Disallow: /admin');
         $response->assertSee('Disallow: /dist/');
+        // A page's download button is a real archive on the other end: a
+        // crawler following it spends bandwidth and inflates the package's
+        // download count.
+        $response->assertSee('Disallow: /p/*/*/download');
+        $response->assertSee('Disallow: /r/*/p/*/*/download');
     }
 
     public function test_an_installation_that_opts_out_of_indexing_says_so(): void

--- a/tests/Feature/PublicRepositoryPageTest.php
+++ b/tests/Feature/PublicRepositoryPageTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A repository's landing page, and the two documents that get the pages
+ * found — served at the same URLs the Composer API answers on, which is the
+ * whole reason the feature is shaped this way.
+ */
+class PublicRepositoryPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_the_root_still_lands_on_the_panel_when_no_page_is_published(): void
+    {
+        $this->get('/')->assertRedirect('/admin/login');
+    }
+
+    public function test_the_composer_api_is_untouched_by_the_page_at_its_root(): void
+    {
+        Repository::default()->update(['public' => true, 'page_enabled' => true]);
+
+        // The page answers at "/" and packages.json answers where it always
+        // did; a browser and Composer never see each other's response.
+        $this->get('/')->assertOk()->assertSee('<!DOCTYPE html>', false);
+        $this->get('/packages.json')->assertOk()->assertJsonStructure(['metadata-url']);
+    }
+
+    public function test_an_enabled_root_page_describes_the_repository(): void
+    {
+        Repository::default()->update([
+            'public' => true,
+            'page_enabled' => true,
+            'description' => 'Everything Acme publishes.',
+            'page_body' => '## Getting started',
+        ]);
+
+        $response = $this->get('/');
+
+        $response->assertOk();
+        $response->assertSee('Everything Acme publishes.');
+        $response->assertSee('<h2>Getting started</h2>', false);
+        $response->assertSee('composer config repositories.');
+        $response->assertSee('"@type":"CollectionPage"', false);
+    }
+
+    public function test_only_packages_with_pages_of_their_own_are_listed(): void
+    {
+        Repository::default()->update(['public' => true, 'page_enabled' => true]);
+
+        Package::factory()->create(['name' => 'acme/listed', 'page_enabled' => true]);
+        Package::factory()->create(['name' => 'acme/unlisted', 'page_enabled' => false]);
+
+        $this->get('/')
+            ->assertSee('acme/listed')
+            // A package this registry will not describe is not named either:
+            // that is how a private package's existence leaks out of a public
+            // landing page.
+            ->assertDontSee('acme/unlisted');
+    }
+
+    public function test_the_package_list_can_be_switched_off(): void
+    {
+        Repository::default()->update([
+            'public' => true,
+            'page_enabled' => true,
+            'page_lists_packages' => false,
+        ]);
+
+        Package::factory()->create(['name' => 'acme/listed', 'page_enabled' => true]);
+
+        $this->get('/')
+            ->assertOk()
+            ->assertDontSee('acme/listed');
+    }
+
+    public function test_a_named_repository_answers_its_page_at_its_own_mount(): void
+    {
+        $internal = Repository::create([
+            'name' => 'Internal',
+            'path' => 'internal',
+            'public' => true,
+            'page_enabled' => true,
+            'description' => 'Internal packages.',
+        ]);
+
+        $this->get('/r/internal')
+            ->assertOk()
+            ->assertSee('Internal packages.')
+            ->assertSee('<link rel="canonical" href="'.config('app.url').'/r/internal">', false);
+
+        $this->assertSame($internal->id, Repository::forPath('internal')?->id);
+    }
+
+    public function test_a_named_repository_without_a_page_is_not_found(): void
+    {
+        Repository::create(['name' => 'Internal', 'path' => 'internal', 'public' => true]);
+
+        // Not a redirect to a login form: this URL has never answered a page,
+        // and a stranger who found it has no account to log into.
+        $this->get('/r/internal')->assertNotFound();
+    }
+
+    public function test_the_sitemap_lists_every_published_page(): void
+    {
+        Repository::default()->update(['public' => true, 'page_enabled' => true]);
+
+        Package::factory()->create(['name' => 'acme/listed', 'page_enabled' => true]);
+        Package::factory()->create(['name' => 'acme/unlisted', 'page_enabled' => false]);
+
+        $response = $this->get('/sitemap.xml');
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'application/xml');
+        $response->assertSee('<loc>'.config('app.url').'</loc>', false);
+        $response->assertSee('<loc>'.config('app.url').'/p/acme/listed</loc>', false);
+        $response->assertDontSee('acme/unlisted');
+    }
+
+    public function test_robots_points_at_the_sitemap_and_keeps_crawlers_off_the_api(): void
+    {
+        $response = $this->get('/robots.txt');
+
+        $response->assertOk();
+        $response->assertSee('Sitemap: '.config('app.url').'/sitemap.xml');
+        $response->assertSee('Disallow: /admin');
+        $response->assertSee('Disallow: /dist/');
+    }
+
+    public function test_an_installation_that_opts_out_of_indexing_says_so(): void
+    {
+        config(['registry.pages.sitemap' => false]);
+
+        Repository::default()->update(['public' => true, 'page_enabled' => true]);
+
+        // Both documents still answer: a 404 on robots.txt is read by some
+        // crawlers as permission to crawl everything.
+        $this->get('/robots.txt')
+            ->assertOk()
+            ->assertSee("User-agent: *\nDisallow: /");
+
+        $this->get('/sitemap.xml')
+            ->assertOk()
+            ->assertDontSee('<loc>', false);
+    }
+}


### PR DESCRIPTION
This pull request introduces public pages for packages and repositories, allowing anyone to view a readable page with package information, installation instructions, and (optionally) downloads, without requiring authentication. The feature is off by default and can be enabled per package or repository. The changes include configuration options, documentation updates, and new UI actions for managing public page content. Additionally, there are improvements to how repository file links are resolved for accurate rendering of markdown content.

**Public pages feature:**

* Added support for public pages that display package/repository information, rendered markdown, install commands, and optional downloads. The feature is controlled per package or repository and is off by default. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR17-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R221-R230)
* Introduced new configuration options in `.env.example` and documented them in `README.md`, including `PAGE_IMAGE`, `PAGE_SITEMAP`, `PAGE_MARKDOWN_CACHE_MINUTES`, and `PAGE_MAX_BODY_KB`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR195-R208) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R268-R278)
* Added a new enum `PageDownloads` to control the level of downloadable archives offered on public pages (`none`, `latest`, or `all`).

**UI and admin actions:**

* Implemented a `RefreshPageContentAction` for package admins to manually refresh the public page content from the repository, providing immediate feedback and notifications. Integrated this action into the package admin panel. [[1]](diffhunk://#diff-03b877d6bb8b33ef2e7b701ea6a99ed2d6135d368185443b9fbf2fef8aeeb44eR1-R79) [[2]](diffhunk://#diff-32826273eff746a8961da048baaa8f8078f7687a49ffd841f09107f99a3b8e17R8) [[3]](diffhunk://#diff-32826273eff746a8961da048baaa8f8078f7687a49ffd841f09107f99a3b8e17R25)

**Repository link resolution:**

* Enhanced `SourceProvider` with methods to generate correct URLs for viewing or fetching raw files, ensuring that markdown links and images resolve properly on public pages.

**Documentation and changelog:**

* Updated `README.md` and `CHANGELOG.md` to describe the new public pages feature, configuration, and its default-off behavior. Noted the removal of the static `public/robots.txt` file in favor of dynamic handling. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL391-R415) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL351-R366) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R444)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New anonymous surface serves user-controlled markdown and optional archives; mitigations include private-repo caps, escaped HTML, rate limits, and robots rules, but misconfiguration could expose more than intended.
> 
> **Overview**
> **Public pages (opt-in)** let packages and repositories publish readable URLs at existing Composer mounts (`/p/{vendor}/{package}`, repository root or `/r/{path}`). Nothing is enabled until toggled in the panel; the site root keeps redirecting to admin login until the default repository publishes a landing page.
> 
> **Package pages** show metadata, rendered markdown (panel body overrides repo `package-page.md` / README), optional install commands and version history, and downloads via a new `PageDownloads` enum (`none` / `latest` / `all`). **Private repositories** still allow a descriptive page but cap offered downloads and install commands to nothing, with an access notice. **Repository landing pages** add optional markdown, package list (only packages with their own page), and shared `composer config` via `Repository::configureCommand()`.
> 
> **Serving stack:** new page controllers and Blade layout, `PackagePage` + hardened `PageMarkdown` (escaped HTML, link/image resolution via new `SourceProvider` browse/raw URLs), sync-time and queued `RefreshPackagePage` / panel **Refresh page** action, anonymous download route with same analytics rules as other archives, `throttle:pages` (120/min), dynamic `/sitemap.xml` and `/robots.txt` (static `public/robots.txt` removed), plus `PAGE_*` config and a migration for page columns.
> 
> **Docs/tests:** `docs/public-pages.md`, README/CHANGELOG/.env updates, and broad feature tests for content, access, downloads, and SEO behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54329a0021ea33a10c8056aba7e5ba11d9e372be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->