### PR TITLE
Implement multi-repository package serving and visibility control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ must act on are collected under **Upgrading from 0.9.x** at the end.
   list them (`PAGE_SITEMAP=false` to publish neither). See
   [docs/public-pages.md](docs/public-pages.md).
 
+- **One package, several repositories.** A package lives in one Composer
+  repository and can be served from any number of others — the same package, one
+  sync, one set of versions and archives, one download counter, answering under
+  every mount that serves it. Add it from the package's form (**Also served
+  from**), from a repository's package list (**Serve an existing package**),
+  through `POST /api/v1/packages/{id}/repositories`, or with
+  `php artisan package:serve acme/widgets internal`. Access is decided by the
+  mount rather than by the package, so a package added to a private repository
+  is private there and one added to a public repository is readable there —
+  publishing it, which is the edge to know before using this. Publishing itself
+  stays with the repository the package lives in, and no repository can serve
+  two packages under one name. See
+  [docs/shared-packages.md](docs/shared-packages.md).
+
 - The [Composer v2 repository API](https://getcomposer.org/doc/05-repositories.md#composer):
   `packages.json`, `search.json`, `list.json`, per-package `p2` metadata, and
   `dist` zipballs. A consuming project needs one `repositories` entry and no

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Failed authentications are rate limited per address (30 a minute), and the 429 t
 
 ### Repositories, and the public default
 
-A **repository** here is a Composer repository this registry serves. Every package belongs to exactly one. The default repository answers at the site root; every other one you create is mounted under `/r/{path}`, so a single installation can serve independent registries — a public one and an internal one, say — with independent access rules.
+A **repository** here is a Composer repository this registry serves. Every package lives in one, and can be served from any number of others. The default repository answers at the site root; every other one you create is mounted under `/r/{path}`, so a single installation can serve independent registries — a public one and an internal one, say — with independent access rules.
 
 Whether a repository can be read without a token is the `public` flag on it. Repositories you create are private.
 
@@ -199,6 +199,14 @@ Whether a repository can be read without a token is the `public` flag on it. Rep
 > The **default repository is created public**. It stands in for the whole registry as it behaved before repositories and tokens existed, and packages created without choosing a repository land in it — so on a fresh installation, anyone who can reach the app can list and install everything in it. Open **Repositories → Default** and turn **Public** off (or move the packages to a repository of your own) before the app is reachable from anywhere you don't control.
 
 A presented token is always checked, public repository or not. A CI system holding a revoked token hears about it as a `401` rather than continuing to work by accident until someone makes the repository private.
+
+### Serving one package from several repositories
+
+A package lives in one repository and can be added to as many others as you like — the same package, one sync, one set of archives, answering under every mount that serves it. Use **Also served from** on the package's form, **Serve an existing package** on a repository's, `POST /api/v1/packages/{id}/repositories`, or `php artisan package:serve acme/widgets internal`.
+
+Access is decided by the mount rather than by the package: a package added to a private repository is private there even if it is public where it lives — and, the edge worth knowing before you use this, **adding a package to a public repository publishes it**. Publishing stays with the repository the package lives in; a share serves what a package publishes and confers no right to publish into it. Two packages cannot share a name in one repository, so a repository already answering for the name refuses.
+
+See **[docs/shared-packages.md](docs/shared-packages.md)**.
 
 ### Reserved vendors
 
@@ -306,6 +314,7 @@ The panel is the usual way in, but everything an operator needs can be done with
 | `packages:sync [name]` | Sync versions from their sources. Takes a composer name or `owner/repo`; `--source=` narrows to one source, `--queue` dispatches instead of running inline. The scheduler runs `--queue` hourly. |
 | `package:rebuild [name]` | Re-import every version, trusting nothing already stored. The recovery path for corrupted archives or metadata drift — reach for it when a sync says everything is current but the output isn't. |
 | `package:add <url>` | Create a package from a VCS repository URL and queue its first sync. `--name=`, `--repo=` (which Composer repository to serve it from), `--subdirectory=` (for a monorepo), `--token=`, `--no-webhook`, `--no-sync`. The scriptable equivalent of the create wizard. |
+| `package:serve <name> <repo>` | Serve an existing package from another Composer repository — `root` names the registry root. `--remove` stops serving it there; `--home=` disambiguates a name that lives in more than one repository. See [docs/shared-packages.md](docs/shared-packages.md). |
 | `package:delete <name>` | Delete a package, its versions and its stored archives. `--repo=` disambiguates a name served in more than one repository; `--force` skips the confirmation. |
 
 **Archives**
@@ -446,6 +455,7 @@ After adding new Filament resources, re-run both `php artisan shield:generate --
 - [docs/mirroring.md](docs/mirroring.md) — serving packagist.org's packages through this registry: enabling it, what consumers see, failure behaviour, and what it costs in disk.
 - [docs/outgoing-webhooks.md](docs/outgoing-webhooks.md) — telling a deploy pipeline or a non-Slack chat tool that a version published or a sync failed: the events, the payloads, and how to verify a signature.
 - [docs/public-pages.md](docs/public-pages.md) — publishing a readable page for a package or a repository: the toggles, where the content comes from, what a private package withholds, and the social-preview and search tags.
+- [docs/shared-packages.md](docs/shared-packages.md) — serving one package from several Composer repositories: how to, what decides access under each mount, and what stays with the repository the package lives in.
 - [docs/teams.md](docs/teams.md) — granting access to a group rather than a person: what a team holds, how effective access composes, and what it costs on the Composer hot path.
 - [docs/webhooks.md](docs/webhooks.md) — auto-syncing on push: the two GitHub delivery paths, GitLab's per-project hooks, and how to tell whether a package is actually covered.
 - [CHANGELOG.md](CHANGELOG.md) — what changed in each release and what it asks of the operator.

--- a/app/Console/Commands/DeletePackage.php
+++ b/app/Console/Commands/DeletePackage.php
@@ -25,10 +25,11 @@ class DeletePackage extends Command
     {
         $candidates = Package::query()
             ->where('name', $this->argument('name'))
-            ->when($this->option('repo'), fn ($query, string $path) => $query->whereHas(
-                'composerRepository',
-                fn ($repositories) => $repositories->where('path', $path),
-            ))
+            // Present but empty is the registry root; see Package::livingIn().
+            ->when(
+                $this->option('repo') !== null,
+                fn ($query) => $query->livingIn((string) $this->option('repo')),
+            )
             ->with('composerRepository')
             ->get();
 

--- a/app/Console/Commands/RebuildPackages.php
+++ b/app/Console/Commands/RebuildPackages.php
@@ -28,10 +28,11 @@ class RebuildPackages extends Command
             // Uploaded artifacts have no source to rebuild from.
             ->whereNotNull('repository')
             ->when($this->argument('name'), fn ($query, string $name) => $query->where('name', $name))
-            ->when($this->option('repo'), fn ($query, string $path) => $query->whereHas(
-                'composerRepository',
-                fn ($repositories) => $repositories->where('path', $path),
-            ))
+            // Present but empty is the registry root; see Package::livingIn().
+            ->when(
+                $this->option('repo') !== null,
+                fn ($query) => $query->livingIn((string) $this->option('repo')),
+            )
             ->get();
 
         if ($packages->isEmpty()) {

--- a/app/Console/Commands/ServePackage.php
+++ b/app/Console/Commands/ServePackage.php
@@ -106,10 +106,13 @@ class ServePackage extends Command
     {
         $candidates = Package::query()
             ->where('name', mb_strtolower((string) $this->argument('name')))
-            ->when($this->option('home'), fn ($query, string $path) => $query->whereHas(
-                'composerRepository',
-                fn ($repositories) => $repositories->where('path', $path),
-            ))
+            // Present but empty is the registry root, exactly as the repo
+            // argument reads it — so `!== null` rather than truthiness, which
+            // would drop the filter for the most common home of all.
+            ->when(
+                $this->option('home') !== null,
+                fn ($query) => $query->livingIn((string) $this->option('home')),
+            )
             ->with('composerRepository')
             ->get();
 

--- a/app/Console/Commands/ServePackage.php
+++ b/app/Console/Commands/ServePackage.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * Which Composer repositories serve a package.
+ *
+ * A package lives in one repository and can be served from any number of
+ * others — the same row, the same versions and the same archives, answering
+ * under another mount with its own access rules. This is that decision from a
+ * provisioning script, where the panel's "Also served from" is the same one
+ * from a screen.
+ */
+class ServePackage extends Command
+{
+    protected $signature = 'package:serve
+        {name : The composer name of the package}
+        {repo : The Composer repository path to serve it from; "root" or "" for the registry root}
+        {--home= : The Composer repository path the package lives in, when the name is served in more than one}
+        {--remove : Stop serving it there instead}';
+
+    protected $description = 'Serve an existing package from another Composer repository';
+
+    public function handle(): int
+    {
+        $package = $this->package();
+
+        if (! $package instanceof Package) {
+            return self::FAILURE;
+        }
+
+        $repository = $this->repository();
+
+        if (! $repository instanceof Repository) {
+            return self::FAILURE;
+        }
+
+        return $this->option('remove')
+            ? $this->remove($package, $repository)
+            : $this->add($package, $repository);
+    }
+
+    private function add(Package $package, Repository $repository): int
+    {
+        try {
+            $package->serveFrom([$repository]);
+        } catch (Throwable $exception) {
+            // A name the target already answers for, or a vendor it may not
+            // publish under — both already say what to do about it.
+            $this->components->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->components->info(sprintf(
+            '%s is now served from %s. Consumers configure it with: %s',
+            $package->name,
+            $this->describe($repository),
+            $repository->configureCommand(),
+        ));
+
+        return self::SUCCESS;
+    }
+
+    private function remove(Package $package, Repository $repository): int
+    {
+        if ($repository->getKey() === $package->repository_id) {
+            $this->components->error(sprintf(
+                '%s lives in %s. Move it to another repository instead of removing it from this one.',
+                $package->name,
+                $this->describe($repository),
+            ));
+
+            return self::FAILURE;
+        }
+
+        $package->stopServingFrom([$repository]);
+
+        $this->components->info(sprintf(
+            '%s is no longer served from %s. It is still served from %s.',
+            $package->name,
+            $this->describe($repository),
+            Repository::query()
+                ->whereKey($package->servingRepositoryIds())
+                ->orderBy('name')
+                ->pluck('name')
+                ->implode(', '),
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The package this command addresses.
+     *
+     * A name is unique within a repository rather than across the registry, so
+     * one served in two of them needs --home to say which is meant — the same
+     * ambiguity package:delete resolves with --repo, and resolved the same way.
+     */
+    private function package(): ?Package
+    {
+        $candidates = Package::query()
+            ->where('name', mb_strtolower((string) $this->argument('name')))
+            ->when($this->option('home'), fn ($query, string $path) => $query->whereHas(
+                'composerRepository',
+                fn ($repositories) => $repositories->where('path', $path),
+            ))
+            ->with('composerRepository')
+            ->get();
+
+        if ($candidates->isEmpty()) {
+            $this->components->error('No matching package found.');
+
+            return null;
+        }
+
+        if ($candidates->count() > 1) {
+            $this->components->error(sprintf(
+                'That name lives in several Composer repositories (%s); pick one with --home.',
+                $candidates->map(fn (Package $package): string => $package->composerRepository->path ?? 'root')->implode(', '),
+            ));
+
+            return null;
+        }
+
+        return $candidates->sole();
+    }
+
+    /**
+     * The repository named by the argument. The root repository is mounted at
+     * no path at all, so it is named rather than pathed.
+     */
+    private function repository(): ?Repository
+    {
+        $path = trim((string) $this->argument('repo'));
+
+        if ($path === '' || $path === 'root') {
+            return Repository::default();
+        }
+
+        $repository = Repository::query()->where('path', $path)->first();
+
+        if (! $repository instanceof Repository) {
+            $this->components->error(sprintf(
+                'No Composer repository is served at /r/%s. Existing paths: %s.',
+                $path,
+                Repository::query()->whereNotNull('path')->orderBy('path')->pluck('path')->implode(', ') ?: '(none)',
+            ));
+
+            return null;
+        }
+
+        return $repository;
+    }
+
+    private function describe(Repository $repository): string
+    {
+        return $repository->path === null
+            ? "{$repository->name} (the registry root)"
+            : "{$repository->name} (/r/{$repository->path})";
+    }
+}

--- a/app/Exceptions/NameCollision.php
+++ b/app/Exceptions/NameCollision.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Models\Package;
+use RuntimeException;
+
+/**
+ * A package was about to be served from a repository that already answers for
+ * its name.
+ *
+ * One Composer repository serves one package per name — everything on the
+ * Composer surface resolves a name inside a repository, and two rows sharing
+ * one there is a lookup with no right answer. The pivot's
+ * (repository_id, package_name) unique index is the backstop; this is what the
+ * paths that add a package to a repository raise first, so the refusal reads as
+ * a decision rather than a query error.
+ *
+ * @see Package::serveFrom()
+ */
+class NameCollision extends RuntimeException {}

--- a/app/Filament/Resources/Activities/Tables/ActivitiesTable.php
+++ b/app/Filament/Resources/Activities/Tables/ActivitiesTable.php
@@ -25,6 +25,8 @@ class ActivitiesTable
         'role_revoked' => 'Role revoked',
         'grant_added' => 'Access granted',
         'grant_removed' => 'Access revoked',
+        'serving_added' => 'Served from repository',
+        'serving_removed' => 'Removed from repository',
     ];
 
     public static function configure(Table $table): Table
@@ -65,7 +67,7 @@ class ActivitiesTable
                     ->color(fn (?string $state): string => match ($state) {
                         'created', 'restored' => 'success',
                         'deleted', 'role_revoked', 'grant_removed' => 'danger',
-                        'role_granted', 'grant_added' => 'warning',
+                        'role_granted', 'grant_added', 'serving_added', 'serving_removed' => 'warning',
                         default => 'gray',
                     })
                     ->sortable(),

--- a/app/Filament/Resources/Packages/Pages/CreatePackage.php
+++ b/app/Filament/Resources/Packages/Pages/CreatePackage.php
@@ -55,6 +55,10 @@ class CreatePackage extends CreateRecord
         /** @var Package $package */
         $package = $this->getRecord();
 
+        // Any repositories chosen alongside the one the package lives in.
+        // @see PackageForm::servingRepositories()
+        $package->serveFrom($this->data['serving_repositories'] ?? []);
+
         $registrar = app(WebhookRegistrar::class);
 
         if ($registrar->register($package) === WebhookCoverage::Repository) {

--- a/app/Filament/Resources/Packages/Pages/EditPackage.php
+++ b/app/Filament/Resources/Packages/Pages/EditPackage.php
@@ -26,7 +26,7 @@ class EditPackage extends EditRecord
     }
 
     /**
-     * Carry the auto-sync toggle through to GitHub.
+     * Carry the serving repositories and the auto-sync toggle through.
      *
      * Only when it was the thing that changed: every other save — a renamed
      * package, a corrected description — must not cost an API call, and must
@@ -36,6 +36,12 @@ class EditPackage extends EditRecord
     {
         /** @var Package $package */
         $package = $this->getRecord();
+
+        // Where the package is served from has no column behind it, so it is
+        // written here rather than with the rest of the form. After the save,
+        // because the home repository may have moved in the same submit and
+        // the serving rows are settled against where it has landed.
+        $package->syncServingRepositories($this->data['serving_repositories'] ?? []);
 
         if (! $package->wasChanged('webhook_enabled')) {
             return;

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -7,7 +7,6 @@ use App\Enums\PageDownloads;
 use App\Enums\WebhookCoverage;
 use App\Models\Package;
 use App\Models\Repository;
-use App\Models\ReservedVendor;
 use App\Models\Source;
 use Closure;
 use Filament\Forms\Components\Placeholder;
@@ -424,18 +423,22 @@ class PackageForm
                 ignoreRecord: true,
                 modifyRuleUsing: fn (Unique $rule, Get $get): Unique => self::uniquePerRepository($rule, $get),
             )
-            // Package's own saving hook refuses this too, but by throwing —
-            // which from a form is a 500 where the admin wanted a field error
-            // naming the repository that owns the vendor.
+            // Package's own saving hook refuses both of these too, but by
+            // throwing — which from a form is a 500 where the admin wanted a
+            // field error saying what stands in the way: a vendor another
+            // repository has reserved, or a name the chosen repository already
+            // serves from a package that merely lives elsewhere, which the
+            // unique rule above cannot see because shares live on the pivot.
             ->rules([
-                fn (Get $get): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get): void {
-                    $conflict = ReservedVendor::conflictFor(
-                        (string) $value,
+                fn (Get $get, ?Package $record): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get, $record): void {
+                    $refusal = Package::servingRefusal(
+                        mb_strtolower((string) $value),
                         (int) ($get('repository_id') ?? Repository::default()->id),
+                        $record?->getKey(),
                     );
 
-                    if ($conflict instanceof ReservedVendor) {
-                        $fail($conflict->refusal((string) $value));
+                    if ($refusal !== null) {
+                        $fail($refusal);
                     }
                 },
             ])

--- a/app/Filament/Resources/Packages/Schemas/PackageForm.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageForm.php
@@ -41,6 +41,7 @@ class PackageForm
                 self::repository(),
                 self::subdirectory(),
                 self::composerRepository(),
+                self::servingRepositories(),
                 self::source(),
                 self::token(),
                 self::latestVersion(),
@@ -313,7 +314,63 @@ class PackageForm
             ->default(fn (): int => Repository::default()->id)
             ->required()
             ->selectablePlaceholder(false)
-            ->helperText('Which of this registry\'s repositories serves the package.');
+            // Live so that the repositories offered below are the ones this
+            // package is not already homed in.
+            ->live()
+            ->helperText('Where the package lives: the repository it is published into, and the mount its page URL is cut from.');
+    }
+
+    /**
+     * The other repositories this package answers under.
+     *
+     * A package lives in one repository and can be served from any number of
+     * others — the same row, the same versions and archives, under another
+     * mount with its own access rules. This is the whole of that decision;
+     * everything else about the package is unchanged by it.
+     *
+     * Not a `relationship()` select, though `repositories` is one: a serving
+     * row carries the package's name for the per-repository unique index, and
+     * Filament's sync would write neither that nor the two refusals below.
+     * The pages hand the chosen ids to Package::syncServingRepositories()
+     * instead. @see \App\Filament\Resources\Packages\Pages\EditPackage
+     */
+    public static function servingRepositories(): Select
+    {
+        return Select::make('serving_repositories')
+            ->label('Also served from')
+            ->multiple()
+            ->options(fn (Get $get): array => Repository::query()
+                ->whereKeyNot((int) ($get('repository_id') ?? Repository::default()->id))
+                ->orderBy('name')
+                ->pluck('name', 'id')
+                ->all())
+            ->afterStateHydrated(fn (Select $component, ?Package $record) => $component->state(
+                $record === null ? [] : array_values(array_diff(
+                    $record->servingRepositoryIds(),
+                    [(int) $record->repository_id],
+                )),
+            ))
+            // Written by the page after the save rather than with it, since
+            // there is no column behind this.
+            ->dehydrated(false)
+            ->rules([
+                fn (Get $get, ?Package $record): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get, $record): void {
+                    foreach ((array) $value as $repositoryId) {
+                        $refusal = Package::servingRefusal(
+                            mb_strtolower((string) $get('name')),
+                            (int) $repositoryId,
+                            $record?->getKey(),
+                        );
+
+                        if ($refusal !== null) {
+                            $fail($refusal);
+
+                            return;
+                        }
+                    }
+                },
+            ])
+            ->helperText('Optional. Every repository chosen here serves this same package under its own mount, with its own access rules.');
     }
 
     /**

--- a/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageInfolist.php
@@ -6,6 +6,7 @@ use App\Enums\SourceProvider;
 use App\Enums\WebhookCoverage;
 use App\Filament\Resources\Sources\SourceResource;
 use App\Models\Package;
+use App\Models\Repository;
 use App\Services\GitHub\WebhookRegistrar;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
@@ -44,12 +45,25 @@ class PackageInfolist
                     ->badge()
                     ->placeholder('-'),
                 TextEntry::make('composerRepository.name')
-                    ->label('Served in')
+                    ->label('Lives in')
                     ->badge()
                     ->color('gray')
                     ->helperText(fn (Package $record): string => $record->composerRepository->public
                         ? 'Public repository — readable without a token.'
                         : 'Private repository — consumers need an access token.'),
+                TextEntry::make('serving_repositories')
+                    ->label('Also served from')
+                    ->badge()
+                    ->color('gray')
+                    // The same package under other mounts, each with its own
+                    // access rules — which is why the repository it lives in
+                    // says nothing about how readable it is over there.
+                    ->state(fn (Package $record): array => Repository::query()
+                        ->whereKey(array_diff($record->servingRepositoryIds(), [(int) $record->repository_id]))
+                        ->orderBy('name')
+                        ->pluck('name')
+                        ->all())
+                    ->placeholder('Nowhere else'),
                 TextEntry::make('source.name')
                     ->label('Source')
                     ->badge()

--- a/app/Filament/Resources/Packages/Schemas/PackageWizard.php
+++ b/app/Filament/Resources/Packages/Schemas/PackageWizard.php
@@ -69,6 +69,7 @@ class PackageWizard
                     PackageForm::name()
                         ->helperText('Read from the repository\'s composer.json, and overwritten by it again on every sync.'),
                     PackageForm::composerRepository(),
+                    PackageForm::servingRepositories(),
                     PackageForm::description(),
                 ]),
         ];

--- a/app/Filament/Resources/Packages/Tables/PackagesTable.php
+++ b/app/Filament/Resources/Packages/Tables/PackagesTable.php
@@ -55,11 +55,21 @@ class PackagesTable
                         : null)
                     ->placeholder('Uploaded artifacts'),
                 TextColumn::make('composerRepository.name')
-                    ->label('Served in')
+                    ->label('Lives in')
                     ->badge()
                     ->color('gray')
                     ->sortable()
                     ->toggleable(),
+                TextColumn::make('repositories.name')
+                    ->label('Served from')
+                    ->badge()
+                    ->color('gray')
+                    // Every mount that answers for the package, the one it
+                    // lives in included: this column is what a consumer would
+                    // find, and hiding the home repository from a list of
+                    // mounts would make a package served in one place look
+                    // like a package served nowhere.
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('source.name')
                     ->label('Source')
                     ->badge()
@@ -112,7 +122,11 @@ class PackagesTable
             ->filters([
                 SelectFilter::make('composerRepository')
                     ->label('Composer repository')
-                    ->relationship('composerRepository', 'name')
+                    // Through the serving relation rather than the home
+                    // column, so that filtering by a repository lists what
+                    // that repository actually serves — which is the question
+                    // this filter is asked.
+                    ->relationship('repositories', 'name')
                     ->multiple()
                     ->preload(),
                 SelectFilter::make('source')

--- a/app/Filament/Resources/Repositories/RelationManagers/PackagesRelationManager.php
+++ b/app/Filament/Resources/Repositories/RelationManagers/PackagesRelationManager.php
@@ -4,20 +4,30 @@ namespace App\Filament\Resources\Repositories\RelationManagers;
 
 use App\Filament\Resources\Packages\PackageResource;
 use App\Models\Package;
+use App\Models\Repository;
 use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Gate;
+use Throwable;
 
 /**
  * What this repository actually serves.
  *
  * The form above is all configuration — paths, reservations, upstreams — and
- * none of it says what a consumer pointed at the mount would find. Read-only on
- * purpose: a package belongs to a repository from the moment it is created and
- * moving one would change the URL Composer resolves it at, so this lists and
- * links out rather than editing in place.
+ * none of it says what a consumer pointed at the mount would find.
+ *
+ * Two kinds of row, and the difference matters: a package that *lives* here,
+ * which this screen links out to rather than editing in place, and one served
+ * here on top of living somewhere else. The second kind can be added and
+ * removed from this side, because that is the decision this screen is about —
+ * what this mount answers for. Moving a package is still the package's own
+ * form, since it changes the URL Composer resolves it at.
  */
 class PackagesRelationManager extends RelationManager
 {
@@ -41,11 +51,22 @@ class PackagesRelationManager extends RelationManager
                     // rather than opening a modal.
                     ->url(fn (): string => PackageResource::getUrl('create'))
                     ->visible(fn (): bool => PackageResource::canCreate()),
+                $this->serveExisting(),
+            ])
+            ->recordActions([
+                $this->stopServing(),
             ])
             ->columns([
                 TextColumn::make('name')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    // Which of the two kinds of row this is. Said on the name
+                    // rather than in a column of its own, because for most
+                    // repositories every row is the same kind and a column
+                    // repeating "Lives here" is a column nobody reads.
+                    ->description(fn (Package $record): ?string => $record->repository_id === $this->getOwnerRecord()->getKey()
+                        ? null
+                        : 'Served here; lives in '.$record->composerRepository->name),
                 TextColumn::make('latest_version')
                     ->label('Latest version')
                     ->badge()
@@ -62,5 +83,130 @@ class PackagesRelationManager extends RelationManager
                     ->color(fn (Package $record): ?string => $record->sync_error ? 'danger' : null)
                     ->tooltip(fn (Package $record): ?string => $record->sync_error),
             ]);
+    }
+
+    /**
+     * Add a package that lives elsewhere to this repository's mount.
+     *
+     * Not Filament's AttachAction, which would write the pivot row itself: a
+     * serving row carries the package's name for the per-repository unique
+     * index, and the two refusals — a name this repository already answers
+     * for, a vendor another repository has reserved — are decisions worth
+     * stating rather than unique-index errors.
+     */
+    private function serveExisting(): Action
+    {
+        return Action::make('serveExisting')
+            ->label('Serve an existing package')
+            ->icon(Heroicon::OutlinedArrowsRightLeft)
+            ->color('gray')
+            ->modalHeading('Serve an existing package here')
+            ->modalDescription('The same package, answering under this repository\'s mount as well as its own — one row, one sync, one set of archives.')
+            ->modalSubmitActionLabel('Serve here')
+            // The permission the package form asks for, since this is the
+            // same decision made from the other side of it.
+            ->visible(fn (): bool => Gate::allows('Update:Package'))
+            ->schema([
+                Select::make('packages')
+                    ->label('Packages')
+                    ->multiple()
+                    ->required()
+                    ->searchable()
+                    ->options(fn (): array => $this->servableOptions())
+                    ->getSearchResultsUsing(fn (string $search): array => $this->servableOptions($search))
+                    ->helperText('Packages this repository does not serve yet. A name it already answers for cannot be added twice.'),
+            ])
+            ->action(function (array $data): void {
+                $repository = $this->repository();
+                $served = [];
+                $refused = [];
+
+                foreach (Package::query()->whereKey($data['packages'])->get() as $package) {
+                    try {
+                        $package->serveFrom([$repository]);
+                        $served[] = $package->name;
+                    } catch (Throwable $exception) {
+                        // One refusal must not take the rest of the selection
+                        // with it, and it has to be said: silently serving
+                        // three of four is how a consumer's install fails.
+                        $refused[] = "{$package->name}: {$exception->getMessage()}";
+                    }
+                }
+
+                if ($served !== []) {
+                    Notification::make()
+                        ->success()
+                        ->title(count($served).' package(s) now served here')
+                        ->body(implode(', ', $served))
+                        ->send();
+                }
+
+                if ($refused !== []) {
+                    Notification::make()
+                        ->danger()
+                        ->title('Some packages could not be served here')
+                        ->body(implode(' — ', $refused))
+                        ->persistent()
+                        ->send();
+                }
+            });
+    }
+
+    /**
+     * Stop serving a package that lives somewhere else.
+     *
+     * Only ever offered for those: a package's home repository is where it
+     * lives, and detaching it from that is a move rather than a removal.
+     */
+    private function stopServing(): Action
+    {
+        return Action::make('stopServing')
+            ->label('Stop serving')
+            ->icon(Heroicon::OutlinedMinusCircle)
+            ->color('danger')
+            ->requiresConfirmation()
+            ->modalHeading('Stop serving this package here')
+            ->modalDescription('Consumers resolving it through this mount will stop finding it. The package itself, and every other repository serving it, is untouched.')
+            ->visible(fn (Package $record): bool => $record->repository_id !== $this->getOwnerRecord()->getKey()
+                && Gate::allows('update', $record))
+            ->action(function (Package $record): void {
+                $record->stopServingFrom([$this->repository()]);
+
+                Notification::make()
+                    ->success()
+                    ->title("{$record->name} is no longer served here")
+                    ->send();
+            });
+    }
+
+    /**
+     * The repository this screen hangs off, typed. `getOwnerRecord()` answers
+     * `Model`, and everything below wants the two methods only a Repository
+     * has.
+     */
+    private function repository(): Repository
+    {
+        return Repository::query()->findOrFail($this->getOwnerRecord()->getKey());
+    }
+
+    /**
+     * The packages this repository could serve and does not, as options.
+     *
+     * Bounded rather than exhaustive: a registry is allowed to hold more
+     * packages than a select can render, which is what the search is for.
+     *
+     * @return array<int, string>
+     */
+    private function servableOptions(?string $search = null): array
+    {
+        $repository = $this->repository();
+
+        return Package::query()
+            ->whereDoesntHave('repositories', fn (Builder $query) => $query->whereKey($repository->getKey()))
+            ->when($search !== null, fn (Builder $query) => $query->where('name', 'like', '%'.$search.'%'))
+            ->orderBy('name')
+            ->limit(50)
+            ->pluck('name', 'id')
+            ->all();
     }
 }

--- a/app/Filament/Resources/Repositories/RelationManagers/PackagesRelationManager.php
+++ b/app/Filament/Resources/Repositories/RelationManagers/PackagesRelationManager.php
@@ -192,6 +192,11 @@ class PackagesRelationManager extends RelationManager
     /**
      * The packages this repository could serve and does not, as options.
      *
+     * Labelled with where each one lives, not the composer name alone: the
+     * same name may live in several repositories, and two options reading
+     * "acme/widgets" are a coin toss on which package this mount ends up
+     * serving.
+     *
      * Bounded rather than exhaustive: a registry is allowed to hold more
      * packages than a select can render, which is what the search is for.
      *
@@ -204,9 +209,13 @@ class PackagesRelationManager extends RelationManager
         return Package::query()
             ->whereDoesntHave('repositories', fn (Builder $query) => $query->whereKey($repository->getKey()))
             ->when($search !== null, fn (Builder $query) => $query->where('name', 'like', '%'.$search.'%'))
+            ->with('composerRepository')
             ->orderBy('name')
             ->limit(50)
-            ->pluck('name', 'id')
+            ->get()
+            ->mapWithKeys(fn (Package $package): array => [
+                $package->id => "{$package->name} — lives in {$package->composerRepository->name}",
+            ])
             ->all();
     }
 }

--- a/app/Http/Controllers/Api/V1/PackageController.php
+++ b/app/Http/Controllers/Api/V1/PackageController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Exceptions\NameCollision;
+use App\Exceptions\VendorReserved;
 use App\Http\Resources\Api\V1\PackageDetailResource;
 use App\Http\Resources\Api\V1\PackageResource;
 use App\Jobs\SyncPackageJob;
@@ -61,11 +63,14 @@ class PackageController extends ApiController
             // Present but empty is the root repository, whose path is null —
             // the one repository that cannot be named by a path because it is
             // not mounted under one.
+            // Through the serving relation, not the home column: what a caller
+            // filtering by a repository is asking is what that repository
+            // serves, and a package added to it answers there like any other.
             ->when($request->has('repository'), fn (Builder $query) => $query->whereHas(
-                'composerRepository',
+                'repositories',
                 fn (Builder $repositories) => $repositories->where('path', $validated['repository'] ?? null),
             ))
-            ->with('composerRepository')
+            ->with(['composerRepository', 'repositories'])
             ->withCount('versions')
             ->orderBy('name')
             ->paginate($this->perPage($request));
@@ -79,7 +84,7 @@ class PackageController extends ApiController
 
         // Newest first, the order /p2 serves and the order a caller checking
         // "has my release landed yet" reads.
-        $record->load('composerRepository')->loadCount('versions');
+        $record->load(['composerRepository', 'repositories'])->loadCount('versions');
         $record->setRelation('versions', $record->versions()->orderedByVersion()->get());
 
         return new PackageDetailResource($record);
@@ -168,7 +173,7 @@ class PackageController extends ApiController
 
         $queued = $request->boolean('sync', true) && SyncPackageJob::dispatchUnlessPending($package);
 
-        $package->load('composerRepository')->loadCount('versions');
+        $package->load(['composerRepository', 'repositories'])->loadCount('versions');
 
         return (new PackageDetailResource($package))
             ->additional([
@@ -236,7 +241,7 @@ class PackageController extends ApiController
         // polling for completion knows which run it is watching.
         $queued = SyncPackageJob::dispatchUnlessPending($record, force: $request->boolean('force'));
 
-        $record->load('composerRepository')->loadCount('versions');
+        $record->load(['composerRepository', 'repositories'])->loadCount('versions');
 
         return (new PackageDetailResource($record))
             ->additional(['sync_queued' => $queued])
@@ -244,6 +249,92 @@ class PackageController extends ApiController
             // Accepted, not OK: the versions are imported by a worker, and the
             // package in this body is the one from before that ran.
             ->setStatusCode(202);
+    }
+
+    /**
+     * Add a package to another Composer repository, which then serves the same
+     * package under its own mount — the panel's "Also served from", scriptable.
+     *
+     * Two grants, because it is two decisions: a change to the package, and a
+     * change to what the target repository publishes. A credential that may
+     * publish into a repository cannot pull somebody else's package into it,
+     * and one that may change a package cannot publish it somewhere it has no
+     * standing.
+     */
+    public function serve(Request $request, string $package): JsonResponse
+    {
+        $record = $this->find($request, $package);
+        $repository = $this->targetRepository($request);
+
+        $this->authorizeServing($request, $record, $repository);
+
+        try {
+            $record->serveFrom([$repository]);
+        } catch (NameCollision|VendorReserved $exception) {
+            // Both are refusals about the *name* under the target mount, and
+            // both read as a 422 on the field that has to change — the same
+            // treatment store() gives a reserved vendor.
+            throw ValidationException::withMessages(['repository' => $exception->getMessage()]);
+        }
+
+        return $this->served($record);
+    }
+
+    /**
+     * Stop a repository serving a package that lives somewhere else.
+     *
+     * Never the repository it lives in: that is a move, and moving a package
+     * changes the URL Composer resolves it at. A repository that does not
+     * serve it is not an error either — the request asked for a state that
+     * already holds.
+     */
+    public function unserve(Request $request, string $package): JsonResponse
+    {
+        $record = $this->find($request, $package);
+        $repository = $this->targetRepository($request);
+
+        $this->authorizeServing($request, $record, $repository);
+
+        if ($repository->getKey() === $record->repository_id) {
+            throw ValidationException::withMessages([
+                'repository' => "\"{$record->name}\" lives in this Composer repository. Move it to another one instead.",
+            ]);
+        }
+
+        $record->stopServingFrom([$repository]);
+
+        return $this->served($record);
+    }
+
+    /**
+     * The two grants a serving change asks for. @see serve()
+     */
+    private function authorizeServing(Request $request, Package $package, Repository $repository): void
+    {
+        $token = $this->token($request);
+
+        abort_unless(
+            $token->mayWriteToPackage($package),
+            403,
+            'This token may not change this package.',
+        );
+
+        abort_unless(
+            $token->mayWriteTo($repository),
+            403,
+            'This token may not publish into that repository.',
+        );
+    }
+
+    /**
+     * The package as it now stands, with the repositories serving it — which
+     * is the whole of what either endpoint above changed.
+     */
+    private function served(Package $package): JsonResponse
+    {
+        $package->load(['composerRepository', 'repositories'])->loadCount('versions');
+
+        return (new PackageDetailResource($package))->response();
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/PackageController.php
+++ b/app/Http/Controllers/Api/V1/PackageController.php
@@ -9,7 +9,6 @@ use App\Http\Resources\Api\V1\PackageResource;
 use App\Jobs\SyncPackageJob;
 use App\Models\Package;
 use App\Models\Repository;
-use App\Models\ReservedVendor;
 use App\Services\GitHub\WebhookRegistrar;
 use App\Support\ComposerName;
 use Illuminate\Database\Eloquent\Builder;
@@ -157,13 +156,17 @@ class PackageController extends ApiController
 
         $package->name = mb_strtolower($name);
 
-        // The model refuses this on save too, by throwing; asked here it is a
-        // 422 on the field that has to change, like every other name problem
-        // this endpoint reports.
-        $conflict = ReservedVendor::conflictFor($package->name, $repository->id);
+        // The model refuses these on save too, by throwing; asked here they
+        // are a 422 on the field that has to change, like every other name
+        // problem this endpoint reports. Both of a serving refusal's questions
+        // apply: a reserved vendor, and a name the repository already serves
+        // from a package that lives elsewhere — which the unique rule above
+        // cannot see, because shares live on the pivot rather than in
+        // packages.repository_id.
+        $refusal = Package::servingRefusal($package->name, $repository->id);
 
-        if ($conflict instanceof ReservedVendor) {
-            throw ValidationException::withMessages(['name' => $conflict->refusal($package->name)]);
+        if ($refusal !== null) {
+            throw ValidationException::withMessages(['name' => $refusal]);
         }
 
         $package->save();

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -556,7 +556,7 @@ class ComposerRepositoryController extends Controller
         $name = mb_strtolower("{$vendor}/".($dev ? substr($package, 0, -4) : $package));
 
         $record = $repository->packages()
-            ->visibleTo($this->token($request))
+            ->visibleTo($this->token($request), $repository)
             ->where('name', $name)
             ->first();
 
@@ -924,7 +924,7 @@ class ComposerRepositoryController extends Controller
         $repository = $this->repository($request);
 
         $record = $repository->packages()
-            ->visibleTo($this->token($request))
+            ->visibleTo($this->token($request), $repository)
             ->where('name', $name)
             ->first();
 
@@ -1174,8 +1174,10 @@ class ComposerRepositoryController extends Controller
      */
     private function servedPackages(Request $request): Builder
     {
-        return $this->repository($request)->packages()
-            ->visibleTo($this->token($request))
+        $repository = $this->repository($request);
+
+        return $repository->packages()
+            ->visibleTo($this->token($request), $repository)
             ->has('versions')
             ->getQuery();
     }

--- a/app/Http/Controllers/Pages/PackageArchiveController.php
+++ b/app/Http/Controllers/Pages/PackageArchiveController.php
@@ -55,7 +55,10 @@ class PackageArchiveController extends Controller
 
         abort_unless($found instanceof Package, 404, 'No package page is published at this address.');
 
-        $offered = $found->pageDownloads();
+        // Through this mount, not through wherever the package lives: a
+        // private repository serving a package that is public elsewhere still
+        // offers nothing to an anonymous visitor. @see Package::pageDownloads()
+        $offered = $found->servedFrom($repository)->pageDownloads();
 
         abort_if(
             $offered === PageDownloads::None,

--- a/app/Http/Controllers/Pages/PackageAssetController.php
+++ b/app/Http/Controllers/Pages/PackageAssetController.php
@@ -72,6 +72,8 @@ class PackageAssetController extends Controller
 
         abort_unless($found instanceof Package, 404, 'No package page is published at this address.');
 
+        $found->servedFrom($repository);
+
         $type = $this->contentType($path);
 
         $contents = $this->contents($found, $this->confine($path));

--- a/app/Http/Controllers/Pages/PackagePageController.php
+++ b/app/Http/Controllers/Pages/PackagePageController.php
@@ -73,6 +73,11 @@ class PackagePageController extends Controller
 
         abort_unless($found instanceof Package, 404, 'No package page is published at this address.');
 
-        return $found;
+        // The package may be served from several repositories, and everything
+        // this page prints that is about a *mount* rather than about the
+        // package — the URL to configure, the install commands, whether an
+        // anonymous visitor may download anything — belongs to the one that
+        // was asked for. @see Package::servingRepository()
+        return $found->servedFrom($repository);
     }
 }

--- a/app/Http/Controllers/Pages/SitemapController.php
+++ b/app/Http/Controllers/Pages/SitemapController.php
@@ -122,20 +122,26 @@ class SitemapController extends Controller
 
         Package::query()
             ->withPage()
-            ->with('composerRepository')
+            // Every repository serving the package rather than the one it
+            // lives in: a package added to two repositories has a page under
+            // each mount, and each is a distinct URL a crawler can reach.
+            ->with('repositories')
             ->orderBy('id')
             // Chunked because this is one query over a table that is allowed
             // to be enormous, answered for an anonymous request.
             ->limit(self::MAX_URLS)
             ->each(function (Package $package) use (&$urls): void {
-                $urls[] = [
-                    'loc' => $package->pageUrl(),
-                    // What a crawler asks this for is "has the thing at that
-                    // URL changed", and for a package page the answer is a
-                    // release or an edit — not the hourly sync that writes
-                    // `last_synced_at` whether or not anything moved.
-                    'lastmod' => $package->updated_at?->toAtomString(),
-                ];
+                foreach ($package->repositories as $repository) {
+                    $urls[] = [
+                        'loc' => $package->servedFrom($repository)->pageUrl(),
+                        // What a crawler asks this for is "has the thing at
+                        // that URL changed", and for a package page the answer
+                        // is a release or an edit — not the hourly sync that
+                        // writes `last_synced_at` whether or not anything
+                        // moved.
+                        'lastmod' => $package->updated_at?->toAtomString(),
+                    ];
+                }
             });
 
         return $urls;

--- a/app/Http/Resources/Api/V1/PackageResource.php
+++ b/app/Http/Resources/Api/V1/PackageResource.php
@@ -45,7 +45,14 @@ class PackageResource extends JsonResource
             'abandoned' => $this->abandoned,
             'replacement_package' => $this->replacement_package,
             'downloads' => $this->total_downloads,
+            // Where the package lives — the repository it is published into,
+            // and the mount its page URL is cut from.
             'repository' => new RepositoryResource($this->whenLoaded('composerRepository')),
+            // Every repository serving it, the one above included. A package
+            // can be added to any number of them, each with its own mount and
+            // its own access rules, and this is the list a consumer's
+            // composer.json could point at.
+            'repositories' => RepositoryResource::collection($this->whenLoaded('repositories')),
             'sync' => $this->syncState($request),
             'versions_count' => $this->whenCounted('versions'),
             'created_at' => $this->created_at?->toIso8601String(),

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -172,6 +172,8 @@ class Package extends Model
             // package lands in is half of the question this asks.
             $package->guardReservedVendor();
 
+            $package->guardServedName();
+
             $package->linkSource();
 
             // Derived after the source is linked, not before: the parse is
@@ -315,6 +317,25 @@ class Package extends Model
     public function repositories(): BelongsToMany
     {
         return $this->belongsToMany(Repository::class)->withPivot('package_name');
+    }
+
+    /**
+     * Narrow to the packages that live in the repository mounted at the given
+     * path — the console commands' disambiguator, so it reads a path the way
+     * their repo arguments do: "root" and the empty string name the registry
+     * root, whose path is null and could otherwise not be picked at all.
+     *
+     * @param  Builder<self>  $query
+     * @return Builder<self>
+     */
+    public function scopeLivingIn(Builder $query, string $path): Builder
+    {
+        $path = trim($path);
+
+        return $query->whereHas('composerRepository', fn (Builder $repositories) => $repositories->where(
+            'path',
+            $path === '' || $path === 'root' ? null : $path,
+        ));
     }
 
     /**
@@ -940,6 +961,39 @@ class Package extends Model
             if ($conflict instanceof ReservedVendor) {
                 throw new VendorReserved($conflict, (string) $this->name);
             }
+        }
+    }
+
+    /**
+     * Refuse a name that some other package already publishes on a mount this
+     * one will be served from — the guarantee the packages table's
+     * (repository_id, name) unique index cannot see, because a share lives on
+     * the pivot alone.
+     *
+     * The same shape as guardReservedVendor() above, for the same reasons:
+     * only when the name or the home is actually moving, and a throw rather
+     * than a silent correction. Every serving row is rewritten from these two
+     * columns the moment the save lands (see reconcileServingRepositories),
+     * so a collision left unasked here surfaces there as a bare unique-index
+     * error instead of a refusal anybody can act on.
+     *
+     * Checked against every repository the save will write a row into: the
+     * current mounts, which a rename lands the new name on all at once, plus
+     * the home being moved into, which is not on the pivot yet.
+     *
+     * @throws NameCollision
+     */
+    public function guardServedName(): void
+    {
+        if (! $this->isDirty('name') && ! $this->isDirty('repository_id')) {
+            return;
+        }
+
+        foreach (array_unique([...$this->servingRepositoryIds(), (int) $this->repository_id]) as $repositoryId) {
+            throw_if(
+                self::nameServedElsewhere((string) $this->name, $repositoryId, $this->getKey()),
+                new NameCollision(self::collisionRefusal((string) $this->name)),
+            );
         }
     }
 

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -896,10 +896,16 @@ class Package extends Model
             return;
         }
 
-        $conflict = ReservedVendor::conflictFor((string) $this->name, (int) $this->repository_id);
+        // Every repository serving this package, not only the one it lives
+        // in: a rename lands the new name under every mount at once, and a
+        // vendor reserved by one of the others is refused there for exactly
+        // the reason it is refused here.
+        foreach ($this->servingRepositoryIds() as $repositoryId) {
+            $conflict = ReservedVendor::conflictFor((string) $this->name, $repositoryId);
 
-        if ($conflict instanceof ReservedVendor) {
-            throw new VendorReserved($conflict, (string) $this->name);
+            if ($conflict instanceof ReservedVendor) {
+                throw new VendorReserved($conflict, (string) $this->name);
+            }
         }
     }
 
@@ -1245,7 +1251,7 @@ class Package extends Model
             // Which entry in the consumer's composer.json this repository
             // claims, and what it is pointed at, is the repository's own
             // decision — the same line its landing page prints.
-            'repository' => $this->composerRepository->configureCommand(),
+            'repository' => $this->servingRepository()->configureCommand(),
             'require' => "composer require {$require}",
         ];
     }
@@ -1351,7 +1357,7 @@ class Package extends Model
     {
         [$vendor, $name] = explode('/', (string) $this->name, 2) + ['', ''];
 
-        return $this->composerRepository->url('/p/'.$vendor.'/'.$name);
+        return $this->servingRepository()->url('/p/'.$vendor.'/'.$name);
     }
 
     /**
@@ -1417,7 +1423,7 @@ class Package extends Model
      */
     public function pageDownloads(): PageDownloads
     {
-        if (! $this->composerRepository->public) {
+        if (! $this->servingRepository()->public) {
             return PageDownloads::None;
         }
 
@@ -1436,7 +1442,7 @@ class Package extends Model
      */
     public function pageShowsInstall(): bool
     {
-        return (bool) $this->page_install && $this->composerRepository->public;
+        return (bool) $this->page_install && $this->servingRepository()->public;
     }
 
     /**
@@ -1446,7 +1452,7 @@ class Package extends Model
      */
     public function pageRequiresAccess(): bool
     {
-        return ! $this->composerRepository->public;
+        return ! $this->servingRepository()->public;
     }
 
     /**
@@ -1530,7 +1536,7 @@ class Package extends Model
 
         [$vendor, $name] = explode('/', (string) $this->name, 2) + ['', ''];
 
-        return $this->composerRepository->url('/p/'.$vendor.'/'.$name.'/asset');
+        return $this->servingRepository()->url('/p/'.$vendor.'/'.$name.'/asset');
     }
 
     /**
@@ -1630,7 +1636,7 @@ class Package extends Model
 
         return str_starts_with($fallback, 'http://') || str_starts_with($fallback, 'https://')
             ? $fallback
-            : $this->composerRepository->pageRootUrl().'/'.ltrim($fallback, '/');
+            : $this->servingRepository()->pageRootUrl().'/'.ltrim($fallback, '/');
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -6,6 +6,7 @@ use App\Enums\PageBodySource;
 use App\Enums\PageDownloads;
 use App\Enums\SourceProvider;
 use App\Enums\WebhookCoverage;
+use App\Exceptions\NameCollision;
 use App\Exceptions\VendorReserved;
 use App\Jobs\RefreshPackagePage;
 use App\Models\Concerns\LogsAuditableChanges;
@@ -18,6 +19,7 @@ use App\Services\GitLab\GitLabClient;
 use App\Services\PackageSynchronizer;
 use App\Sources\RepositoryClient;
 use App\Sources\StubClient;
+use App\Support\AuditedBelongsToMany;
 use Database\Factories\PackageFactory;
 use Illuminate\Bus\Batch;
 use Illuminate\Bus\BatchRepository;
@@ -27,7 +29,9 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -69,6 +73,15 @@ class Package extends Model
         // ever been read back from the database.
         'subdirectory' => '',
     ];
+
+    /**
+     * The repository this package is answering as part of, when a request
+     * resolved it inside one. Not an attribute: it is a property of the
+     * request rather than of the package, and it is never stored.
+     *
+     * @see servingRepository()
+     */
+    protected ?Repository $servingRepository = null;
 
     /**
      * Publishing decisions, and who the package authenticates as. Sync
@@ -168,6 +181,13 @@ class Package extends Model
             // re-derived under the provider that now applies.
             $package->repository_path = $package->normalizedRepositoryPath();
         });
+
+        // The pivot that says where this package is served is derived from
+        // this row in one direction only — the home repository and the name
+        // are decided here, and every serving row has to agree with them.
+        // Anything else is a package reachable under a name it no longer has,
+        // or served from a repository it was moved out of.
+        static::saved(fn (self $package) => $package->reconcileServingRepositories());
 
         // Announced from `saved` rather than from the panel action that usually
         // raises the flag, because it is not the only one: the API, a console
@@ -271,6 +291,287 @@ class Package extends Model
     public function composerRepository(): BelongsTo
     {
         return $this->belongsTo(Repository::class, 'repository_id');
+    }
+
+    /**
+     * Every Composer repository this package is served from: the home
+     * repository above, plus every other one it has been added to.
+     *
+     * This is the relation the serving paths read from — `/p2`, `/dist`, the
+     * page, the upload endpoint and the API all resolve a package *within a
+     * repository*, and all of them do it through Repository::packages(),
+     * which is the other side of this. A package added to two repositories is
+     * one row, one sync, one set of archives and one download counter,
+     * answering under both mounts.
+     *
+     * Reads only. Every write goes through serveFrom()/stopServingFrom()
+     * below, because a serving row carries the name it was written with and
+     * because the checks that guard it — a name the target repository already
+     * serves, a vendor another repository has reserved — have to run before
+     * the row exists rather than as a unique-index failure afterwards.
+     *
+     * @return BelongsToMany<Repository, $this>
+     */
+    public function repositories(): BelongsToMany
+    {
+        return $this->belongsToMany(Repository::class)->withPivot('package_name');
+    }
+
+    /**
+     * The repository this package is being served through right now, which is
+     * its home unless a request said otherwise.
+     *
+     * One package can be reached under several mounts, and almost everything
+     * a page prints about it is a property of the mount rather than of the
+     * package: the URL to configure, the install commands, whether an
+     * anonymous visitor may download an archive at all. A page rendered under
+     * /r/internal that printed the public repository's `composer config` line
+     * because that is where the package happens to live would be telling the
+     * visitor to fetch it from somewhere they were not asking about.
+     *
+     * @see servedFrom() for how a request sets it
+     */
+    public function servingRepository(): Repository
+    {
+        return $this->servingRepository ?? $this->composerRepository;
+    }
+
+    /**
+     * Answer as the copy of this package that the given repository serves.
+     *
+     * Set by the controllers that resolve a package inside a mount, and by
+     * nothing else: a package read from the panel, a notification or an export
+     * has no mount to speak of and falls back to its home.
+     */
+    public function servedFrom(Repository $repository): static
+    {
+        $this->servingRepository = $repository;
+
+        return $this;
+    }
+
+    /**
+     * Add this package to the given repositories, on top of wherever it is
+     * already served.
+     *
+     * Silent about repositories it is already served from — adding a package
+     * where it already is, is not a change and not an error — and refuses the
+     * two things that would leave a repository unable to answer for a name:
+     * another package already publishing it there, and a vendor prefix some
+     * other repository has reserved.
+     *
+     * @param  iterable<int, Repository|int>  $repositories
+     *
+     * @throws VendorReserved
+     * @throws NameCollision
+     */
+    public function serveFrom(iterable $repositories): void
+    {
+        $ids = $this->repositoryKeys($repositories);
+        $added = array_values(array_diff($ids, $this->servingRepositoryIds()));
+
+        if ($added === []) {
+            return;
+        }
+
+        foreach ($added as $id) {
+            $this->guardServingIn($id);
+        }
+
+        $timestamp = $this->freshTimestamp();
+
+        DB::table('package_repository')->insert(array_map(fn (int $id): array => [
+            'package_id' => $this->getKey(),
+            'repository_id' => $id,
+            'package_name' => (string) $this->name,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ], $added));
+
+        $this->recordServingChange('serving_added', $added);
+
+        $this->unsetRelation('repositories');
+    }
+
+    /**
+     * Stop serving this package from the given repositories.
+     *
+     * The home repository is never one of them: a package is *somewhere*, and
+     * a row detached from its home would be a package with no canonical page
+     * and no repository its name is unique within. Moving a package is
+     * changing `repository_id`, which the panel offers and which carries the
+     * old home out with it.
+     *
+     * @param  iterable<int, Repository|int>  $repositories
+     */
+    public function stopServingFrom(iterable $repositories): void
+    {
+        $removed = array_values(array_diff(
+            array_intersect($this->repositoryKeys($repositories), $this->servingRepositoryIds()),
+            [(int) $this->repository_id],
+        ));
+
+        if ($removed === []) {
+            return;
+        }
+
+        DB::table('package_repository')
+            ->where('package_id', $this->getKey())
+            ->whereIn('repository_id', $removed)
+            ->delete();
+
+        $this->recordServingChange('serving_removed', $removed);
+
+        $this->unsetRelation('repositories');
+    }
+
+    /**
+     * Serve this package from exactly these repositories, adding and removing
+     * to get there — what a multi-select on a form means when it is saved.
+     *
+     * The home repository is added to whatever is asked for rather than
+     * validated against it, so a form that leaves it out cannot detach a
+     * package from the repository it lives in.
+     *
+     * @param  iterable<int, Repository|int>  $repositories
+     */
+    public function syncServingRepositories(iterable $repositories): void
+    {
+        $wanted = array_values(array_unique(array_merge(
+            [(int) $this->repository_id],
+            $this->repositoryKeys($repositories),
+        )));
+
+        $this->stopServingFrom(array_diff($this->servingRepositoryIds(), $wanted));
+        $this->serveFrom($wanted);
+    }
+
+    /**
+     * The ids of the repositories serving this package, home first.
+     *
+     * Read from the pivot rather than through the relation, because every
+     * caller here is comparing ids and loading the repository rows to compare
+     * their keys is a join for nothing.
+     *
+     * @return list<int>
+     */
+    public function servingRepositoryIds(): array
+    {
+        if ($this->getKey() === null) {
+            return [(int) $this->repository_id];
+        }
+
+        return DB::table('package_repository')
+            ->where('package_id', $this->getKey())
+            ->orderByRaw('repository_id = ? desc', [(int) $this->repository_id])
+            ->orderBy('repository_id')
+            ->pluck('repository_id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+    }
+
+    /**
+     * Whether the given repository may serve this package under its name.
+     *
+     * @throws VendorReserved
+     * @throws NameCollision
+     */
+    private function guardServingIn(int $repositoryId): void
+    {
+        $reservation = ReservedVendor::conflictFor((string) $this->name, $repositoryId);
+
+        throw_if($reservation instanceof ReservedVendor, fn (): VendorReserved => new VendorReserved($reservation, (string) $this->name));
+
+        $taken = DB::table('package_repository')
+            ->where('repository_id', $repositoryId)
+            ->where('package_name', (string) $this->name)
+            ->where('package_id', '!=', $this->getKey())
+            ->exists();
+
+        throw_if($taken, new NameCollision(
+            "The \"{$this->name}\" name is already served by that Composer repository, so this package "
+            .'cannot be added to it as well. One repository answers for one package per name.'
+        ));
+    }
+
+    /**
+     * The keys behind whatever a caller passed — models, ids, or a mix.
+     *
+     * @param  iterable<int, Repository|int>  $repositories
+     * @return list<int>
+     */
+    private function repositoryKeys(iterable $repositories): array
+    {
+        $keys = [];
+
+        foreach ($repositories as $repository) {
+            $keys[] = $repository instanceof Repository ? (int) $repository->getKey() : (int) $repository;
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * File the change where grants are filed.
+     *
+     * Where a package is served from is not a permission, but it is read the
+     * same way and asked about for the same reasons — "when did this land in
+     * the public repository, and who put it there" — and the attribute diff
+     * that catches every other change to a package cannot see a pivot row.
+     *
+     * @see AuditedBelongsToMany for the same problem one pivot over
+     *
+     * @param  list<int>  $ids
+     */
+    private function recordServingChange(string $event, array $ids): void
+    {
+        $names = Repository::query()->whereKey($ids)->pluck('name')->all();
+
+        activity('audit')
+            ->performedOn($this)
+            ->event($event)
+            ->withProperties(['repositories' => $names])
+            ->log($event);
+    }
+
+    /**
+     * Make the serving rows agree with this row, after every save.
+     *
+     * Three things can put them out of step, and all three are ordinary edits:
+     * a package created (which has no serving row yet), a package moved to
+     * another home repository, and a package renamed — including the rename a
+     * sync adopts on a package that has never been synced, which is where a
+     * stale `package_name` would go unnoticed longest.
+     */
+    private function reconcileServingRepositories(): void
+    {
+        $rows = fn (): \Illuminate\Database\Query\Builder => DB::table('package_repository')->where('package_id', $this->getKey());
+
+        // Out of the repository it left. A move is not a share: what the panel
+        // offers is one repository the package lives in, and leaving the old
+        // row behind would go on serving it from both.
+        if ($this->wasChanged('repository_id')) {
+            $rows()->where('repository_id', $this->getOriginal('repository_id'))->delete();
+        }
+
+        if ($this->wasChanged('name')) {
+            $rows()->update([
+                'package_name' => (string) $this->name,
+                'updated_at' => $this->freshTimestamp(),
+            ]);
+        }
+
+        if (! $rows()->where('repository_id', $this->repository_id)->exists()) {
+            $timestamp = $this->freshTimestamp();
+
+            DB::table('package_repository')->insert([
+                'package_id' => $this->getKey(),
+                'repository_id' => (int) $this->repository_id,
+                'package_name' => (string) $this->name,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ]);
+        }
     }
 
     /**

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -582,30 +582,63 @@ class Package extends Model
      * exactly what its owner does. A deploy token sees public repositories
      * plus whatever it was granted — or everything, when it holds no grants.
      *
+     * `$through` is the repository the request is addressed to, and it is what
+     * a package served from several of them is judged by. A package is
+     * readable *through a mount*, never in the abstract: one added to both a
+     * public repository and a private one is public under the first and
+     * private under the second, and asking whether any repository serving it
+     * is public would publish the private mount's copy to anyone who found the
+     * URL. The Composer endpoints and the pages therefore always pass their
+     * mount; the panel-wide readers pass nothing, where the question really is
+     * "may this person see this package at all".
+     *
      * @param  Builder<self>  $query
      * @return Builder<self>
      */
-    public function scopeVisibleTo(Builder $query, ?Token $token): Builder
+    public function scopeVisibleTo(Builder $query, ?Token $token, ?Repository $through = null): Builder
     {
         $principal = $token?->tokenable;
 
         if ($principal instanceof User) {
-            return $query->visibleToUser($principal);
+            return $query->visibleToUser($principal, $through);
         }
 
         if ($principal instanceof DeployToken && ! $principal->isScoped()) {
             return $query;
         }
 
-        return $query->where(function (Builder $query) use ($principal): void {
-            $query->whereHas('composerRepository', fn (Builder $repositories) => $repositories->where('public', true));
+        // A mount everything on it may be read from asks nothing of the
+        // database — which is the common case, and cheaper than the subquery
+        // this scope ran before there was anything to be through.
+        if ($through instanceof Repository && $this->readableWholesale($principal, $through)) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $query) use ($principal, $through): void {
+            $query->whereHas('repositories', fn (Builder $repositories) => $repositories
+                ->when($through instanceof Repository, fn (Builder $one) => $one->whereKey($through->getKey()))
+                ->where(function (Builder $readable) use ($principal): void {
+                    $readable->where('public', true);
+
+                    if ($principal instanceof DeployToken) {
+                        $readable->orWhereIn('repositories.id', $principal->repositories()->select('repositories.id'));
+                    }
+                }));
 
             if ($principal instanceof DeployToken) {
-                $query
-                    ->orWhereIn('packages.id', $principal->packages()->select('packages.id'))
-                    ->orWhereIn('packages.repository_id', $principal->repositories()->select('repositories.id'));
+                $query->orWhereIn('packages.id', $principal->packages()->select('packages.id'));
             }
         });
+    }
+
+    /**
+     * Whether this mount is readable in full by the principal, whatever it
+     * happens to serve.
+     */
+    private function readableWholesale(mixed $principal, Repository $through): bool
+    {
+        return $through->public
+            || ($principal instanceof DeployToken && $principal->repositories()->whereKey($through->getKey())->exists());
     }
 
     /**
@@ -630,16 +663,26 @@ class Package extends Model
      * @param  Builder<self>  $query
      * @return Builder<self>
      */
-    public function scopeVisibleToUser(Builder $query, User $user): Builder
+    public function scopeVisibleToUser(Builder $query, User $user, ?Repository $through = null): Builder
     {
         if ($user->hasUnscopedAccess()) {
             return $query;
         }
 
-        return $query->where(function (Builder $query) use ($user): void {
-            $query->whereHas('composerRepository', fn (Builder $repositories) => $repositories->where('public', true))
-                ->orWhereIn('packages.id', $user->packageGrants())
-                ->orWhereIn('packages.repository_id', $user->repositoryGrants());
+        // As in visibleTo(): a mount this person reaches wholesale settles the
+        // question without a subquery, and the grant is asked for as one
+        // indexed existence check rather than as a union per row.
+        if ($through instanceof Repository && ($through->public || $user->isGrantedRepository($through))) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $query) use ($user, $through): void {
+            $query->whereHas('repositories', fn (Builder $repositories) => $repositories
+                ->when($through instanceof Repository, fn (Builder $one) => $one->whereKey($through->getKey()))
+                ->where(fn (Builder $readable) => $readable
+                    ->where('public', true)
+                    ->orWhereIn('repositories.id', $user->repositoryGrants())))
+                ->orWhereIn('packages.id', $user->packageGrants());
         });
     }
 

--- a/app/Models/Package.php
+++ b/app/Models/Package.php
@@ -482,16 +482,50 @@ class Package extends Model
 
         throw_if($reservation instanceof ReservedVendor, fn (): VendorReserved => new VendorReserved($reservation, (string) $this->name));
 
-        $taken = DB::table('package_repository')
-            ->where('repository_id', $repositoryId)
-            ->where('package_name', (string) $this->name)
-            ->where('package_id', '!=', $this->getKey())
-            ->exists();
+        throw_if(
+            self::nameServedElsewhere((string) $this->name, $repositoryId, $this->getKey()),
+            new NameCollision(self::collisionRefusal((string) $this->name)),
+        );
+    }
 
-        throw_if($taken, new NameCollision(
-            "The \"{$this->name}\" name is already served by that Composer repository, so this package "
-            .'cannot be added to it as well. One repository answers for one package per name.'
-        ));
+    /**
+     * Why a repository cannot serve this name, in the words a form field and
+     * an action's error notification both show — or null when it can.
+     *
+     * The same two questions serveFrom() throws over, asked where an answer is
+     * still useful: a select that greys nothing out and then fails on save is
+     * a worse screen than one that says why while the admin is looking at it.
+     */
+    public static function servingRefusal(string $name, int $repositoryId, ?int $except = null): ?string
+    {
+        $reservation = ReservedVendor::conflictFor($name, $repositoryId);
+
+        if ($reservation instanceof ReservedVendor) {
+            return $reservation->refusal($name);
+        }
+
+        return self::nameServedElsewhere($name, $repositoryId, $except)
+            ? self::collisionRefusal($name)
+            : null;
+    }
+
+    /**
+     * Whether some other package already answers for this name in the given
+     * repository.
+     */
+    private static function nameServedElsewhere(string $name, int $repositoryId, ?int $except): bool
+    {
+        return DB::table('package_repository')
+            ->where('repository_id', $repositoryId)
+            ->where('package_name', $name)
+            ->when($except !== null, fn ($query) => $query->where('package_id', '!=', $except))
+            ->exists();
+    }
+
+    private static function collisionRefusal(string $name): string
+    {
+        return "The \"{$name}\" name is already served by that Composer repository, so this package "
+            .'cannot be added to it as well. One repository answers for one package per name.';
     }
 
     /**

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -19,7 +19,8 @@ use Illuminate\Support\Str;
 /**
  * A named Composer repository this registry serves.
  *
- * Every package belongs to exactly one repository. The default repository
+ * Every package lives in exactly one repository and can be served from any
+ * number of others; @see Package::repositories(). The default repository
  * (path null) answers at the site root, exactly as the registry did before
  * repositories existed; every other repository is mounted under /r/{path},
  * so one installation can serve independent registries — a public one and an

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Str;
@@ -65,9 +66,33 @@ class Repository extends Model
     }
 
     /**
+     * The packages this repository serves — the ones that live here and the
+     * ones that were added on top.
+     *
+     * A many-to-many rather than the `hasMany` it was, because a package is
+     * served from any number of repositories now. `packages.repository_id`
+     * still says where each one *lives*, and Package::composerRepository()
+     * still reads it; this says where each one *answers*, which is what every
+     * serving path wants and the only thing that changed underneath them.
+     *
+     * @return BelongsToMany<Package, $this>
+     */
+    public function packages(): BelongsToMany
+    {
+        return $this->belongsToMany(Package::class)->withPivot('package_name');
+    }
+
+    /**
+     * The packages that live here — the ones this repository is the home of.
+     *
+     * Narrower than packages() above and used where the distinction is the
+     * point: a repository cannot be deleted while packages call it home
+     * (the foreign key says so), and the panel's own listing is a screen for
+     * administering those rather than for the copies served alongside them.
+     *
      * @return HasMany<Package, $this>
      */
-    public function packages(): HasMany
+    public function ownedPackages(): HasMany
     {
         return $this->hasMany(Package::class);
     }
@@ -328,7 +353,10 @@ class Repository extends Model
         return $this->packages()
             ->withPage()
             ->orderBy('name')
-            ->get(['id', 'repository_id', 'name', 'description', 'type', 'latest_version', 'abandoned']);
+            // Qualified, unlike the `hasMany` this used to be: the relation
+            // joins the serving pivot, and an unqualified column list would
+            // leave the engine to guess which side each one came from.
+            ->get(['packages.id', 'packages.repository_id', 'packages.name', 'packages.description', 'packages.type', 'packages.latest_version', 'packages.abandoned']);
     }
 
     /**

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -12,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -202,7 +204,7 @@ class Repository extends Model
             if ($principal instanceof DeployToken) {
                 $query
                     ->orWhereIn('repositories.id', $principal->repositories()->select('repositories.id'))
-                    ->orWhereIn('repositories.id', $principal->packages()->select('packages.repository_id'));
+                    ->orWhereIn('repositories.id', self::servingIds($principal->packages()->select('packages.id')->getQuery()));
             }
         });
     }
@@ -236,11 +238,27 @@ class Repository extends Model
         return $query->where(function (Builder $query) use ($user): void {
             $query->where('public', true)
                 ->orWhereIn('repositories.id', $user->repositoryGrants())
-                // Through the packages rather than the pivot, because what is
-                // wanted is the repository each granted package is served
-                // from, and only the package row knows that.
-                ->orWhereIn('repositories.id', $user->grantedPackages()->select('packages.repository_id'));
+                // Every repository serving a granted package, which since a
+                // package can be served from several is a question for the
+                // serving pivot rather than for a column on the package.
+                ->orWhereIn('repositories.id', self::servingIds($user->packageGrants()));
         });
+    }
+
+    /**
+     * The repositories serving any of the given packages.
+     *
+     * Takes the ids as a query rather than as a list, so the whole thing stays
+     * one statement — the callers hand it a union of grant pivots, which is a
+     * shape that must be used whole. @see User::packageGrants()
+     *
+     * @param  QueryBuilder|Builder<Package>  $packages
+     */
+    private static function servingIds(QueryBuilder|Builder $packages): QueryBuilder
+    {
+        return DB::table('package_repository')
+            ->select('package_repository.repository_id')
+            ->whereIn('package_repository.package_id', $packages);
     }
 
     /**

--- a/app/Models/ReservedVendor.php
+++ b/app/Models/ReservedVendor.php
@@ -19,7 +19,8 @@ use Illuminate\Support\Str;
  * here, then a mistake — or a compromised credential — can put a package under
  * a vendor prefix that a whole organisation trusts. Reserving `acme` says: this
  * registry serves that vendor from exactly one repository, and nothing else may
- * introduce a name under it.
+ * introduce a name under it — including a package added to a second repository,
+ * which is introducing the name there. @see Package::serveFrom()
  *
  * It bounds *where* a name may appear, not *who* may publish. Who is still the
  * grant system's answer — a principal has to be able to write into the owning

--- a/app/Services/CreateVersionFromZip.php
+++ b/app/Services/CreateVersionFromZip.php
@@ -78,16 +78,21 @@ class CreateVersionFromZip
 
         $version = (string) $version;
 
-        $package = Package::query()->firstOrCreate(
-            ['repository_id' => $repository->id, 'name' => $name],
-            [
+        // Whatever this repository already serves under the name, which is not
+        // necessarily a package that lives here: one added from another
+        // repository answers under this mount, and an upload addressed to that
+        // name is a version of it rather than a second package with the same
+        // name — which the serving pivot's unique index would refuse anyway.
+        $package = $repository->packages()->where('packages.name', $name)->first()
+            ?? Package::query()->create([
+                'repository_id' => $repository->id,
+                'name' => $name,
                 'description' => $composerJson['description'] ?? null,
                 'type' => $composerJson['type'] ?? null,
                 // There is no VCS repository behind an uploaded package, so
                 // there is nothing for a webhook to hear about.
                 'webhook_enabled' => false,
-            ],
-        );
+            ]);
 
         $data = [
             // Dist URLs are keyed by reference; an artifact has no commit

--- a/app/Services/PackageSynchronizer.php
+++ b/app/Services/PackageSynchronizer.php
@@ -472,26 +472,29 @@ class PackageSynchronizer
     }
 
     /**
-     * Whether another package in the same Composer repository already
-     * publishes the given name.
+     * Whether any repository serving this package already serves the given
+     * name from another package.
      *
-     * The (repository_id, name) unique index would reject the rename with a
-     * bare query error; asked first, the conflict reads as what it is — one
-     * Composer repository cannot serve two packages under one name.
+     * The serving pivot's (repository_id, package_name) unique index would
+     * reject the rename with a bare query error; asked first, the conflict
+     * reads as what it is — one Composer repository cannot serve two packages
+     * under one name. Every repository this package answers under is checked,
+     * not only the one it lives in: a rename moves the name under all of them
+     * at once, and one of them refusing is the whole rename refused.
      */
     private function nameTaken(Package $package, string $name): bool
     {
-        return Package::query()
-            ->where('repository_id', $package->repository_id)
-            ->whereKeyNot($package->getKey())
-            ->where('name', $name)
+        return DB::table('package_repository')
+            ->whereIn('repository_id', $package->servingRepositoryIds())
+            ->where('package_name', $name)
+            ->where('package_id', '!=', $package->getKey())
             ->exists();
     }
 
     private function nameConflict(string $name): string
     {
         return "The repository's composer.json is named \"{$name}\", which another package"
-            .' in this Composer repository already publishes. Move one of them to a'
+            .' a Composer repository serving this one already publishes. Move one of them to a'
             .' different repository, or fix the composer.json name.';
     }
 

--- a/app/Support/PageSchema.php
+++ b/app/Support/PageSchema.php
@@ -41,7 +41,7 @@ class PageSchema
             'publisher' => [
                 '@type' => 'Organization',
                 'name' => (string) config('app.name'),
-                'url' => $package->composerRepository->pageRootUrl(),
+                'url' => $package->servingRepository()->pageRootUrl(),
             ],
         ];
 

--- a/database/migrations/2026_08_14_000000_serve_a_package_from_several_repositories.php
+++ b/database/migrations/2026_08_14_000000_serve_a_package_from_several_repositories.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Which repositories serve a package. Until now that was one column on
+        // the package — `packages.repository_id` — and one package could be
+        // reached under exactly one mount. Publishing the same library to an
+        // internal repository and a public one meant two package rows syncing
+        // the same VCS URL twice, with two sets of versions, archives, download
+        // counters and webhooks to keep in step.
+        //
+        // `packages.repository_id` stays, and stays meaningful: it is the
+        // package's *home* — where it was created, what its canonical page URL
+        // is cut from, and which repository a reserved vendor is measured
+        // against. This table is the full set, home included, so that every
+        // query that serves a repository ("the packages of repository R") can
+        // read one relation and get both.
+        Schema::create('package_repository', function (Blueprint $table) {
+            $table->id();
+
+            // Cascading from both sides, like every other pivot here: a
+            // deleted package is served nowhere, and a deleted repository
+            // serves nothing. Note that repositories are restrictOnDelete from
+            // `packages` — a repository holding packages cannot be deleted at
+            // all — so this cascade only ever fires for the shares.
+            $table->foreignId('package_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('repository_id')->constrained()->cascadeOnDelete();
+
+            // The package's name, copied. It is here for the unique index
+            // below and for nothing else: a repository cannot serve two
+            // packages under one name, because the whole Composer surface —
+            // /p2, /dist, the page, the upload endpoint — resolves a name
+            // within a repository and would have no way to choose.
+            //
+            // `packages.name` used to carry that guarantee on its own through
+            // the (repository_id, name) unique index, which is still there and
+            // still right for the home repository. It cannot see a share, so
+            // the guarantee moves here, where it covers both.
+            //
+            // Kept in step by Package::booted(), which rewrites these rows
+            // whenever the name changes. Named `package_name` rather than
+            // `name` because `$repository->packages()->where('name', ...)` is
+            // written all over the serving paths, and a bare `name` on the
+            // pivot would make every one of those ambiguous.
+            $table->string('package_name');
+
+            $table->timestamps();
+
+            $table->unique(['package_id', 'repository_id']);
+            $table->unique(['repository_id', 'package_name']);
+        });
+
+        // Every package that exists is served where it always was. After this
+        // the pivot is the whole truth about serving, and the column beside it
+        // is only the home half of it.
+        DB::table('packages')
+            ->orderBy('id')
+            ->select(['id', 'repository_id', 'name'])
+            ->chunk(500, function ($packages): void {
+                DB::table('package_repository')->insert($packages->map(fn ($package): array => [
+                    'package_id' => $package->id,
+                    'repository_id' => $package->repository_id,
+                    'package_name' => $package->name,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ])->all());
+            });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // The shares are the only thing lost, and there is nowhere to put
+        // them: a package can hold one repository_id and it already does.
+        Schema::dropIfExists('package_repository');
+    }
+};

--- a/docs/api.md
+++ b/docs/api.md
@@ -159,7 +159,7 @@ on every delete. `GET /packages?name=…` resolves a name to an id in one call.
 | `name` | Exact Composer name |
 | `q` | Name prefix — `acme/` lists one vendor |
 | `type` | Composer package type, e.g. `library` |
-| `repository` | The Composer repository's URL path. Pass it empty (`?repository=`) for the root repository, which has no path |
+| `repository` | The Composer repository's URL path — what it *serves*, which includes packages living elsewhere and served from it. Pass it empty (`?repository=`) for the root repository, which has no path |
 | `per_page` | 1–100, default 25 |
 
 ```bash
@@ -207,9 +207,14 @@ curl -H "Authorization: Bearer $PP_TOKEN" \
 ```
 
 `url` is the VCS repository the package syncs from — `null` for one published
-by artifact upload. `repository` is the Composer repository serving it. The
-model carries the same collision and names the relation `composerRepository()`
-for the same reason.
+by artifact upload. `repository` is the Composer repository the package *lives
+in*. The model carries the same collision and names the relation
+`composerRepository()` for the same reason.
+
+`repositories` is every Composer repository serving the package, the one above
+included — a package can be
+[served from more than one](shared-packages.md), and this is the list a
+consuming project could point at.
 
 `sync.error` is what the last sync had to say, in the provider's own words, and
 is **absent** — not `null` — for a package the token reaches only because its
@@ -319,6 +324,33 @@ one would have.
 
 A package published by artifact upload has no source to sync from and is
 refused with `422`.
+
+### `POST /packages/{id}/repositories`, `DELETE /packages/{id}/repositories`
+
+Adds a package to another Composer repository, which then serves the same
+package under its own mount — or takes it back out. Requires `api:write`;
+neither unpublishes anything, so neither is behind `api:delete`. Answers `200`
+with the package and its `repositories`. See
+[shared-packages.md](shared-packages.md).
+
+| Field | | |
+| --- | --- | --- |
+| `repository` | optional | The Composer repository's URL path; the root repository when omitted |
+
+```bash
+curl -X POST -H "Authorization: Bearer $PP_TOKEN" \
+  -d 'repository=internal' \
+  https://registry.example.com/api/v1/packages/12/repositories
+```
+
+Two grants, because it is two decisions: the token must be able to change the
+package *and* to publish into the target repository. Either one missing is a
+`403`.
+
+`422` on `repository` for a repository that already serves the name, for one
+whose vendor is [reserved elsewhere](dependency-confusion.md), and for the
+repository the package lives in — removing it from there is a move, and moving
+a package changes the URL Composer resolves it at.
 
 ### `DELETE /packages/{id}`
 

--- a/docs/dependency-confusion.md
+++ b/docs/dependency-confusion.md
@@ -26,7 +26,10 @@ Open **Composer repositories → (a repository) → Reserved vendors** and add t
 vendor prefixes that repository owns — `acme`, not `acme/widgets`.
 
 From then on, no other repository in this installation may introduce a package
-name under that vendor. The rule is enforced everywhere a name is decided: the
+name under that vendor — including by
+[being added as a second repository serving a package](shared-packages.md),
+which introduces the name there like any other publish. The rule is enforced
+everywhere a name is decided: the
 create wizard, `POST /api/v1/packages`, `php artisan package:add`, an artifact
 upload to `POST /upload/{vendor}/{package}`, and a sync adopting the name a
 repository's `composer.json` declares. A vendor may be reserved by one

--- a/docs/shared-packages.md
+++ b/docs/shared-packages.md
@@ -1,0 +1,124 @@
+# Serving one package from several repositories
+
+A package **lives in** one Composer repository and can be **served from** any
+number of others. The same package: one row, one sync, one set of versions and
+archives, one download counter — answering under every mount that serves it,
+each with its own access rules.
+
+The alternative, before this existed, was a second package pointing at the same
+VCS URL. That is two syncs against the same provider, two sets of archives on
+the dist disk, two rows to abandon or rename, and two chances for them to drift
+apart while claiming to be the same library.
+
+## What it is for
+
+- **An internal build a public audience also gets.** The package lives in the
+  private repository your team publishes into; the public repository serves it
+  too, so an outside consumer resolves it without a token and without a second
+  copy of anything.
+- **Repositories per audience rather than per package.** A registry that serves
+  `/r/platform` to one department and `/r/apps` to another can put the handful
+  of shared libraries in both, without either department's mount listing the
+  other's packages.
+- **Moving a package without a flag day.** Add it to the new repository, let
+  consumers migrate their `composer.json` at their own pace, then stop serving
+  it from the old one.
+
+It is *not* mirroring. [Mirroring](mirroring.md) is how a repository answers for
+packages published somewhere else entirely — packagist.org, a corporate proxy —
+by fetching and caching their metadata over the network. This is one
+installation's own package, served from more than one of its own mounts, with
+no network involved and nothing cached.
+
+## Doing it
+
+**In the panel**, from either side:
+
+- The package's own form has **Also served from** beside the repository it
+  lives in. Everything chosen there serves the same package.
+- A repository's **Packages** list has **Serve an existing package**, and a
+  **Stop serving** action on the rows that live somewhere else.
+
+**Over the API** (`api:write`), naming the repository by its mount path:
+
+```bash
+curl -X POST -H "Authorization: Bearer $PP_TOKEN" \
+  -d 'repository=internal' \
+  https://registry.example.com/api/v1/packages/12/repositories
+
+curl -X DELETE -H "Authorization: Bearer $PP_TOKEN" \
+  -d 'repository=internal' \
+  https://registry.example.com/api/v1/packages/12/repositories
+```
+
+**From a shell**:
+
+```bash
+php artisan package:serve acme/widgets internal
+php artisan package:serve acme/widgets internal --remove
+php artisan package:serve acme/widgets root          # the registry root
+```
+
+## The rules
+
+**One repository serves one package per name.** Everything on the Composer
+surface — `/p2`, `/dist`, the page, the upload endpoint — resolves a name
+*inside* a repository, so two packages sharing a name there would be a lookup
+with no right answer. A repository that already answers for the name refuses
+the addition, and says so. The same rule catches a rename afterwards: renaming a
+package moves the name under every mount serving it at once, and one of them
+refusing is the whole rename refused.
+
+**Reserved vendors apply per mount.** A repository that has
+[reserved a vendor prefix](dependency-confusion.md) is the only one that may
+introduce names under it, and adding a package is introducing one. A package
+whose vendor another repository has reserved cannot be served here, for exactly
+the reason it could not have been created here.
+
+**Access is decided by the mount, never by the package.** A package added to a
+private repository is private *there* even if it is public where it lives, and
+a package added to a public repository is readable there even if it lives
+somewhere private. This is the point of the feature and the sharpest edge on it:
+**adding a package to a public repository publishes it.** There is no second
+switch — the repository's `public` flag is the switch, and it was already the
+one deciding this for everything else the repository serves.
+
+**Publishing stays with the repository the package lives in.** A share serves
+what a package publishes; it does not confer the right to publish into it. An
+artifact upload addressed to a mount that serves a package from elsewhere adds
+a version to that package — but only for a credential that could have published
+into the package's own repository. A grant on the serving repository alone
+reads, and does not write.
+
+**The page belongs to the mount it was reached through.** A package served from
+two repositories has a page under each, and each prints its own mount's
+`composer config` line, its own canonical URL, and its own answer to whether an
+anonymous visitor may download an archive. Both are listed in `/sitemap.xml`.
+
+**Where it lives is still one repository.** That is what `repository_id` on the
+package says, and it decides three things: which repository's mount its
+canonical page URL is cut from, which repository a reserved vendor is measured
+against when the package is created or renamed, and who may publish into it.
+Changing it is a *move* — the package stops being served from the old
+repository — and it is offered on the package's form rather than from the
+repository's side, because it changes the URL Composer resolves the package at.
+Removing a package from the repository it lives in is refused everywhere.
+
+## What a consumer sees
+
+Nothing new. Each mount is a Composer repository like any other, and a package
+served from two of them is two `repositories` entries a project could point at —
+resolving to the same package, the same versions and the same zipballs.
+
+A project that lists both mounts resolves the name from whichever it is told to
+prefer, exactly as it would for two unrelated registries; Composer's own rules
+apply, and [dependency-confusion.md](dependency-confusion.md) covers what to
+tell a consuming project when a name matters.
+
+## Audit
+
+Adding and removing a serving repository is filed in the audit log against the
+package, as `serving_added` and `serving_removed`, with the repositories named.
+Where a package is served from is not a permission, but it is asked about the
+same way — "when did this land in the public repository, and who put it there" —
+and an attribute diff cannot see a pivot row.

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,6 +53,17 @@ Route::prefix('v1')
             Route::post('/packages/{package}/sync', [PackageController::class, 'sync'])
                 ->whereNumber('package')
                 ->name('packages.sync');
+
+            // Which repositories serve a package. `api:write` rather than the
+            // delete ability even for the removal: neither unpublishes
+            // anything — the package, its versions and its archives are
+            // untouched, and it goes on being served where it lives.
+            Route::post('/packages/{package}/repositories', [PackageController::class, 'serve'])
+                ->whereNumber('package')
+                ->name('packages.serve');
+            Route::delete('/packages/{package}/repositories', [PackageController::class, 'unserve'])
+                ->whereNumber('package')
+                ->name('packages.unserve');
         });
 
         // Its own ability, not `api:write`. Creating a package and syncing one

--- a/tests/Feature/SharedPackagePanelTest.php
+++ b/tests/Feature/SharedPackagePanelTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\Packages\Pages\CreatePackage;
+use App\Filament\Resources\Packages\Pages\EditPackage;
+use App\Filament\Resources\Repositories\Pages\EditRepository;
+use App\Filament\Resources\Repositories\RelationManagers\PackagesRelationManager;
+use App\Jobs\SyncPackageJob;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+/**
+ * Adding a package to another Composer repository from the panel — from the
+ * package's own form, and from the repository it is being added to.
+ */
+class SharedPackagePanelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $internal;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->actingAs(User::factory()->superAdmin()->create());
+
+        $this->internal = Repository::factory()->create(['path' => 'internal']);
+    }
+
+    /**
+     * @return Testable<PackagesRelationManager>
+     */
+    private function relationManager(): Testable
+    {
+        return Livewire::test(PackagesRelationManager::class, [
+            'ownerRecord' => $this->internal,
+            'pageClass' => EditRepository::class,
+        ]);
+    }
+
+    public function test_the_form_shows_and_saves_the_repositories_a_package_is_served_from(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getRouteKey()])
+            ->assertFormSet(['serving_repositories' => []])
+            ->fillForm(['serving_repositories' => [$this->internal->id]])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertEqualsCanonicalizing(
+            [(int) $package->repository_id, (int) $this->internal->id],
+            $package->fresh()->servingRepositoryIds(),
+        );
+
+        // And back out again, which is the same field left empty.
+        Livewire::test(EditPackage::class, ['record' => $package->getRouteKey()])
+            ->assertFormSet(['serving_repositories' => [$this->internal->id]])
+            ->fillForm(['serving_repositories' => []])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
+    }
+
+    public function test_the_form_refuses_a_repository_that_already_serves_the_name(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+
+        Livewire::test(EditPackage::class, ['record' => $package->getRouteKey()])
+            ->fillForm(['serving_repositories' => [$this->internal->id]])
+            ->call('save')
+            ->assertHasFormErrors(['serving_repositories']);
+
+        $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
+    }
+
+    public function test_a_package_can_be_created_into_several_repositories_at_once(): void
+    {
+        Queue::fake([SyncPackageJob::class]);
+
+        Livewire::test(CreatePackage::class)
+            ->fillForm([
+                'name' => 'acme/widgets',
+                'repository' => 'https://github.com/acme/widgets',
+                'serving_repositories' => [$this->internal->id],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $package = Package::query()->where('name', 'acme/widgets')->sole();
+
+        $this->assertEqualsCanonicalizing(
+            [(int) $package->repository_id, (int) $this->internal->id],
+            $package->servingRepositoryIds(),
+        );
+    }
+
+    public function test_a_repository_can_serve_a_package_that_lives_elsewhere(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        $this->relationManager()
+            ->assertCanNotSeeTableRecords([$package])
+            ->callAction(TestAction::make('serveExisting')->table(), ['packages' => [$package->id]]);
+
+        $this->assertContains((int) $this->internal->id, $package->fresh()->servingRepositoryIds());
+
+        $this->relationManager()->assertCanSeeTableRecords([$package]);
+    }
+
+    public function test_a_repository_can_stop_serving_a_package_it_does_not_own(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        $package->serveFrom([$this->internal]);
+
+        $this->relationManager()
+            ->callAction(TestAction::make('stopServing')->table($package));
+
+        $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
+    }
+
+    public function test_a_repository_cannot_stop_serving_a_package_that_lives_there(): void
+    {
+        $package = Package::factory()->create([
+            'name' => 'acme/widgets',
+            'repository_id' => $this->internal->id,
+        ]);
+
+        $this->relationManager()
+            ->assertActionHidden(TestAction::make('stopServing')->table($package));
+    }
+}

--- a/tests/Feature/SharedPackagePanelTest.php
+++ b/tests/Feature/SharedPackagePanelTest.php
@@ -85,6 +85,23 @@ class SharedPackagePanelTest extends TestCase
         $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
     }
 
+    public function test_the_form_refuses_a_rename_to_a_name_the_home_mount_already_serves(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets'])->serveFrom([$this->internal]);
+
+        $package = Package::factory()->create(['name' => 'acme/gadgets', 'repository_id' => $this->internal->id]);
+
+        // A field error, not the 500 the model's own refusal would be — and
+        // one the name's unique rule cannot raise, since the other package
+        // merely serves here rather than living here.
+        Livewire::test(EditPackage::class, ['record' => $package->getRouteKey()])
+            ->fillForm(['name' => 'acme/widgets'])
+            ->call('save')
+            ->assertHasFormErrors(['name']);
+
+        $this->assertSame('acme/gadgets', $package->fresh()->name);
+    }
+
     public function test_a_package_can_be_created_into_several_repositories_at_once(): void
     {
         Queue::fake([SyncPackageJob::class]);
@@ -117,6 +134,22 @@ class SharedPackagePanelTest extends TestCase
         $this->assertContains((int) $this->internal->id, $package->fresh()->servingRepositoryIds());
 
         $this->relationManager()->assertCanSeeTableRecords([$package]);
+    }
+
+    public function test_the_serve_picker_says_where_each_package_lives(): void
+    {
+        $other = Repository::factory()->create(['path' => 'other', 'name' => 'Other']);
+
+        Package::factory()->create(['name' => 'acme/widgets']);
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $other->id]);
+
+        $manager = $this->relationManager()->instance();
+        $options = (fn (): array => $this->servableOptions())->call($manager);
+
+        // The same composer name twice; the labels are what tells them apart.
+        $this->assertCount(2, $options);
+        $this->assertCount(2, array_unique($options));
+        $this->assertContains('acme/widgets — lives in Other', $options);
     }
 
     public function test_a_repository_can_stop_serving_a_package_it_does_not_own(): void

--- a/tests/Feature/SharedPackageServingTest.php
+++ b/tests/Feature/SharedPackageServingTest.php
@@ -2,13 +2,18 @@
 
 namespace Tests\Feature;
 
+use App\Enums\TokenAbility;
 use App\Exceptions\NameCollision;
 use App\Exceptions\VendorReserved;
+use App\Models\DeployToken;
 use App\Models\Package;
 use App\Models\Repository;
+use App\Models\Token;
+use App\Services\CreateVersionFromZip;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
+use ZipArchive;
 
 /**
  * One package, several Composer repositories.
@@ -170,6 +175,93 @@ class SharedPackageServingTest extends TestCase
             [(int) $package->repository_id, (int) $other->id],
             $this->servingRows($package),
         );
+    }
+
+    public function test_a_private_mount_does_not_publish_a_package_its_home_publishes(): void
+    {
+        $private = Repository::factory()->create(['path' => 'closed', 'public' => false]);
+        $package = $this->released(Package::factory()->create(['name' => 'acme/widgets']));
+
+        $package->serveFrom([$private]);
+
+        // Readable where it lives, which is public...
+        $this->get('/p2/acme/widgets.json')->assertOk();
+
+        // ...and behind the private mount's own door everywhere else. A
+        // package is readable through a mount, never in the abstract.
+        $this->getJson('/r/closed/p2/acme/widgets.json')->assertUnauthorized();
+    }
+
+    public function test_a_public_mount_serves_a_package_that_lives_somewhere_private(): void
+    {
+        $private = Repository::factory()->create(['path' => 'closed', 'public' => false]);
+        $package = $this->released(Package::factory()->create([
+            'name' => 'acme/widgets',
+            'repository_id' => $private->id,
+        ]));
+
+        $package->serveFrom([$this->internal]);
+
+        $this->get('/r/internal/p2/acme/widgets.json')->assertOk();
+        $this->getJson('/r/closed/p2/acme/widgets.json')->assertUnauthorized();
+    }
+
+    public function test_a_deploy_token_granted_a_mount_reads_what_that_mount_serves(): void
+    {
+        $private = Repository::factory()->create(['path' => 'closed', 'public' => false]);
+        $package = $this->released(Package::factory()->create([
+            'name' => 'acme/widgets',
+            'repository_id' => Repository::factory()->create(['path' => 'elsewhere', 'public' => false])->id,
+        ]));
+
+        $package->serveFrom([$private]);
+
+        $deploy = DeployToken::query()->create(['name' => 'ci']);
+        $deploy->repositories()->attach($private);
+        $token = Token::issue($deploy, 'ci', [TokenAbility::RepositoryRead]);
+
+        $this->withToken($token->plainText)
+            ->getJson('/r/closed/p2/acme/widgets.json')
+            ->assertOk();
+
+        // The grant is on the mount, not on the package: through the mount
+        // where the package lives, this token is told nothing — a 404 rather
+        // than a 403, which is how every unreadable package answers here.
+        $this->withToken($token->plainText)
+            ->getJson('/r/elsewhere/p2/acme/widgets.json')
+            ->assertNotFound();
+    }
+
+    public function test_an_upload_through_a_shared_mount_publishes_to_the_package_it_serves(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        $package->serveFrom([$this->internal]);
+
+        app(CreateVersionFromZip::class)->create(
+            $this->internal,
+            'acme/widgets',
+            $this->zip('acme/widgets', 'v2.0.0'),
+            'v2.0.0',
+        );
+
+        $this->assertSame(1, Package::query()->where('name', 'acme/widgets')->count());
+        $this->assertSame('v2.0.0', $package->versions()->sole()->version);
+    }
+
+    /**
+     * A zip holding nothing but a composer.json, which is all the creator
+     * reads out of it.
+     */
+    private function zip(string $name, string $version): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pkg').'.zip';
+
+        $archive = new ZipArchive;
+        $archive->open($path, ZipArchive::CREATE);
+        $archive->addFromString('composer.json', json_encode(['name' => $name, 'version' => $version]));
+        $archive->close();
+
+        return $path;
     }
 
     public function test_deleting_a_package_clears_its_serving_rows(): void

--- a/tests/Feature/SharedPackageServingTest.php
+++ b/tests/Feature/SharedPackageServingTest.php
@@ -10,6 +10,7 @@ use App\Models\DeployToken;
 use App\Models\Package;
 use App\Models\Repository;
 use App\Models\Token;
+use App\Models\User;
 use App\Services\CreateVersionFromZip;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -315,6 +316,91 @@ class SharedPackageServingTest extends TestCase
             ->assertOk()
             ->assertSee(url('/p/acme/widgets'), false)
             ->assertSee(url('/r/internal/p/acme/widgets'), false);
+    }
+
+    public function test_the_api_serves_a_package_from_another_repository_and_stops_again(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        $plain = Token::issue(
+            User::factory()->superAdmin()->create(),
+            'provisioning',
+            [TokenAbility::ApiRead, TokenAbility::ApiWrite],
+        )->plainText;
+
+        $this->withToken($plain)
+            ->postJson("/api/v1/packages/{$package->id}/repositories", ['repository' => 'internal'])
+            ->assertOk()
+            ->assertJsonPath('data.repository.path', null)
+            ->assertJsonCount(2, 'data.repositories');
+
+        $this->assertContains((int) $this->internal->id, $package->fresh()->servingRepositoryIds());
+
+        // And the listing filter follows what a repository serves rather than
+        // what lives in it.
+        $this->withToken($plain)->getJson('/api/v1/packages?repository=internal')
+            ->assertOk()
+            ->assertJsonPath('data.0.name', 'acme/widgets');
+
+        $this->withToken($plain)
+            ->deleteJson("/api/v1/packages/{$package->id}/repositories", ['repository' => 'internal'])
+            ->assertOk()
+            ->assertJsonCount(1, 'data.repositories');
+
+        $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
+    }
+
+    public function test_the_api_refuses_to_remove_a_package_from_where_it_lives(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+
+        $plain = Token::issue(
+            User::factory()->superAdmin()->create(),
+            'provisioning',
+            [TokenAbility::ApiRead, TokenAbility::ApiWrite],
+        )->plainText;
+
+        $this->withToken($plain)
+            ->deleteJson("/api/v1/packages/{$package->id}/repositories", ['repository' => 'internal'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('repository');
+    }
+
+    public function test_the_api_refuses_a_repository_that_already_serves_the_name(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+
+        $plain = Token::issue(
+            User::factory()->superAdmin()->create(),
+            'provisioning',
+            [TokenAbility::ApiRead, TokenAbility::ApiWrite],
+        )->plainText;
+
+        $this->withToken($plain)
+            ->postJson("/api/v1/packages/{$package->id}/repositories", ['repository' => 'internal'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('repository');
+    }
+
+    public function test_the_console_serves_a_package_from_another_repository(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        $this->artisan('package:serve acme/widgets internal')->assertSuccessful();
+
+        $this->assertContains((int) $this->internal->id, $package->fresh()->servingRepositoryIds());
+
+        $this->artisan('package:serve acme/widgets internal --remove')->assertSuccessful();
+
+        $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
+    }
+
+    public function test_the_console_refuses_to_remove_a_package_from_where_it_lives(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+
+        $this->artisan('package:serve acme/widgets internal --remove')->assertFailed();
     }
 
     public function test_deleting_a_package_clears_its_serving_rows(): void

--- a/tests/Feature/SharedPackageServingTest.php
+++ b/tests/Feature/SharedPackageServingTest.php
@@ -160,6 +160,40 @@ class SharedPackageServingTest extends TestCase
         $package->serveFrom([$this->internal]);
     }
 
+    public function test_a_created_package_refuses_a_name_its_home_serves_from_a_share(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets'])->serveFrom([$this->internal]);
+
+        $this->expectException(NameCollision::class);
+
+        // The packages table's (repository_id, name) index cannot refuse this
+        // — the other package merely serves here, it does not live here.
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+    }
+
+    public function test_a_rename_refuses_a_name_a_serving_row_already_occupies(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets'])->serveFrom([$this->internal]);
+
+        $package = Package::factory()->create(['name' => 'acme/gadgets', 'repository_id' => $this->internal->id]);
+
+        $this->expectException(NameCollision::class);
+
+        $package->update(['name' => 'acme/widgets']);
+    }
+
+    public function test_a_move_refuses_a_home_whose_mount_already_serves_the_name(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets'])->serveFrom([$this->internal]);
+
+        $other = Repository::factory()->create(['path' => 'other']);
+        $package = Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $other->id]);
+
+        $this->expectException(NameCollision::class);
+
+        $package->update(['repository_id' => $this->internal->id]);
+    }
+
     public function test_a_reserved_vendor_refuses_the_repository_that_does_not_own_it(): void
     {
         $package = Package::factory()->create(['name' => 'acme/widgets']);
@@ -399,6 +433,26 @@ class SharedPackageServingTest extends TestCase
             ->assertJsonValidationErrors('repository');
     }
 
+    public function test_the_api_refuses_creating_a_name_the_repository_serves_from_a_share(): void
+    {
+        Package::factory()->create(['name' => 'acme/widgets'])->serveFrom([$this->internal]);
+
+        $plain = Token::issue(
+            User::factory()->superAdmin()->create(),
+            'provisioning',
+            [TokenAbility::ApiRead, TokenAbility::ApiWrite],
+        )->plainText;
+
+        $this->withToken($plain)
+            ->postJson('/api/v1/packages', [
+                'url' => 'https://github.com/acme/widgets',
+                'name' => 'acme/widgets',
+                'repository' => 'internal',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
     public function test_the_console_serves_a_package_from_another_repository(): void
     {
         $package = Package::factory()->create(['name' => 'acme/widgets']);
@@ -410,6 +464,20 @@ class SharedPackageServingTest extends TestCase
         $this->artisan('package:serve acme/widgets internal --remove')->assertSuccessful();
 
         $this->assertSame([(int) $package->repository_id], $package->fresh()->servingRepositoryIds());
+    }
+
+    public function test_the_console_picks_the_root_home_with_home_root(): void
+    {
+        $other = Repository::factory()->create(['path' => 'other']);
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+
+        // Ambiguous without --home, and the root home has no path to name —
+        // "root" (or an empty string) is how it is picked.
+        $this->artisan('package:serve acme/widgets other')->assertFailed();
+        $this->artisan('package:serve', ['name' => 'acme/widgets', 'repo' => 'other', '--home' => 'root'])->assertSuccessful();
+
+        $this->assertContains((int) $other->id, $package->fresh()->servingRepositoryIds());
     }
 
     public function test_the_console_refuses_to_remove_a_package_from_where_it_lives(): void

--- a/tests/Feature/SharedPackageServingTest.php
+++ b/tests/Feature/SharedPackageServingTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exceptions\NameCollision;
+use App\Exceptions\VendorReserved;
+use App\Models\Package;
+use App\Models\Repository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * One package, several Composer repositories.
+ *
+ * A package lives in one repository — its home, the one `repository_id` names
+ * — and can be added to any number of others, which then serve the same row:
+ * the same versions, the same archives, the same download counter, under their
+ * own mounts.
+ */
+class SharedPackageServingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $internal;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->internal = Repository::factory()->public()->create(['path' => 'internal']);
+    }
+
+    private function released(Package $package, string $version = 'v1.0.0'): Package
+    {
+        $package->versions()->create([
+            'version' => $version,
+            'reference' => str_repeat('a', 40),
+            'is_dev' => false,
+            'metadata' => ['name' => $package->name, 'version' => $version],
+        ]);
+
+        return $package;
+    }
+
+    /** @return list<int> */
+    private function servingRows(Package $package): array
+    {
+        return DB::table('package_repository')
+            ->where('package_id', $package->id)
+            ->orderBy('repository_id')
+            ->pluck('repository_id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+    }
+
+    public function test_a_created_package_is_served_from_its_home_repository(): void
+    {
+        $package = Package::factory()->create();
+
+        $this->assertSame([(int) $package->repository_id], $this->servingRows($package));
+        $this->assertSame([(int) $package->repository_id], $package->servingRepositoryIds());
+    }
+
+    public function test_a_renamed_package_carries_its_name_into_every_serving_row(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        $package->serveFrom([$this->internal]);
+
+        $package->update(['name' => 'acme/gadgets']);
+
+        $this->assertSame(
+            ['acme/gadgets', 'acme/gadgets'],
+            DB::table('package_repository')->where('package_id', $package->id)->pluck('package_name')->all(),
+        );
+    }
+
+    public function test_moving_a_package_home_stops_the_old_repository_serving_it(): void
+    {
+        $package = Package::factory()->create();
+        $default = (int) $package->repository_id;
+
+        $package->update(['repository_id' => $this->internal->id]);
+
+        $this->assertSame([(int) $this->internal->id], $this->servingRows($package));
+        $this->assertSame(0, Repository::query()->whereKey($default)->first()->packages()->count());
+    }
+
+    public function test_a_shared_package_answers_under_both_mounts(): void
+    {
+        $package = $this->released(Package::factory()->create(['name' => 'acme/widgets']));
+
+        $package->serveFrom([$this->internal]);
+
+        $this->get('/p2/acme/widgets.json')
+            ->assertOk()
+            ->assertJsonPath('packages.acme/widgets.0.version', 'v1.0.0');
+
+        $this->get('/r/internal/p2/acme/widgets.json')
+            ->assertOk()
+            ->assertJsonPath('packages.acme/widgets.0.version', 'v1.0.0');
+
+        $this->get('/r/internal/list.json')
+            ->assertOk()
+            ->assertExactJson(['packageNames' => ['acme/widgets']]);
+    }
+
+    public function test_a_dist_download_is_served_from_a_shared_mount(): void
+    {
+        $package = $this->released(Package::factory()->create(['name' => 'acme/widgets']));
+        $package->serveFrom([$this->internal]);
+
+        $url = $this->get('/r/internal/p2/acme/widgets.json')
+            ->assertOk()
+            ->json('packages.acme/widgets.0.dist.url');
+
+        $this->assertStringContainsString('/r/internal/dist/acme/widgets/', $url);
+    }
+
+    public function test_adding_a_package_twice_changes_nothing(): void
+    {
+        $package = Package::factory()->create();
+
+        $package->serveFrom([$this->internal]);
+        $package->serveFrom([$this->internal, $this->internal]);
+
+        $this->assertCount(2, $this->servingRows($package));
+    }
+
+    public function test_a_repository_refuses_a_name_it_already_serves(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+        Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->internal->id]);
+
+        $this->expectException(NameCollision::class);
+
+        $package->serveFrom([$this->internal]);
+    }
+
+    public function test_a_reserved_vendor_refuses_the_repository_that_does_not_own_it(): void
+    {
+        $package = Package::factory()->create(['name' => 'acme/widgets']);
+
+        Repository::default()->reservedVendors()->create(['vendor' => 'acme']);
+
+        $this->expectException(VendorReserved::class);
+
+        $package->serveFrom([$this->internal]);
+    }
+
+    public function test_a_package_stops_being_served_but_never_leaves_home(): void
+    {
+        $package = Package::factory()->create();
+        $package->serveFrom([$this->internal]);
+
+        $package->stopServingFrom([$this->internal, $package->repository_id]);
+
+        $this->assertSame([(int) $package->repository_id], $this->servingRows($package));
+    }
+
+    public function test_syncing_the_serving_list_adds_and_removes_in_one_step(): void
+    {
+        $other = Repository::factory()->create(['path' => 'other']);
+        $package = Package::factory()->create();
+        $package->serveFrom([$this->internal]);
+
+        $package->syncServingRepositories([$other->id]);
+
+        $this->assertSame(
+            [(int) $package->repository_id, (int) $other->id],
+            $this->servingRows($package),
+        );
+    }
+
+    public function test_deleting_a_package_clears_its_serving_rows(): void
+    {
+        $package = Package::factory()->create();
+        $package->serveFrom([$this->internal]);
+
+        $package->delete();
+
+        $this->assertSame([], $this->servingRows($package));
+    }
+}

--- a/tests/Feature/SharedPackageServingTest.php
+++ b/tests/Feature/SharedPackageServingTest.php
@@ -93,6 +93,22 @@ class SharedPackageServingTest extends TestCase
         $this->assertSame(0, Repository::query()->whereKey($default)->first()->packages()->count());
     }
 
+    public function test_a_mount_that_was_not_given_the_package_does_not_serve_it(): void
+    {
+        // Public, so nothing about this is an authentication answer: the mount
+        // simply does not serve the package, and knowing the name gets a
+        // caller no closer to it.
+        $this->released(Package::factory()->create(['name' => 'acme/widgets']));
+
+        $this->getJson('/r/internal/p2/acme/widgets.json')
+            ->assertNotFound()
+            ->assertJsonPath('message', 'Package acme/widgets is not served by this repository.');
+
+        $this->getJson('/r/internal/dist/acme/widgets/'.str_repeat('a', 40).'.zip')->assertNotFound();
+        $this->get('/r/internal/list.json')->assertOk()->assertExactJson(['packageNames' => []]);
+        $this->get('/r/internal/p/acme/widgets')->assertNotFound();
+    }
+
     public function test_a_shared_package_answers_under_both_mounts(): void
     {
         $package = $this->released(Package::factory()->create(['name' => 'acme/widgets']));

--- a/tests/Feature/SharedPackageServingTest.php
+++ b/tests/Feature/SharedPackageServingTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\PageDownloads;
 use App\Enums\TokenAbility;
 use App\Exceptions\NameCollision;
 use App\Exceptions\VendorReserved;
@@ -262,6 +263,58 @@ class SharedPackageServingTest extends TestCase
         $archive->close();
 
         return $path;
+    }
+
+    public function test_a_page_prints_the_mount_it_was_asked_for(): void
+    {
+        $package = $this->released(Package::factory()->create([
+            'name' => 'acme/widgets',
+            'page_enabled' => true,
+            'page_install' => true,
+        ]));
+
+        $package->serveFrom([$this->internal]);
+
+        $this->get('/r/internal/p/acme/widgets')
+            ->assertOk()
+            ->assertSee('composer config repositories.', false)
+            ->assertSee(url('/r/internal'), false);
+
+        $this->get('/p/acme/widgets')
+            ->assertOk()
+            ->assertSee(url('/p/acme/widgets'), false);
+    }
+
+    public function test_a_page_on_a_private_mount_offers_no_downloads(): void
+    {
+        $private = Repository::factory()->create(['path' => 'closed', 'public' => false]);
+        $package = $this->released(Package::factory()->create([
+            'name' => 'acme/widgets',
+            'page_enabled' => true,
+            'page_downloads' => PageDownloads::Latest,
+        ]));
+
+        $package->serveFrom([$private]);
+
+        // Offered where the package lives, which is public...
+        $this->assertSame(PageDownloads::Latest, $package->servedFrom(Repository::default())->pageDownloads());
+
+        // ...and withheld under the private mount, whose page says instead
+        // that the visitor has to ask for access.
+        $this->get('/r/closed/p/acme/widgets/download')->assertNotFound();
+    }
+
+    public function test_the_sitemap_lists_a_page_under_every_mount_serving_it(): void
+    {
+        config(['registry.pages.sitemap' => true]);
+
+        $package = Package::factory()->create(['name' => 'acme/widgets', 'page_enabled' => true]);
+        $package->serveFrom([$this->internal]);
+
+        $this->get('/sitemap.xml')
+            ->assertOk()
+            ->assertSee(url('/p/acme/widgets'), false)
+            ->assertSee(url('/r/internal/p/acme/widgets'), false);
     }
 
     public function test_deleting_a_package_clears_its_serving_rows(): void


### PR DESCRIPTION
This pull request introduces support for serving a single Composer package from multiple repositories, allowing a package to "live" in one repository but be available under additional mounts with their own access rules. It adds a new `package:serve` command, updates the UI to manage and display these relationships, and documents the feature throughout the codebase and documentation.

**Multi-repository package serving:**
- Added the ability for a package to be served from multiple Composer repositories, with access control determined by each repository mount. This is reflected in both backend logic and the user interface. [[1]](diffhunk://#diff-c0b85926030188a888cc4d8bd270e942e37495cf39359baa9f3577166259fa80R1-R167) [[2]](diffhunk://#diff-8bea0e04cf4ea577051bc4ac6aa307679becc47c7e896b3be3499abaacc355aaL316-R373) [[3]](diffhunk://#diff-8bea0e04cf4ea577051bc4ac6aa307679becc47c7e896b3be3499abaacc355aaR44) [[4]](diffhunk://#diff-2090b9e7da2fed5458a3abbaf1d86636b7b23349faae8e3e3c9c967a4e04a8b8R58-R61) [[5]](diffhunk://#diff-14af8e76ad32bb4a0a3df2434681c5fd658ad9c46770562ac70675cd39bda49fR40-R45) [[6]](diffhunk://#diff-8795e19433c7864b5a05055d07b9709af1dbd850dc2c1359bbad534d71579849L47-R66)

**Command-line support:**
- Introduced the `package:serve` Artisan command to add or remove a package from additional repositories, including logic for disambiguation and error handling.

**UI and activity log enhancements:**
- Updated Filament forms and infolists to allow selecting additional repositories to serve a package from, and to display this information. [[1]](diffhunk://#diff-8bea0e04cf4ea577051bc4ac6aa307679becc47c7e896b3be3499abaacc355aaL316-R373) [[2]](diffhunk://#diff-8795e19433c7864b5a05055d07b9709af1dbd850dc2c1359bbad534d71579849L47-R66)
- Extended activity log and table coloring to include events for serving and removing packages from repositories. [[1]](diffhunk://#diff-ef7726ec96f0323376c171e43d5867be631bde3f7b3c7b16bebb633689626128R28-R29) [[2]](diffhunk://#diff-ef7726ec96f0323376c171e43d5867be631bde3f7b3c7b16bebb633689626128L68-R70)

**Documentation updates:**
- Updated `README.md` and `CHANGELOG.md` to document the new multi-repository serving feature, usage instructions, and its implications for access control and publishing. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR35-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L194-R194) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R203-R210) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R458)

**Error handling improvements:**
- Added a `NameCollision` exception to provide clear errors when a repository already serves a package by the same name, improving UX over database errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication/authorization on the Composer hot path (`visibleTo` per mount) and can unintentionally publish packages when added to a public repository; pivot consistency on rename/move affects all serving mounts.
> 
> **Overview**
> **One package, many Composer mounts.** A package still has a single home (`repository_id`), but can also be served from additional repositories through a new `package_repository` pivot (with per-mount `package_name` uniqueness). Sync, versions, archives, and download counts stay on one row.
> 
> **Management surfaces:** Filament **Also served from** on packages, **Serve an existing package** / **Stop serving** on repository package lists, `POST`/`DELETE` `/api/v1/packages/{id}/repositories`, and `php artisan package:serve`. Audit log events `serving_added` / `serving_removed`. `NameCollision` and unified `Package::servingRefusal()` replace bare DB errors for name/vendor conflicts on shares.
> 
> **Behavior that follows the mount:** Composer `/p2`, `/dist`, list/search, and API package filters use the serving relation. `visibleTo()` takes an optional **through** repository so access is judged per mount (e.g. public share vs private home). Public pages, sitemap URLs, install lines, and download policy use `servedFrom()` / `servingRepository()` for the requested mount.
> 
> **Other touchpoints:** `Repository::packages()` becomes many-to-many (`ownedPackages()` for home-only); pivot backfill migration; rename/move/home reconciliation on save; artifact uploads and sync rename checks respect pivot collisions; console `--repo` disambiguation uses `Package::livingIn()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a809e2b56ee962c81ccb88057f0bfe00e436199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->