### PR TITLE
Add the page columns an amended migration never delivered

### DIFF
--- a/database/migrations/2026_08_13_000000_add_the_page_header_columns_that_shipped_late.php
+++ b/database/migrations/2026_08_13_000000_add_the_page_header_columns_that_shipped_late.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * The four page columns that were added to an already-released migration.
+     *
+     * `page_type`, `page_source`, `page_body_source` and `page_body_path` were
+     * written into 2026_08_12_000000_add_public_pages_to_packages_and_repositories
+     * after that file had already run on a deployed registry. A migration is
+     * recorded by name, so amending one that has run is invisible: a fresh
+     * install gets all thirteen page columns and every registry upgraded
+     * before the amendment gets nine, and only finds out when saving a package
+     * fails on an unknown column. This adds the missing four where they are
+     * missing.
+     *
+     * Guarded per column rather than per table, because both shapes of
+     * database are legitimate and both have to end here — the amended file
+     * created these on anything installed since, and this must be a no-op
+     * there rather than a duplicate-column error. The defaults are the ones
+     * the amended migration declares, so a page's meaning does not depend on
+     * which of the two paths a registry took to get its columns.
+     */
+    public function up(): void
+    {
+        Schema::table('packages', function (Blueprint $table) {
+            if (! Schema::hasColumn('packages', 'page_type')) {
+                $table->boolean('page_type')->default(true);
+            }
+
+            if (! Schema::hasColumn('packages', 'page_source')) {
+                $table->boolean('page_source')->default(false);
+            }
+
+            if (! Schema::hasColumn('packages', 'page_body_source')) {
+                $table->string('page_body_source', 16)->default('auto');
+            }
+
+            if (! Schema::hasColumn('packages', 'page_body_path')) {
+                $table->string('page_body_path')->nullable();
+            }
+        });
+    }
+
+    /**
+     * Deliberately nothing.
+     *
+     * These columns belong to the migration above, whose own `down()` drops
+     * all thirteen of them together. Dropping them here as well would leave
+     * that rollback failing on columns it expects to find, on the one database
+     * shape this migration exists to repair.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
The four header and body-source columns were added to 2026_08_12_000000_add_public_pages_to_packages_and_repositories after that migration had already run in production. Migrations are recorded by name, so the amendment never applied there and saving a package failed on an unknown page_type column. Adds them in a migration of their own, guarded per column so a registry installed since the amendment — which already has all thirteen — passes through untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration on a core `packages` table in production; guarded adds limit blast radius, but wrong defaults or partial state could still affect page settings until verified.
> 
> **Overview**
> Fixes production registries that already ran `2026_08_12_000000_add_public_pages_to_packages_and_repositories` before four page-related columns were added to that file, which left `packages` without `page_type`, `page_source`, `page_body_source`, and `page_body_path` and broke package saves.
> 
> Adds migration `2026_08_13_000000_add_the_page_header_columns_that_shipped_late` to create those columns on `packages` only when each is missing, using the same types and defaults as the amended migration so both upgrade paths converge. **`down()` is intentionally empty** so rollback stays owned by the original migration’s drop of all thirteen page columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75bce1f0f388103fd54f44c17e6c4e4bfd3fa9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->