### PR TITLE
Implement billing layer with merchant drivers, subscriptions, and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,4 +208,26 @@ PAGE_SITEMAP=true
 # PAGE_ASSET_CACHE_MINUTES=1440
 # PAGE_MAX_ASSET_KB=4096
 
+# Billing — sell subscriptions that grant package access. Off by default: a
+# registry that has not turned this on serves exactly what it always served,
+# and none of the billing routes answer. BILLING_MERCHANT names the driver the
+# public buy button sells through (stripe); Manual subscriptions — comps, wire
+# transfers, POs — are always available to administrators regardless.
+# BILLING_PUBLIC_SIGNUP opens /register so strangers can create an account and
+# buy; leave it off to sell only to accounts you create. See docs/billing.md.
+BILLING_ENABLED=false
+BILLING_MERCHANT=stripe
+BILLING_PUBLIC_SIGNUP=false
+BILLING_CURRENCY=usd
+BILLING_TERMS_URL=
+
+# Stripe, when it is the merchant. The webhook secret is the endpoint's
+# signing secret from the Stripe dashboard (or `stripe listen` in
+# development); STRIPE_TAX_ENABLED asks Stripe Tax to compute and collect tax
+# at checkout, and requires Stripe Tax enabled on the account first.
+STRIPE_SECRET=
+STRIPE_PUBLISHABLE=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_TAX_ENABLED=false
+
 VITE_APP_NAME="${APP_NAME}"

--- a/README.md
+++ b/README.md
@@ -445,10 +445,12 @@ After adding new Filament resources, re-run both `php artisan shield:generate --
 ## Further reading
 
 - [docs/api.md](docs/api.md) — the `/api/v1` management API: authentication, abilities, every endpoint, and a release pipeline end to end.
+- [docs/billing.md](docs/billing.md) — selling subscriptions that grant package access: plans, Stripe checkout, the public pricing page, the customer area, lapse behaviours and version ceilings, and the Manual merchant for comps and purchase orders.
 - [docs/dependency-confusion.md](docs/dependency-confusion.md) — reserving vendor prefixes here, and the Composer configuration each consuming project needs so a public package cannot win a private name.
 - [docs/deployment.md](docs/deployment.md) — production drivers, scaling, monitoring, and backup and restore.
 - [docs/download-analytics.md](docs/download-analytics.md) — exporting download statistics as CSV, from the panel or the shell, per package or registry-wide.
 - [docs/github-app.md](docs/github-app.md) — registering the GitHub App and connecting sources, including troubleshooting.
+- [docs/merchant-drivers.md](docs/merchant-drivers.md) — adding a payment merchant other than Stripe: the driver contract, the rules a translation must keep, and what shared machinery a driver inherits.
 - [docs/licensing.md](docs/licensing.md) — the license report, what a version declaring none means, and the CycloneDX SBOM export: its shape, the choices behind it, and what was verified against the spec.
 - [docs/metrics.md](docs/metrics.md) — the Prometheus endpoint: what it exposes, why it is off by default, what to alert on, and what a scrape costs.
 - [docs/monorepos.md](docs/monorepos.md) — publishing several packages from one repository: the subdirectory field, how a dist for part of a repository is built, and what a push to a monorepo syncs.

--- a/app/Console/Commands/ReconcileBilling.php
+++ b/app/Console/Commands/ReconcileBilling.php
@@ -116,15 +116,18 @@ class ReconcileBilling extends Command
             notify: true,
         );
 
-        // A grace window that ran out changes no column — grantsAccess()
+        // A grace window that ran out moves no clock — grantsAccess()
         // already answers differently — but the pivots do not know that
-        // until somebody re-projects.
+        // until somebody re-projects, and the lapse notice must go out
+        // exactly once, which is what the stamp records.
         Subscription::query()
             ->whereNotNull('grace_ends_at')
-            ->whereBetween('grace_ends_at', [now()->subHours((int) config('registry.billing.reconcile_lookback_hours')), now()])
+            ->where('grace_ends_at', '<=', now())
+            ->whereNull('grace_notified_at')
             ->with('customer')
             ->chunkById(100, function ($subscriptions) use ($entitlements, &$moved): void {
                 foreach ($subscriptions as $subscription) {
+                    $subscription->forceFill(['grace_notified_at' => now()])->save();
                     $entitlements->project($subscription);
                     $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
                     $moved++;

--- a/app/Console/Commands/ReconcileBilling.php
+++ b/app/Console/Commands/ReconcileBilling.php
@@ -13,6 +13,7 @@ use App\Services\Billing\EntitlementProjector;
 use App\Services\Billing\SubscriptionProjector;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 use Throwable;
 
 /**
@@ -156,14 +157,24 @@ class ReconcileBilling extends Command
 
         $query->with(['plan', 'customer'])->chunkById(100, function ($subscriptions) use ($to, $entitlements, $notify, &$count): void {
             foreach ($subscriptions as $subscription) {
-                $subscription->forceFill([...$to, 'last_event_at' => now()])->save();
-                $entitlements->project($subscription);
+                // The projector re-reads status from the DB, so the move must
+                // be saved before projecting — a transaction makes that save
+                // revocable: any failure rolls the status back and the row is
+                // picked up again next run. The worst a commit failure can
+                // repeat is one extra email.
+                try {
+                    DB::transaction(function () use ($subscription, $to, $entitlements, $notify): void {
+                        $subscription->forceFill([...$to, 'last_event_at' => now()])->save();
+                        $entitlements->project($subscription);
 
-                if ($notify) {
-                    $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
+                        if ($notify) {
+                            $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
+                        }
+                    });
+                    $count++;
+                } catch (Throwable $e) {
+                    $this->warn("Could not move subscription {$subscription->getKey()}: {$e->getMessage()}");
                 }
-
-                $count++;
             }
         });
 

--- a/app/Console/Commands/ReconcileBilling.php
+++ b/app/Console/Commands/ReconcileBilling.php
@@ -12,6 +12,7 @@ use App\Notifications\Billing\TrialEnding;
 use App\Services\Billing\EntitlementProjector;
 use App\Services\Billing\SubscriptionProjector;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
 use Throwable;
 
 /**
@@ -135,7 +136,11 @@ class ReconcileBilling extends Command
         }
     }
 
-    private function move($query, array $to, EntitlementProjector $entitlements, bool $notify): int
+    /**
+     * @param  Builder<Subscription>  $query
+     * @param  array<string, mixed>  $to
+     */
+    private function move(Builder $query, array $to, EntitlementProjector $entitlements, bool $notify): int
     {
         $count = 0;
 

--- a/app/Console/Commands/ReconcileBilling.php
+++ b/app/Console/Commands/ReconcileBilling.php
@@ -127,10 +127,17 @@ class ReconcileBilling extends Command
             ->with('customer')
             ->chunkById(100, function ($subscriptions) use ($entitlements, &$moved): void {
                 foreach ($subscriptions as $subscription) {
-                    $subscription->forceFill(['grace_notified_at' => now()])->save();
-                    $entitlements->project($subscription);
-                    $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
-                    $moved++;
+                    // Work first, stamp last: a row whose projection or
+                    // notice failed stays eligible next run. The worst a
+                    // stamp failure can repeat is one extra email.
+                    try {
+                        $entitlements->project($subscription);
+                        $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
+                        $subscription->forceFill(['grace_notified_at' => now()])->save();
+                        $moved++;
+                    } catch (Throwable $e) {
+                        $this->warn("Could not cross grace for subscription {$subscription->getKey()}: {$e->getMessage()}");
+                    }
                 }
             });
 

--- a/app/Console/Commands/ReconcileBilling.php
+++ b/app/Console/Commands/ReconcileBilling.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\BillingModel;
+use App\Enums\MerchantProvider;
+use App\Enums\SubscriptionStatus;
+use App\Models\MerchantReference;
+use App\Models\Subscription;
+use App\Notifications\Billing\SubscriptionLapsed;
+use App\Notifications\Billing\TrialEnding;
+use App\Services\Billing\EntitlementProjector;
+use App\Services\Billing\SubscriptionProjector;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * The safety net under the webhooks, and the clock for everything local.
+ *
+ * Three sweeps. Remote: every merchant-billed subscription the merchant
+ * might still move is re-pulled and re-applied, which repairs whatever a
+ * webhook lost during a deploy — the projector discards anything older than
+ * what is already applied, so re-applying current truth is free. Local:
+ * subscriptions whose own clocks crossed a boundary nobody webhooks about —
+ * a Manual period ending, an updates window closing, a grace window running
+ * out, an end-of-period cancellation arriving — are moved and re-projected.
+ * Courtesy: trials ending inside a week get their one warning email.
+ */
+class ReconcileBilling extends Command
+{
+    protected $signature = 'billing:reconcile';
+
+    protected $description = 'Re-pull merchant-billed subscriptions, cross local billing clocks, and repair drift';
+
+    public function handle(SubscriptionProjector $projector, EntitlementProjector $entitlements): int
+    {
+        if (! config('registry.billing.enabled')) {
+            $this->info('Billing is disabled; nothing to reconcile.');
+
+            return self::SUCCESS;
+        }
+
+        $this->reconcileRemote($projector);
+        $this->crossLocalBoundaries($entitlements);
+        $this->warnEndingTrials();
+
+        return self::SUCCESS;
+    }
+
+    private function reconcileRemote(SubscriptionProjector $projector): void
+    {
+        $repaired = 0;
+        $failed = 0;
+
+        Subscription::query()
+            ->reconcilable()
+            ->with(['plan', 'customer'])
+            ->chunkById(100, function ($subscriptions) use ($projector, &$repaired, &$failed): void {
+                foreach ($subscriptions as $subscription) {
+                    $externalId = MerchantReference::externalId($subscription, $subscription->merchant);
+
+                    if ($externalId === null) {
+                        continue;
+                    }
+
+                    try {
+                        $projector->apply($subscription, $subscription->client()->fetchSubscription($externalId));
+                        $repaired++;
+                    } catch (Throwable $e) {
+                        // One unreachable subscription must not stop the
+                        // sweep; it is still here next run.
+                        $this->warn("Could not reconcile subscription {$subscription->getKey()}: {$e->getMessage()}");
+                        $failed++;
+                    }
+                }
+            });
+
+        $this->info("Reconciled {$repaired} merchant-billed subscription(s)".($failed > 0 ? ", {$failed} unreachable" : '').'.');
+    }
+
+    /**
+     * The boundaries only this app's own clock crosses.
+     */
+    private function crossLocalBoundaries(EntitlementProjector $entitlements): void
+    {
+        $moved = 0;
+
+        // An end-of-period cancellation whose period has now ended. Manual
+        // subscriptions cross it here; merchant-billed ones normally get the
+        // merchant's own event first, and this catches the ones that didn't.
+        $moved += $this->move(
+            Subscription::query()
+                ->whereNotNull('cancel_at')
+                ->where('cancel_at', '<=', now())
+                ->whereNotIn('status', [SubscriptionStatus::Canceled, SubscriptionStatus::Expired]),
+            ['status' => SubscriptionStatus::Canceled, 'canceled_at' => now(), 'ends_at' => now()],
+            $entitlements,
+            notify: true,
+        );
+
+        // A Manual subscription (or a one-time purchase, which is Manual in
+        // shape once bought) whose period ran out: Expired, which is the
+        // lapse that FreezeAtVersion and the updates window hang off.
+        $moved += $this->move(
+            Subscription::query()
+                ->whereNotNull('current_period_end')
+                ->where('current_period_end', '<=', now())
+                ->whereIn('status', [SubscriptionStatus::Active, SubscriptionStatus::Trialing])
+                ->where(function ($query): void {
+                    $query->where('merchant', MerchantProvider::Manual)
+                        ->orWhereHas('plan', fn ($plan) => $plan->where('billing_model', BillingModel::OneTimeWithUpdates));
+                }),
+            ['status' => SubscriptionStatus::Expired, 'ends_at' => now()],
+            $entitlements,
+            notify: true,
+        );
+
+        // A grace window that ran out changes no column — grantsAccess()
+        // already answers differently — but the pivots do not know that
+        // until somebody re-projects.
+        Subscription::query()
+            ->whereNotNull('grace_ends_at')
+            ->whereBetween('grace_ends_at', [now()->subHours((int) config('registry.billing.reconcile_lookback_hours')), now()])
+            ->with('customer')
+            ->chunkById(100, function ($subscriptions) use ($entitlements, &$moved): void {
+                foreach ($subscriptions as $subscription) {
+                    $entitlements->project($subscription);
+                    $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
+                    $moved++;
+                }
+            });
+
+        if ($moved > 0) {
+            $this->info("Crossed {$moved} local billing boundary(ies).");
+        }
+    }
+
+    private function move($query, array $to, EntitlementProjector $entitlements, bool $notify): int
+    {
+        $count = 0;
+
+        $query->with(['plan', 'customer'])->chunkById(100, function ($subscriptions) use ($to, $entitlements, $notify, &$count): void {
+            foreach ($subscriptions as $subscription) {
+                $subscription->forceFill([...$to, 'last_event_at' => now()])->save();
+                $entitlements->project($subscription);
+
+                if ($notify) {
+                    $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
+                }
+
+                $count++;
+            }
+        });
+
+        return $count;
+    }
+
+    /**
+     * One warning per subscription, three days out: `trial_warned_at` would
+     * be another column to keep true, so the window's width and the daily
+     * cadence do the deduplication — a trial is inside [2, 3) days from its
+     * end on exactly one nightly run.
+     */
+    private function warnEndingTrials(): void
+    {
+        Subscription::query()
+            ->where('status', SubscriptionStatus::Trialing)
+            ->whereBetween('trial_ends_at', [now()->addDays(2), now()->addDays(3)])
+            ->with(['plan', 'customer'])
+            ->chunkById(100, function ($subscriptions): void {
+                foreach ($subscriptions as $subscription) {
+                    $subscription->customer?->contact()?->notify(new TrialEnding($subscription));
+                }
+            });
+    }
+}

--- a/app/Console/Commands/SyncBillingCatalog.php
+++ b/app/Console/Commands/SyncBillingCatalog.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\MerchantProvider;
+use App\Services\Billing\CatalogSync;
+use Illuminate\Console\Command;
+
+/**
+ * Pushes the plan catalog to the configured merchant — the pipeline's way to
+ * run what the panel's resync action runs. Idempotent; run it whenever.
+ */
+class SyncBillingCatalog extends Command
+{
+    protected $signature = 'billing:sync-catalog {--merchant= : Which merchant to sync to (defaults to the configured one)}';
+
+    protected $description = 'Create or update the merchant\'s products and prices from the local plan catalog';
+
+    public function handle(CatalogSync $sync): int
+    {
+        $merchant = MerchantProvider::tryFrom((string) ($this->option('merchant') ?? config('registry.billing.merchant')));
+
+        if ($merchant === null) {
+            $this->error('Unknown merchant.');
+
+            return self::FAILURE;
+        }
+
+        $count = $sync->syncAll($merchant);
+
+        $this->info("Synced {$count} plan(s) to {$merchant->getLabel()}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/BillingInterval.php
+++ b/app/Enums/BillingInterval.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * How often a price charges.
+ *
+ * The value is what crosses the merchant driver contract: Stripe's own
+ * interval vocabulary happens to match `month`/`year`, and OneTime is the
+ * absence of an interval — a price the driver mirrors as a non-recurring
+ * Price object. Weeks and days are deliberately not offered; nobody sells
+ * package access by the week, and every case here is a case every future
+ * driver must translate.
+ */
+enum BillingInterval: string implements HasLabel
+{
+    case Month = 'month';
+    case Year = 'year';
+    case OneTime = 'one_time';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Month => 'Monthly',
+            self::Year => 'Yearly',
+            self::OneTime => 'One-time',
+        };
+    }
+
+    public function recurring(): bool
+    {
+        return $this !== self::OneTime;
+    }
+}

--- a/app/Enums/BillingModel.php
+++ b/app/Enums/BillingModel.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * How a plan charges for what it grants.
+ *
+ * The two shapes commercial PHP packages are actually sold under, and they
+ * differ in what "the subscription ended" means rather than in how the money
+ * moves. A recurring plan that lapses stops granting; a perpetual plan that
+ * lapses keeps granting what was released while it was paid for, forever. That
+ * second promise is the whole reason LapseBehaviour::FreezeAtVersion and the
+ * version ceiling exist.
+ *
+ * @see LapseBehaviour
+ * @see \App\Services\Billing\VersionCeiling
+ */
+enum BillingModel: string implements HasDescription, HasLabel
+{
+    /** Renews on an interval; access lasts as long as the payments do. */
+    case Recurring = 'recurring';
+
+    /**
+     * Paid once. Access to what was released during the updates window is
+     * permanent; releases after it are not included.
+     */
+    case OneTimeWithUpdates = 'one_time_with_updates';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Recurring => 'Recurring subscription',
+            self::OneTimeWithUpdates => 'One-time purchase with an updates window',
+        };
+    }
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Recurring => 'Billed every period. Access continues for as long as the subscription is paid.',
+            self::OneTimeWithUpdates => 'Billed once. The customer keeps every version released during the updates window, permanently, and stops receiving new ones when it closes.',
+        };
+    }
+
+    /**
+     * Whether a plan on this model has a renewal date at all. A one-time
+     * purchase has an updates window that closes and nothing that renews, so
+     * the reconciler has no remote subscription to re-pull and the dunning
+     * settings on the plan mean nothing.
+     */
+    public function renews(): bool
+    {
+        return $this === self::Recurring;
+    }
+
+    /**
+     * Whether the plan's updates window is the thing that decides how long
+     * access to *new* releases lasts — as opposed to the billing period.
+     */
+    public function hasUpdatesWindow(): bool
+    {
+        return $this === self::OneTimeWithUpdates;
+    }
+}

--- a/app/Enums/BillingModel.php
+++ b/app/Enums/BillingModel.php
@@ -2,6 +2,7 @@
 
 namespace App\Enums;
 
+use App\Services\Billing\VersionCeiling;
 use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
 
@@ -16,7 +17,7 @@ use Filament\Support\Contracts\HasLabel;
  * version ceiling exist.
  *
  * @see LapseBehaviour
- * @see \App\Services\Billing\VersionCeiling
+ * @see VersionCeiling
  */
 enum BillingModel: string implements HasDescription, HasLabel
 {

--- a/app/Enums/CancellationTiming.php
+++ b/app/Enums/CancellationTiming.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * When a customer's own cancellation takes their access away.
+ *
+ * The industry norm is end-of-period: the customer paid for the month, so the
+ * month is theirs, and the subscription simply does not renew. Immediate is
+ * the stricter reading — cancelling is renouncing — and it is what this
+ * registry's operator chose as the default, so it is first and the plan form
+ * defaults to it. Either way the merchant is told the same thing
+ * (cancel now / cancel at period end) and the local record follows the
+ * merchant's answer, so the two clocks cannot disagree.
+ */
+enum CancellationTiming: string implements HasDescription, HasLabel
+{
+    case Immediate = 'immediate';
+    case EndOfPeriod = 'end_of_period';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Immediate => 'Immediately',
+            self::EndOfPeriod => 'At the end of the paid period',
+        };
+    }
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Immediate => 'Cancelling withdraws access at once, before the paid period runs out.',
+            self::EndOfPeriod => 'Cancelling stops the renewal; access continues until the period the customer already paid for ends.',
+        };
+    }
+}

--- a/app/Enums/GrantSource.php
+++ b/app/Enums/GrantSource.php
@@ -2,6 +2,8 @@
 
 namespace App\Enums;
 
+use App\Models\User;
+use App\Services\Billing\EntitlementProjector;
 use Filament\Support\Contracts\HasLabel;
 
 /**
@@ -25,8 +27,8 @@ use Filament\Support\Contracts\HasLabel;
  * duplicates — the caller only ever tests membership. That is what lets the
  * whole billing layer land without touching the hot path.
  *
- * @see \App\Services\Billing\EntitlementProjector
- * @see \App\Models\User::packageGrants()
+ * @see EntitlementProjector
+ * @see User::packageGrants()
  */
 enum GrantSource: string implements HasLabel
 {

--- a/app/Enums/GrantSource.php
+++ b/app/Enums/GrantSource.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * Who wrote a row into one of the four grant pivots.
+ *
+ * Access in this registry has always been a grant: a row in `package_user`,
+ * `repository_user`, `package_team` or `repository_team` that
+ * Package::scopeVisibleToUser() folds into every read. Selling access adds a
+ * second author for those rows — the entitlement projector — and the two must
+ * not be able to overwrite each other.
+ *
+ * So every grant carries the hand that made it, and the composite unique on
+ * each pivot includes it. A package can be granted to the same user twice, once
+ * by an administrator and once by a subscription, and each can be withdrawn
+ * without disturbing the other: cancelling a subscription must not revoke the
+ * access somebody was given by name, and an administrator tidying up a grant
+ * list must not silently un-sell something that has been paid for.
+ *
+ * The visibility scopes never look at this column. They ask which package ids a
+ * user reaches, and the union that answers is documented as tolerating
+ * duplicates — the caller only ever tests membership. That is what lets the
+ * whole billing layer land without touching the hot path.
+ *
+ * @see \App\Services\Billing\EntitlementProjector
+ * @see \App\Models\User::packageGrants()
+ */
+enum GrantSource: string implements HasLabel
+{
+    /** Written by a person in the panel, the API or a console command. */
+    case Manual = 'manual';
+
+    /** Written by the entitlement projector, on behalf of a subscription. */
+    case Subscription = 'subscription';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Manual => 'Granted directly',
+            self::Subscription => 'Granted by a subscription',
+        };
+    }
+
+    /**
+     * Whether a person editing grants in the panel may add or remove this kind
+     * of row. Subscription grants are the projector's to write and nobody
+     * else's — an administrator who wants one gone cancels or suspends the
+     * subscription behind it, which is the record that will otherwise put it
+     * straight back on the next reconcile.
+     */
+    public function editableByHand(): bool
+    {
+        return $this === self::Manual;
+    }
+}

--- a/app/Enums/LapseBehaviour.php
+++ b/app/Enums/LapseBehaviour.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasDescription;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * What a subscription's lapse does to the access it granted.
+ *
+ * A property of the plan, not of the code: the same registry can sell a
+ * strict per-seat tool that cuts off on non-payment next to a perpetual
+ * licence that keeps every version its buyer ever paid for. The projector
+ * reads this once, at the moment a subscription stops granting access, and
+ * does exactly one of these four things.
+ *
+ * Whatever the choice, renewal reverses it. Withdrawn grants are re-projected,
+ * revoked tokens are the one exception — a soft-deleted credential is not
+ * un-deleted, because its plain text is long gone; the customer issues a new
+ * one and the old row stays in the audit log.
+ *
+ * @see \App\Services\Billing\EntitlementProjector
+ */
+enum LapseBehaviour: string implements HasDescription, HasLabel
+{
+    /**
+     * Remove the subscription's grants. Tokens survive and keep reaching
+     * whatever else their owner is granted; the paid packages simply stop
+     * being visible. The default, because it is the only choice that is both
+     * complete and perfectly reversible.
+     */
+    case WithdrawEntitlement = 'withdraw_entitlement';
+
+    /**
+     * Withdraw the grants and soft-delete every token the subscription
+     * issued. For plans whose token is the product — where a credential
+     * shared around a team is the abuse being priced against.
+     */
+    case RevokeTokens = 'revoke_tokens';
+
+    /**
+     * Keep the grants, pin a version ceiling. Everything released while the
+     * subscription was paid stays installable forever; anything newer needs a
+     * live subscription. The lapse behaviour of a perpetual licence, and the
+     * implied choice for BillingModel::OneTimeWithUpdates.
+     */
+    case FreezeAtVersion = 'freeze_at_version';
+
+    /**
+     * Do nothing. The subscription record lapses, the access stays. For
+     * plans that are really donations, sponsorships or support contracts,
+     * where cutting anything off would be the wrong answer.
+     */
+    case None = 'none';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::WithdrawEntitlement => 'Withdraw access',
+            self::RevokeTokens => 'Withdraw access and revoke tokens',
+            self::FreezeAtVersion => 'Freeze at the versions already released',
+            self::None => 'Keep access',
+        };
+    }
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::WithdrawEntitlement => 'The plan\'s packages stop being visible. Tokens keep working for anything else their owner can reach, and renewal restores everything.',
+            self::RevokeTokens => 'Access is withdrawn and every token this subscription issued is revoked. After renewal the customer must issue new tokens.',
+            self::FreezeAtVersion => 'Versions released while the subscription was active remain installable forever; newer releases require renewing.',
+            self::None => 'Nothing is withdrawn. Use for sponsorships and goodwill plans where access should outlive the payments.',
+        };
+    }
+
+    /**
+     * Whether lapsing under this behaviour leaves the subscription's grants
+     * in place. The projector uses this to decide between deleting its pivot
+     * rows and keeping them alongside a ceiling.
+     */
+    public function keepsGrants(): bool
+    {
+        return match ($this) {
+            self::FreezeAtVersion, self::None => true,
+            self::WithdrawEntitlement, self::RevokeTokens => false,
+        };
+    }
+}

--- a/app/Enums/LapseBehaviour.php
+++ b/app/Enums/LapseBehaviour.php
@@ -2,6 +2,7 @@
 
 namespace App\Enums;
 
+use App\Services\Billing\EntitlementProjector;
 use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasLabel;
 
@@ -19,7 +20,7 @@ use Filament\Support\Contracts\HasLabel;
  * un-deleted, because its plain text is long gone; the customer issues a new
  * one and the old row stays in the audit log.
  *
- * @see \App\Services\Billing\EntitlementProjector
+ * @see EntitlementProjector
  */
 enum LapseBehaviour: string implements HasDescription, HasLabel
 {

--- a/app/Enums/MerchantProvider.php
+++ b/app/Enums/MerchantProvider.php
@@ -5,6 +5,7 @@ namespace App\Enums;
 use App\Merchants\Manual\ManualClient;
 use App\Merchants\MerchantClient;
 use App\Merchants\Stripe\StripeClient;
+use App\Sources\StubClient;
 use Filament\Support\Contracts\HasLabel;
 
 /**
@@ -22,7 +23,7 @@ use Filament\Support\Contracts\HasLabel;
  * "none" is spelled Manual.
  *
  * @see MerchantClient
- * @see \App\Sources\StubClient for the pattern this follows
+ * @see StubClient for the pattern this follows
  */
 enum MerchantProvider: string implements HasLabel
 {

--- a/app/Enums/MerchantProvider.php
+++ b/app/Enums/MerchantProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Enums;
+
+use App\Merchants\Manual\ManualClient;
+use App\Merchants\MerchantClient;
+use App\Merchants\Stripe\StripeClient;
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * The payment merchants a subscription can be billed through.
+ *
+ * The same shape as SourceProvider: the enum is the registry of drivers, the
+ * client() factory is the one place a case becomes an implementation, and a
+ * case may exist before its driver does by resolving to a stub that refuses
+ * loudly. Stripe and Manual are implemented.
+ *
+ * Manual is a real driver, not a test double. It is a subscription an
+ * administrator created with no merchant behind it — a comped account, a wire
+ * transfer, a purchase order — and it is also what proves the contract holds
+ * for a driver with no network at all. Every subscription has a merchant;
+ * "none" is spelled Manual.
+ *
+ * @see MerchantClient
+ * @see \App\Sources\StubClient for the pattern this follows
+ */
+enum MerchantProvider: string implements HasLabel
+{
+    case Stripe = 'stripe';
+    case Manual = 'manual';
+
+    /**
+     * The driver for this merchant — the single point where the enum's value
+     * becomes behaviour, mirroring Package::client().
+     */
+    public function client(): MerchantClient
+    {
+        return match ($this) {
+            self::Stripe => StripeClient::fromConfig(),
+            self::Manual => new ManualClient,
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Stripe => 'Stripe',
+            self::Manual => 'Manual / offline',
+        };
+    }
+
+    /**
+     * Whether this merchant can sell to a stranger: hosted checkout is what
+     * the public buy button redirects to, so a plan whose merchant lacks it
+     * can only be sold by an administrator.
+     */
+    public function supportsHostedCheckout(): bool
+    {
+        return match ($this) {
+            self::Stripe => true,
+            self::Manual => false,
+        };
+    }
+
+    /** Whether customers manage their card and invoices on a merchant-hosted portal. */
+    public function supportsPortal(): bool
+    {
+        return match ($this) {
+            self::Stripe => true,
+            self::Manual => false,
+        };
+    }
+
+    /** Whether the merchant computes and collects tax at checkout. */
+    public function supportsTax(): bool
+    {
+        return match ($this) {
+            self::Stripe => (bool) config('services.stripe.tax_enabled'),
+            self::Manual => false,
+        };
+    }
+
+    /** Whether this merchant sends webhooks that need a signature check. */
+    public function receivesWebhooks(): bool
+    {
+        return $this === self::Stripe;
+    }
+}

--- a/app/Enums/SubscriptionStatus.php
+++ b/app/Enums/SubscriptionStatus.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+/**
+ * The canonical lifecycle of a subscription, whatever the merchant calls it.
+ *
+ * Every driver normalises its own vocabulary into these cases before anything
+ * local reads it — Stripe's `incomplete_expired` and `unpaid`, a manual
+ * subscription's plain dates, whatever a future Paddle driver reports. The
+ * one question the rest of the app ever asks is grantsAccess(), so drivers
+ * only need to get *that* mapping right; the finer cases exist for the panel
+ * and the reconciler, which need to say why access stopped.
+ *
+ * PastDue grants access on purpose: it is the dunning window, where the
+ * merchant is retrying a failed payment and the operator chose to keep the
+ * customer's CI green while it does. The hard stops — dispute, refund,
+ * suspension — do not pass through PastDue; they go straight to Suspended or
+ * Canceled, which is what makes them immediate.
+ *
+ * @see \App\Services\Billing\SubscriptionProjector
+ */
+enum SubscriptionStatus: string implements HasLabel
+{
+    /** Checkout started, first payment not yet settled. Grants nothing. */
+    case Incomplete = 'incomplete';
+
+    /** In a trial period. Grants access; the merchant holds the clock. */
+    case Trialing = 'trialing';
+
+    /** Paid up. */
+    case Active = 'active';
+
+    /**
+     * A renewal payment failed and the merchant is retrying. Access
+     * continues until the merchant gives up (Unpaid) or the plan's own
+     * grace_days run out, whichever the projector is watching.
+     */
+    case PastDue = 'past_due';
+
+    /** Paused at the merchant. Grants nothing, but nothing is torn down remotely. */
+    case Paused = 'paused';
+
+    /** Ended by the customer or the operator. */
+    case Canceled = 'canceled';
+
+    /** The merchant exhausted its retries and gave up collecting. */
+    case Unpaid = 'unpaid';
+
+    /**
+     * Withheld by an administrator without touching the billing
+     * relationship — abuse, a dispute under investigation, licence sharing.
+     * The one status only this app can set; no merchant event produces it
+     * and no merchant event clears it.
+     */
+    case Suspended = 'suspended';
+
+    /**
+     * Ran its course. The terminal state of a one-time purchase whose
+     * updates window has closed — nothing failed and nobody cancelled.
+     */
+    case Expired = 'expired';
+
+    /**
+     * The single question the entitlement projector asks. Everything else
+     * on this enum is reporting.
+     */
+    public function grantsAccess(): bool
+    {
+        return match ($this) {
+            self::Trialing, self::Active, self::PastDue => true,
+            self::Incomplete, self::Paused, self::Canceled,
+            self::Unpaid, self::Suspended, self::Expired => false,
+        };
+    }
+
+    /**
+     * Whether a subscription in this status has stopped granting for a
+     * reason the plan's lapse behaviour should answer — as opposed to never
+     * having granted (Incomplete) or being administratively withheld
+     * (Suspended, where the punishment is the point and the lapse behaviour
+     * would soften it).
+     */
+    public function isLapse(): bool
+    {
+        return match ($this) {
+            self::Canceled, self::Unpaid, self::Expired, self::Paused => true,
+            default => false,
+        };
+    }
+
+    /**
+     * The statuses the nightly reconciler re-pulls from the merchant: those
+     * that grant access now, and those the merchant might still move.
+     */
+    public static function reconcilable(): array
+    {
+        return [self::Incomplete, self::Trialing, self::Active, self::PastDue, self::Paused];
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Incomplete => 'Incomplete',
+            self::Trialing => 'Trialing',
+            self::Active => 'Active',
+            self::PastDue => 'Past due',
+            self::Paused => 'Paused',
+            self::Canceled => 'Canceled',
+            self::Unpaid => 'Unpaid',
+            self::Suspended => 'Suspended',
+            self::Expired => 'Expired',
+        };
+    }
+
+    /**
+     * The badge colour Filament tables show this status in — the panel's
+     * shorthand for "money is fine / money needs attention / access is off".
+     */
+    public function color(): string
+    {
+        return match ($this) {
+            self::Active, self::Trialing => 'success',
+            self::PastDue, self::Incomplete, self::Paused => 'warning',
+            self::Canceled, self::Unpaid, self::Suspended, self::Expired => 'danger',
+        };
+    }
+}

--- a/app/Enums/SubscriptionStatus.php
+++ b/app/Enums/SubscriptionStatus.php
@@ -2,6 +2,7 @@
 
 namespace App\Enums;
 
+use App\Services\Billing\SubscriptionProjector;
 use Filament\Support\Contracts\HasLabel;
 
 /**
@@ -20,7 +21,7 @@ use Filament\Support\Contracts\HasLabel;
  * suspension — do not pass through PastDue; they go straight to Suspended or
  * Canceled, which is what makes them immediate.
  *
- * @see \App\Services\Billing\SubscriptionProjector
+ * @see SubscriptionProjector
  */
 enum SubscriptionStatus: string implements HasLabel
 {
@@ -94,6 +95,8 @@ enum SubscriptionStatus: string implements HasLabel
     /**
      * The statuses the nightly reconciler re-pulls from the merchant: those
      * that grant access now, and those the merchant might still move.
+     *
+     * @return list<self>
      */
     public static function reconcilable(): array
     {

--- a/app/Filament/Resources/Activities/Pages/ListActivities.php
+++ b/app/Filament/Resources/Activities/Pages/ListActivities.php
@@ -31,6 +31,6 @@ class ListActivities extends ListRecords
      */
     public function getSubheading(): string
     {
-        return 'Every change recorded anywhere in the registry, including records you cannot reach elsewhere.';
+        return 'A complete history of every change in the registry.';
     }
 }

--- a/app/Filament/Resources/BillingCustomers/BillingCustomerResource.php
+++ b/app/Filament/Resources/BillingCustomers/BillingCustomerResource.php
@@ -29,7 +29,7 @@ class BillingCustomerResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'name';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+    protected static string|UnitEnum|null $navigationGroup = 'Commercial';
 
     protected static ?int $navigationSort = 30;
 
@@ -46,7 +46,7 @@ class BillingCustomerResource extends Resource
     }
 
     /**
-     * The whole Billing group stays out of the sidebar until billing is
+     * The whole Commercial group stays out of the sidebar until billing is
      * turned on: a registry that has not enabled it shows exactly the panel
      * it always showed. The pages still answer by URL for administrators
      * setting things up ahead of the switch.

--- a/app/Filament/Resources/BillingCustomers/BillingCustomerResource.php
+++ b/app/Filament/Resources/BillingCustomers/BillingCustomerResource.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Resources\BillingCustomers;
+
+use App\Filament\Resources\BillingCustomers\Pages\CreateBillingCustomer;
+use App\Filament\Resources\BillingCustomers\Pages\EditBillingCustomer;
+use App\Filament\Resources\BillingCustomers\Pages\ListBillingCustomers;
+use App\Filament\Resources\BillingCustomers\Schemas\BillingCustomerForm;
+use App\Filament\Resources\BillingCustomers\Tables\BillingCustomersTable;
+use App\Models\BillingCustomer;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+/**
+ * Billing customers: the payer behind an account — who the card belongs to
+ * and who the invoice names, kept apart from the account itself.
+ *
+ * @extends \Filament\Resources\Resource<BillingCustomer>
+ */
+class BillingCustomerResource extends Resource
+{
+    protected static ?string $model = BillingCustomer::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedIdentification;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+
+    protected static ?int $navigationSort = 30;
+
+    protected static ?string $modelLabel = 'billing customer';
+
+    public static function form(Schema $schema): Schema
+    {
+        return BillingCustomerForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return BillingCustomersTable::configure($table);
+    }
+
+    /**
+     * The whole Billing group stays out of the sidebar until billing is
+     * turned on: a registry that has not enabled it shows exactly the panel
+     * it always showed. The pages still answer by URL for administrators
+     * setting things up ahead of the switch.
+     */
+    public static function shouldRegisterNavigation(): bool
+    {
+        return (bool) config('registry.billing.enabled');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListBillingCustomers::route('/'),
+            'create' => CreateBillingCustomer::route('/create'),
+            'edit' => EditBillingCustomer::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BillingCustomers/Pages/CreateBillingCustomer.php
+++ b/app/Filament/Resources/BillingCustomers/Pages/CreateBillingCustomer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BillingCustomers\Pages;
+
+use App\Filament\Resources\BillingCustomers\BillingCustomerResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBillingCustomer extends CreateRecord
+{
+    protected static string $resource = BillingCustomerResource::class;
+}

--- a/app/Filament/Resources/BillingCustomers/Pages/EditBillingCustomer.php
+++ b/app/Filament/Resources/BillingCustomers/Pages/EditBillingCustomer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BillingCustomers\Pages;
+
+use App\Filament\Resources\BillingCustomers\BillingCustomerResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBillingCustomer extends EditRecord
+{
+    protected static string $resource = BillingCustomerResource::class;
+}

--- a/app/Filament/Resources/BillingCustomers/Pages/ListBillingCustomers.php
+++ b/app/Filament/Resources/BillingCustomers/Pages/ListBillingCustomers.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\BillingCustomers\Pages;
+
+use App\Filament\Concerns\HidesBreadcrumbs;
+use App\Filament\Resources\BillingCustomers\BillingCustomerResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBillingCustomers extends ListRecords
+{
+    use HidesBreadcrumbs;
+
+    protected static string $resource = BillingCustomerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/BillingCustomers/Schemas/BillingCustomerForm.php
+++ b/app/Filament/Resources/BillingCustomers/Schemas/BillingCustomerForm.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Filament\Resources\BillingCustomers\Schemas;
+
+use App\Enums\MerchantProvider;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Forms\Components\MorphToSelect;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+class BillingCustomerForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                MorphToSelect::make('billable')
+                    ->types([
+                        MorphToSelect\Type::make(User::class)
+                            ->titleAttribute('name'),
+                        MorphToSelect\Type::make(Team::class)
+                            ->titleAttribute('name'),
+                    ])
+                    ->searchable()
+                    ->required()
+                    ->columnSpanFull()
+                    ->live(),
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->helperText('Who the invoice names — routinely not who logs in.'),
+                TextInput::make('email')
+                    ->email()
+                    ->required()
+                    ->maxLength(255)
+                    ->helperText('Where billing mail goes: receipts, dunning notices, trial reminders.'),
+                Select::make('merchant')
+                    ->options(MerchantProvider::class)
+                    ->default(MerchantProvider::Manual)
+                    ->required()
+                    ->helperText('Manual for customers billed outside any processor. A customer created by checkout arrives as Stripe on its own.'),
+                Select::make('billing_contact_user_id')
+                    ->label('Billing contact')
+                    ->relationship('billingContact', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->visible(fn (Get $get): bool => $get('billable_type') === Team::class)
+                    ->helperText('The one member billing mail and the activation token go to. Required in practice for a team customer.'),
+
+                Section::make('Business details')
+                    ->description('Captured at checkout for merchant-billed customers; entered here for Manual ones. What EU B2B invoices are required to carry.')
+                    ->columnSpanFull()
+                    ->columns(2)
+                    ->collapsed()
+                    ->schema([
+                        TextInput::make('company_name')->maxLength(255),
+                        TextInput::make('tax_id')
+                            ->label('Tax / VAT ID')
+                            ->maxLength(64),
+                        TextInput::make('address.line1')->label('Address line 1'),
+                        TextInput::make('address.line2')->label('Address line 2'),
+                        TextInput::make('address.city')->label('City'),
+                        TextInput::make('address.state')->label('State / region'),
+                        TextInput::make('address.postal_code')->label('Postal code'),
+                        TextInput::make('address.country')
+                            ->label('Country')
+                            ->maxLength(2)
+                            ->helperText('Two-letter ISO code.'),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/BillingCustomers/Tables/BillingCustomersTable.php
+++ b/app/Filament/Resources/BillingCustomers/Tables/BillingCustomersTable.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Resources\BillingCustomers\Tables;
+
+use App\Models\BillingCustomer;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class BillingCustomersTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('name')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->description(fn (BillingCustomer $record): string => $record->email),
+                TextColumn::make('billable_type')
+                    ->label('Kind')
+                    ->formatStateUsing(fn (string $state): string => class_basename($state))
+                    ->badge()
+                    ->color('gray'),
+                TextColumn::make('billable.name')
+                    ->label('Account'),
+                TextColumn::make('merchant')
+                    ->badge()
+                    ->color('gray'),
+                TextColumn::make('subscriptions_count')
+                    ->label('Subscriptions')
+                    ->counts('subscriptions')
+                    ->badge()
+                    ->color('gray'),
+                TextColumn::make('company_name')
+                    ->placeholder('—')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->emptyStateHeading('No billing customers')
+            ->emptyStateDescription('A billing customer is the payer behind an account — created by checkout, or here for customers billed by hand.');
+    }
+}

--- a/app/Filament/Resources/Invoices/InvoiceResource.php
+++ b/app/Filament/Resources/Invoices/InvoiceResource.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filament\Resources\Invoices;
+
+use App\Filament\Resources\Invoices\Pages\ListInvoices;
+use App\Filament\Resources\Invoices\Tables\InvoicesTable;
+use App\Models\Invoice;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+/**
+ * Invoices: the local mirror of what the merchant issued. Read-only by
+ * design — the merchant renders the documents; these rows exist so history
+ * is browsable without a live API call and survives a merchant migration.
+ *
+ * @extends \Filament\Resources\Resource<Invoice>
+ */
+class InvoiceResource extends Resource
+{
+    protected static ?string $model = Invoice::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+
+    protected static ?int $navigationSort = 40;
+
+    public static function table(Table $table): Table
+    {
+        return InvoicesTable::configure($table);
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    /**
+     * The whole Billing group stays out of the sidebar until billing is
+     * turned on: a registry that has not enabled it shows exactly the panel
+     * it always showed. The pages still answer by URL for administrators
+     * setting things up ahead of the switch.
+     */
+    public static function shouldRegisterNavigation(): bool
+    {
+        return (bool) config('registry.billing.enabled');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListInvoices::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Invoices/InvoiceResource.php
+++ b/app/Filament/Resources/Invoices/InvoiceResource.php
@@ -24,7 +24,7 @@ class InvoiceResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
 
-    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+    protected static string|UnitEnum|null $navigationGroup = 'Commercial';
 
     protected static ?int $navigationSort = 40;
 
@@ -39,7 +39,7 @@ class InvoiceResource extends Resource
     }
 
     /**
-     * The whole Billing group stays out of the sidebar until billing is
+     * The whole Commercial group stays out of the sidebar until billing is
      * turned on: a registry that has not enabled it shows exactly the panel
      * it always showed. The pages still answer by URL for administrators
      * setting things up ahead of the switch.

--- a/app/Filament/Resources/Invoices/Pages/ListInvoices.php
+++ b/app/Filament/Resources/Invoices/Pages/ListInvoices.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Filament\Resources\Invoices\Pages;
+
+use App\Filament\Concerns\HidesBreadcrumbs;
+use App\Filament\Resources\Invoices\InvoiceResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListInvoices extends ListRecords
+{
+    use HidesBreadcrumbs;
+
+    protected static string $resource = InvoiceResource::class;
+}

--- a/app/Filament/Resources/Invoices/Tables/InvoicesTable.php
+++ b/app/Filament/Resources/Invoices/Tables/InvoicesTable.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Resources\Invoices\Tables;
+
+use App\Models\Invoice;
+use Filament\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class InvoicesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('issued_at', 'desc')
+            ->columns([
+                TextColumn::make('number')
+                    ->searchable()
+                    ->placeholder('—'),
+                TextColumn::make('customer.name')
+                    ->label('Customer')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('total')
+                    ->formatStateUsing(fn (Invoice $record): string => strtoupper($record->currency).' '.number_format($record->total / 100, 2))
+                    ->sortable(),
+                TextColumn::make('amount_refunded')
+                    ->label('Refunded')
+                    ->formatStateUsing(fn (Invoice $record): string => $record->amount_refunded > 0
+                        ? strtoupper($record->currency).' '.number_format($record->amount_refunded / 100, 2)
+                        : '—'),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'paid' => 'success',
+                        'open', 'draft' => 'warning',
+                        default => 'danger',
+                    }),
+                TextColumn::make('issued_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->recordActions([
+                Action::make('open')
+                    ->label('View at merchant')
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->url(fn (Invoice $record): ?string => $record->hosted_url, shouldOpenInNewTab: true)
+                    ->visible(fn (Invoice $record): bool => $record->hosted_url !== null),
+            ])
+            ->emptyStateHeading('No invoices')
+            ->emptyStateDescription('Invoices are mirrored here as the merchant issues them.');
+    }
+}

--- a/app/Filament/Resources/Plans/Pages/CreatePlan.php
+++ b/app/Filament/Resources/Plans/Pages/CreatePlan.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\Plans\Pages;
+
+use App\Filament\Resources\Plans\PlanResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePlan extends CreateRecord
+{
+    protected static string $resource = PlanResource::class;
+}

--- a/app/Filament/Resources/Plans/Pages/EditPlan.php
+++ b/app/Filament/Resources/Plans/Pages/EditPlan.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Filament\Resources\Plans\Pages;
+
+use App\Filament\Resources\Plans\PlanResource;
+use App\Jobs\ReprojectPlanEntitlements;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPlan extends EditRecord
+{
+    protected static string $resource = PlanResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+
+    /**
+     * Editing a plan's entitlements changes what every subscriber holds, so
+     * every subscription re-projects — on the queue, because a popular plan
+     * is thousands of customers and this request is one person's save.
+     */
+    protected function afterSave(): void
+    {
+        ReprojectPlanEntitlements::dispatch($this->record->getKey());
+    }
+}

--- a/app/Filament/Resources/Plans/Pages/ListPlans.php
+++ b/app/Filament/Resources/Plans/Pages/ListPlans.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\Plans\Pages;
+
+use App\Filament\Concerns\HidesBreadcrumbs;
+use App\Filament\Resources\Plans\PlanResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPlans extends ListRecords
+{
+    use HidesBreadcrumbs;
+
+    protected static string $resource = PlanResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/Plans/PlanResource.php
+++ b/app/Filament/Resources/Plans/PlanResource.php
@@ -33,7 +33,7 @@ class PlanResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'name';
 
-    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+    protected static string|UnitEnum|null $navigationGroup = 'Commercial';
 
     protected static ?int $navigationSort = 10;
 
@@ -48,7 +48,7 @@ class PlanResource extends Resource
     }
 
     /**
-     * The whole Billing group stays out of the sidebar until billing is
+     * The whole Commercial group stays out of the sidebar until billing is
      * turned on: a registry that has not enabled it shows exactly the panel
      * it always showed. The pages still answer by URL for administrators
      * setting things up ahead of the switch.

--- a/app/Filament/Resources/Plans/PlanResource.php
+++ b/app/Filament/Resources/Plans/PlanResource.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Filament\Resources\Plans;
+
+use App\Filament\Resources\Plans\Pages\CreatePlan;
+use App\Filament\Resources\Plans\Pages\EditPlan;
+use App\Filament\Resources\Plans\Pages\ListPlans;
+use App\Filament\Resources\Plans\Schemas\PlanForm;
+use App\Filament\Resources\Plans\Tables\PlansTable;
+use App\Models\Plan;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+/**
+ * Plans: what the registry sells, and every rule a subscription lives by.
+ *
+ * A plan bundles entitlements the way a team bundles grants, so Create:Plan
+ * and Update:Plan are powers of the same weight as Create:Team — whoever
+ * holds them decides what money buys. The entitlement pickers are scoped to
+ * the editor's own sight for exactly the reason TeamForm's are.
+ *
+ * @extends \Filament\Resources\Resource<Plan>
+ */
+class PlanResource extends Resource
+{
+    protected static ?string $model = Plan::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedTag;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+
+    protected static ?int $navigationSort = 10;
+
+    public static function form(Schema $schema): Schema
+    {
+        return PlanForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return PlansTable::configure($table);
+    }
+
+    /**
+     * The whole Billing group stays out of the sidebar until billing is
+     * turned on: a registry that has not enabled it shows exactly the panel
+     * it always showed. The pages still answer by URL for administrators
+     * setting things up ahead of the switch.
+     */
+    public static function shouldRegisterNavigation(): bool
+    {
+        return (bool) config('registry.billing.enabled');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListPlans::route('/'),
+            'create' => CreatePlan::route('/create'),
+            'edit' => EditPlan::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Plans/Schemas/PlanForm.php
+++ b/app/Filament/Resources/Plans/Schemas/PlanForm.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace App\Filament\Resources\Plans\Schemas;
+
+use App\Enums\BillingInterval;
+use App\Enums\BillingModel;
+use App\Enums\CancellationTiming;
+use App\Enums\LapseBehaviour;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\User;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class PlanForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255)
+                    ->placeholder('Pro')
+                    ->live(onBlur: true)
+                    ->afterStateUpdated(function (Get $get, callable $set, ?string $state): void {
+                        if (! $get('slug')) {
+                            $set('slug', Str::slug((string) $state));
+                        }
+                    }),
+                TextInput::make('slug')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(ignoreRecord: true)
+                    ->rule('alpha_dash')
+                    ->helperText('The plan\'s URL on the pricing page, and the handle it is synced to merchants under. Renaming after launch breaks shared links.'),
+                Textarea::make('description')
+                    ->rows(2)
+                    ->columnSpanFull()
+                    ->placeholder('What buying this plan gets a customer.'),
+                Toggle::make('active')
+                    ->default(true)
+                    ->helperText('Whether the plan can be bought at all. Existing subscriptions are unaffected either way.'),
+                Toggle::make('listed')
+                    ->helperText('Show on the public pricing page. An unlisted plan is still sellable by direct link — launch offers, negotiated tiers.'),
+
+                Section::make('Billing')
+                    ->columnSpanFull()
+                    ->columns(2)
+                    ->schema([
+                        Select::make('billing_model')
+                            ->options(BillingModel::class)
+                            ->default(BillingModel::Recurring)
+                            ->required()
+                            ->live()
+                            ->helperText('How the plan charges — and what "it ended" means.'),
+                        TextInput::make('trial_days')
+                            ->numeric()
+                            ->minValue(0)
+                            ->default(0)
+                            ->visible(fn (Get $get): bool => $get('billing_model') === BillingModel::Recurring || $get('billing_model') === BillingModel::Recurring->value)
+                            ->helperText('Days before the first charge. 0 is no trial.'),
+                        TextInput::make('updates_window_months')
+                            ->numeric()
+                            ->minValue(1)
+                            ->visible(fn (Get $get): bool => $get('billing_model') === BillingModel::OneTimeWithUpdates || $get('billing_model') === BillingModel::OneTimeWithUpdates->value)
+                            ->requiredIf('billing_model', BillingModel::OneTimeWithUpdates->value)
+                            ->helperText('Months of new releases a purchase includes. What exists when the window closes is the customer\'s forever.'),
+                        Repeater::make('prices')
+                            ->relationship()
+                            ->columnSpanFull()
+                            ->columns(4)
+                            ->defaultItems(1)
+                            ->schema([
+                                TextInput::make('currency')
+                                    ->default(fn (): string => (string) config('registry.billing.currency'))
+                                    ->required()
+                                    ->maxLength(3)
+                                    ->helperText('ISO 4217, e.g. usd.'),
+                                TextInput::make('amount')
+                                    ->numeric()
+                                    ->required()
+                                    ->minValue(0)
+                                    ->helperText('Minor units: 1999 is $19.99.'),
+                                Select::make('interval')
+                                    ->options(BillingInterval::class)
+                                    ->default(BillingInterval::Month)
+                                    ->required(),
+                                Toggle::make('active')
+                                    ->default(true)
+                                    ->inline(false),
+                            ])
+                            ->helperText('Retiring a price stops offering it; subscriptions already on it keep being charged under it.'),
+                    ]),
+
+                Section::make('Entitlements')
+                    ->description('What a subscription to this plan grants — the same two shapes a grant has always had, projected onto every subscriber for as long as they are paid up.')
+                    ->columnSpanFull()
+                    ->schema([
+                        Select::make('repositories')
+                            ->label('Granted repositories')
+                            ->relationship('repositories', 'name', self::visibleRepositories(...))
+                            ->multiple()
+                            ->preload()
+                            ->helperText('Every package in the chosen repositories, present and future.'),
+                        Select::make('packages')
+                            ->label('Granted packages')
+                            ->relationship('packages', 'name', self::visiblePackages(...))
+                            ->multiple()
+                            ->searchable()
+                            ->preload()
+                            ->helperText('Individual packages, wherever they are served from.'),
+                    ]),
+
+                Section::make('Lifecycle')
+                    ->description('What happens when a subscription to this plan stops being paid — each plan decides for itself.')
+                    ->columnSpanFull()
+                    ->columns(2)
+                    ->schema([
+                        Select::make('lapse_behaviour')
+                            ->options(LapseBehaviour::class)
+                            ->default(LapseBehaviour::WithdrawEntitlement)
+                            ->required()
+                            ->helperText('Freeze-at-version is the perpetual-licence shape, and the implied choice for a one-time purchase.'),
+                        TextInput::make('grace_days')
+                            ->numeric()
+                            ->minValue(0)
+                            ->placeholder('Follow the merchant')
+                            ->helperText('Days of continued access after the merchant gives up collecting, before the lapse behaviour runs. Empty follows the merchant\'s own dunning alone.'),
+                        Select::make('cancellation')
+                            ->options(CancellationTiming::class)
+                            ->default(CancellationTiming::Immediate)
+                            ->required()
+                            ->helperText('When the customer\'s own cancellation takes access away. End-of-period is the industry norm.'),
+                        TextInput::make('token_limit')
+                            ->numeric()
+                            ->minValue(1)
+                            ->placeholder('Unlimited')
+                            ->helperText('How many access tokens a subscription may hold at once. The auto-issued one counts.'),
+                        Toggle::make('auto_issue_token')
+                            ->default(true)
+                            ->label('Auto-issue a token on activation')
+                            ->helperText('Mint a read token the moment the purchase completes, shown once, so the buyer leaves checkout with a working credential.'),
+                        TextInput::make('sort')
+                            ->numeric()
+                            ->default(0)
+                            ->helperText('Position on the pricing page, lowest first.'),
+                    ]),
+            ]);
+    }
+
+    /**
+     * Scoped for the reason TeamForm scopes its pickers: an unscoped,
+     * preloaded picker is a list of every private repository and package
+     * name, handed to anybody holding Create:Plan.
+     *
+     * @param  Builder<Repository>  $query
+     * @return Builder<Repository>
+     */
+    private static function visibleRepositories(Builder $query): Builder
+    {
+        return $query->visibleToUser(self::actingUser());
+    }
+
+    /**
+     * @param  Builder<Package>  $query
+     * @return Builder<Package>
+     */
+    private static function visiblePackages(Builder $query): Builder
+    {
+        return $query->visibleToUser(self::actingUser());
+    }
+
+    private static function actingUser(): User
+    {
+        /** @var User */
+        return auth()->user();
+    }
+}

--- a/app/Filament/Resources/Plans/Tables/PlansTable.php
+++ b/app/Filament/Resources/Plans/Tables/PlansTable.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Filament\Resources\Plans\Tables;
+
+use App\Models\Plan;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class PlansTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('sort')
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->description(fn (Plan $record): string => $record->slug),
+                TextColumn::make('billing_model')
+                    ->label('Model')
+                    ->badge()
+                    ->color('gray'),
+                TextColumn::make('prices')
+                    ->label('Prices')
+                    ->state(fn (Plan $record): string => $record->prices
+                        ->where('active', true)
+                        ->map->display()
+                        ->join(', ') ?: '—'),
+                TextColumn::make('subscriptions_count')
+                    ->label('Subscriptions')
+                    ->counts('subscriptions')
+                    ->badge()
+                    ->color('gray')
+                    ->sortable(),
+                IconColumn::make('active')
+                    ->boolean(),
+                IconColumn::make('listed')
+                    ->boolean()
+                    ->toggleable(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make()
+                    ->modalDescription('Existing subscriptions keep the plan (the delete is refused while any point at it); retiring usually means turning Active off instead.'),
+            ])
+            ->emptyStateHeading('No plans')
+            ->emptyStateDescription('A plan names what a subscription grants, its prices, and every rule its lifecycle follows.');
+    }
+}

--- a/app/Filament/Resources/Subscriptions/Actions/CancelSubscriptionAction.php
+++ b/app/Filament/Resources/Subscriptions/Actions/CancelSubscriptionAction.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Actions;
+
+use App\Enums\CancellationTiming;
+use App\Enums\MerchantProvider;
+use App\Enums\SubscriptionStatus;
+use App\Models\Subscription;
+use App\Services\Billing\EntitlementProjector;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Toggle;
+
+/**
+ * Cancel a subscription from the operator's side.
+ *
+ * For a merchant-billed subscription the cancellation is sent to the
+ * merchant, and the local row waits for the confirming event — the merchant
+ * owns the clock, and a local edit it disagrees with would be repaired away
+ * by the next webhook. A Manual subscription has no merchant to wait for,
+ * so it is cancelled directly and re-projected on the spot.
+ */
+class CancelSubscriptionAction
+{
+    public static function make(): Action
+    {
+        return Action::make('cancel')
+            ->label('Cancel')
+            ->icon('heroicon-o-x-circle')
+            ->color('danger')
+            ->visible(fn (Subscription $record): bool => ! in_array($record->status, [
+                SubscriptionStatus::Canceled, SubscriptionStatus::Expired,
+            ], true))
+            ->schema([
+                Toggle::make('immediately')
+                    ->label('Cancel immediately')
+                    ->default(fn (Subscription $record): bool => $record->plan->cancellation === CancellationTiming::Immediate)
+                    ->helperText('Off lets the paid period run out; on withdraws access now.'),
+            ])
+            ->requiresConfirmation()
+            ->action(function (Subscription $record, array $data): void {
+                $immediately = (bool) $data['immediately'];
+
+                if ($record->merchant !== MerchantProvider::Manual) {
+                    $record->client()->cancel($record, $immediately);
+                }
+
+                if (! $immediately) {
+                    // Access runs to the end of the paid period. The status
+                    // stays what it is — Canceled would withdraw access on
+                    // the next projection — and the boundary is crossed by
+                    // the merchant's confirming event, or by the nightly
+                    // reconcile for a Manual subscription.
+                    $record->forceFill(['cancel_at' => $record->current_period_end])->save();
+
+                    return;
+                }
+
+                $record->forceFill([
+                    'status' => SubscriptionStatus::Canceled,
+                    'canceled_at' => now(),
+                    'ends_at' => now(),
+                    'last_event_at' => now(),
+                ])->save();
+
+                app(EntitlementProjector::class)->project($record);
+            });
+    }
+}

--- a/app/Filament/Resources/Subscriptions/Actions/SuspendSubscriptionAction.php
+++ b/app/Filament/Resources/Subscriptions/Actions/SuspendSubscriptionAction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Actions;
+
+use App\Models\Subscription;
+use App\Services\Billing\EntitlementProjector;
+use Filament\Actions\Action;
+use Filament\Forms\Components\TextInput;
+
+/**
+ * The administrative hard stop, and its reversal.
+ *
+ * Suspension withholds access without touching the billing relationship —
+ * the merchant keeps charging unless somebody also cancels — and it bypasses
+ * the plan's lapse behaviour on purpose: it is for abuse, licence sharing
+ * and disputes, where a frozen-ceiling keepsake would defeat the act.
+ */
+class SuspendSubscriptionAction
+{
+    public static function make(): Action
+    {
+        return Action::make('suspend')
+            ->label(fn (Subscription $record): string => $record->suspended_at === null ? 'Suspend' : 'Unsuspend')
+            ->icon('heroicon-o-no-symbol')
+            ->color(fn (Subscription $record): string => $record->suspended_at === null ? 'danger' : 'success')
+            ->schema(fn (Subscription $record): array => $record->suspended_at === null ? [
+                TextInput::make('reason')
+                    ->required()
+                    ->maxLength(255)
+                    ->helperText('Shown to other administrators, and kept in the audit log.'),
+            ] : [])
+            ->requiresConfirmation()
+            ->modalDescription(fn (Subscription $record): string => $record->suspended_at === null
+                ? 'Access is withdrawn immediately, whatever the plan\'s lapse behaviour says. Billing at the merchant continues until cancelled.'
+                : 'Access is restored immediately.')
+            ->action(function (Subscription $record, array $data): void {
+                $record->forceFill($record->suspended_at === null
+                    ? ['suspended_at' => now(), 'suspension_reason' => $data['reason']]
+                    : ['suspended_at' => null, 'suspension_reason' => null])->save();
+
+                app(EntitlementProjector::class)->project($record);
+            });
+    }
+}

--- a/app/Filament/Resources/Subscriptions/Pages/CreateSubscription.php
+++ b/app/Filament/Resources/Subscriptions/Pages/CreateSubscription.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Pages;
+
+use App\Enums\MerchantProvider;
+use App\Enums\SubscriptionStatus;
+use App\Filament\Resources\Subscriptions\SubscriptionResource;
+use App\Models\Subscription;
+use App\Services\Billing\EntitlementProjector;
+use App\Services\Billing\SubscriptionTokens;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Creates a Manual subscription: active from now, granted immediately.
+ *
+ * The one place a subscription is born without a merchant behind it. The
+ * activation token is issued here too when the plan says so — its plain text
+ * goes to the admin in a notification, because the buyer never saw a
+ * checkout success page to read it from.
+ */
+class CreateSubscription extends CreateRecord
+{
+    protected static string $resource = SubscriptionResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $subscription = Subscription::query()->create([
+            ...$data,
+            'merchant' => MerchantProvider::Manual,
+            'status' => SubscriptionStatus::Active,
+            'current_period_start' => now(),
+            'last_event_at' => now(),
+        ]);
+
+        app(EntitlementProjector::class)->project($subscription);
+
+        $token = app(SubscriptionTokens::class)->issueActivationToken($subscription);
+
+        if ($token !== null) {
+            Notification::make()
+                ->title('Access token issued')
+                ->body("Hand this to the customer — it is shown once: {$token->plainText}")
+                ->persistent()
+                ->success()
+                ->send();
+        }
+
+        return $subscription;
+    }
+}

--- a/app/Filament/Resources/Subscriptions/Pages/EditSubscription.php
+++ b/app/Filament/Resources/Subscriptions/Pages/EditSubscription.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Subscriptions\Pages;
 use App\Filament\Resources\Subscriptions\Actions\CancelSubscriptionAction;
 use App\Filament\Resources\Subscriptions\Actions\SuspendSubscriptionAction;
 use App\Filament\Resources\Subscriptions\SubscriptionResource;
+use App\Models\Subscription;
 use App\Services\Billing\EntitlementProjector;
 use Filament\Resources\Pages\EditRecord;
 
@@ -28,6 +29,10 @@ class EditSubscription extends EditRecord
 
     protected function afterSave(): void
     {
-        app(EntitlementProjector::class)->project($this->record->fresh());
+        $record = $this->record;
+
+        if ($record instanceof Subscription) {
+            app(EntitlementProjector::class)->project($record->refresh());
+        }
     }
 }

--- a/app/Filament/Resources/Subscriptions/Pages/EditSubscription.php
+++ b/app/Filament/Resources/Subscriptions/Pages/EditSubscription.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Pages;
+
+use App\Filament\Resources\Subscriptions\Actions\CancelSubscriptionAction;
+use App\Filament\Resources\Subscriptions\Actions\SuspendSubscriptionAction;
+use App\Filament\Resources\Subscriptions\SubscriptionResource;
+use App\Services\Billing\EntitlementProjector;
+use Filament\Resources\Pages\EditRecord;
+
+/**
+ * Managing a subscription is actions, not fields: the merchant owns the
+ * clocks, and the two things an operator legitimately does — suspend and
+ * cancel — change state through the same paths the webhooks use, so the
+ * next event cannot quietly undo them.
+ */
+class EditSubscription extends EditRecord
+{
+    protected static string $resource = SubscriptionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            SuspendSubscriptionAction::make(),
+            CancelSubscriptionAction::make(),
+        ];
+    }
+
+    protected function afterSave(): void
+    {
+        app(EntitlementProjector::class)->project($this->record->fresh());
+    }
+}

--- a/app/Filament/Resources/Subscriptions/Pages/ListSubscriptions.php
+++ b/app/Filament/Resources/Subscriptions/Pages/ListSubscriptions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Pages;
+
+use App\Filament\Concerns\HidesBreadcrumbs;
+use App\Filament\Resources\Subscriptions\SubscriptionResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSubscriptions extends ListRecords
+{
+    use HidesBreadcrumbs;
+
+    protected static string $resource = SubscriptionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make()
+                ->label('New manual subscription'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Subscriptions/Schemas/SubscriptionForm.php
+++ b/app/Filament/Resources/Subscriptions/Schemas/SubscriptionForm.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Schemas;
+
+use App\Models\Plan;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+/**
+ * The create form only makes Manual subscriptions — comps, wire transfers,
+ * purchase orders. Everything merchant-billed is created by checkout and
+ * maintained by webhooks; editing its clocks here would just be overwritten
+ * by the next event, so the edit page is actions, not fields.
+ */
+class SubscriptionForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Select::make('billing_customer_id')
+                    ->label('Customer')
+                    ->relationship('customer', 'name')
+                    ->searchable()
+                    ->preload()
+                    ->required()
+                    ->helperText('Create the customer first, under Billing customers.'),
+                Select::make('plan_id')
+                    ->label('Plan')
+                    ->relationship('plan', 'name')
+                    ->preload()
+                    ->required()
+                    ->live(),
+                Select::make('plan_price_id')
+                    ->label('Price')
+                    ->options(fn (Get $get): array => Plan::query()
+                        ->find($get('plan_id'))
+                        ?->prices()
+                        ->get()
+                        ->mapWithKeys(fn ($price): array => [$price->getKey() => $price->display()])
+                        ->all() ?? [])
+                    ->required()
+                    ->helperText('What this would cost if it were billed — kept for the record; nothing is charged.'),
+                DateTimePicker::make('current_period_end')
+                    ->label('Runs until')
+                    ->helperText('Empty means indefinitely — the shape of a comp. A date makes it lapse there, under the plan\'s lapse behaviour, when the nightly reconcile passes it.'),
+            ]);
+    }
+}

--- a/app/Filament/Resources/Subscriptions/SubscriptionResource.php
+++ b/app/Filament/Resources/Subscriptions/SubscriptionResource.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions;
+
+use App\Filament\Resources\Subscriptions\Pages\CreateSubscription;
+use App\Filament\Resources\Subscriptions\Pages\EditSubscription;
+use App\Filament\Resources\Subscriptions\Pages\ListSubscriptions;
+use App\Filament\Resources\Subscriptions\Schemas\SubscriptionForm;
+use App\Filament\Resources\Subscriptions\Tables\SubscriptionsTable;
+use App\Models\Subscription;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use UnitEnum;
+
+/**
+ * Subscriptions: who has paid access, through which plan, in what state.
+ *
+ * Merchant-billed rows are projections the webhooks and the reconciler keep
+ * true — the panel reads them and acts on them (suspend, cancel) but never
+ * edits their clocks by hand. What *is* created here is the Manual
+ * subscription: a comp, a wire transfer, a PO, recorded first-class so the
+ * projector treats it exactly like paid ones.
+ *
+ * @extends \Filament\Resources\Resource<Subscription>
+ */
+class SubscriptionResource extends Resource
+{
+    protected static ?string $model = Subscription::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedArrowPathRoundedSquare;
+
+    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+
+    protected static ?int $navigationSort = 20;
+
+    public static function form(Schema $schema): Schema
+    {
+        return SubscriptionForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return SubscriptionsTable::configure($table);
+    }
+
+    /**
+     * The whole Billing group stays out of the sidebar until billing is
+     * turned on: a registry that has not enabled it shows exactly the panel
+     * it always showed. The pages still answer by URL for administrators
+     * setting things up ahead of the switch.
+     */
+    public static function shouldRegisterNavigation(): bool
+    {
+        return (bool) config('registry.billing.enabled');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListSubscriptions::route('/'),
+            'create' => CreateSubscription::route('/create'),
+            'edit' => EditSubscription::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/Subscriptions/SubscriptionResource.php
+++ b/app/Filament/Resources/Subscriptions/SubscriptionResource.php
@@ -32,7 +32,7 @@ class SubscriptionResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedArrowPathRoundedSquare;
 
-    protected static string|UnitEnum|null $navigationGroup = 'Billing';
+    protected static string|UnitEnum|null $navigationGroup = 'Commercial';
 
     protected static ?int $navigationSort = 20;
 
@@ -47,7 +47,7 @@ class SubscriptionResource extends Resource
     }
 
     /**
-     * The whole Billing group stays out of the sidebar until billing is
+     * The whole Commercial group stays out of the sidebar until billing is
      * turned on: a registry that has not enabled it shows exactly the panel
      * it always showed. The pages still answer by URL for administrators
      * setting things up ahead of the switch.

--- a/app/Filament/Resources/Subscriptions/Tables/SubscriptionsTable.php
+++ b/app/Filament/Resources/Subscriptions/Tables/SubscriptionsTable.php
@@ -20,7 +20,7 @@ class SubscriptionsTable
                     ->label('Customer')
                     ->searchable()
                     ->sortable()
-                    ->description(fn (Subscription $record): string => $record->customer?->email ?? ''),
+                    ->description(fn (Subscription $record): string => (string) $record->customer?->email),
                 TextColumn::make('plan.name')
                     ->label('Plan')
                     ->sortable(),

--- a/app/Filament/Resources/Subscriptions/Tables/SubscriptionsTable.php
+++ b/app/Filament/Resources/Subscriptions/Tables/SubscriptionsTable.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Filament\Resources\Subscriptions\Tables;
+
+use App\Enums\SubscriptionStatus;
+use App\Models\Subscription;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class SubscriptionsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->defaultSort('created_at', 'desc')
+            ->columns([
+                TextColumn::make('customer.name')
+                    ->label('Customer')
+                    ->searchable()
+                    ->sortable()
+                    ->description(fn (Subscription $record): string => $record->customer?->email ?? ''),
+                TextColumn::make('plan.name')
+                    ->label('Plan')
+                    ->sortable(),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (SubscriptionStatus $state): string => $state->color()),
+                TextColumn::make('merchant')
+                    ->badge()
+                    ->color('gray')
+                    ->toggleable(),
+                TextColumn::make('current_period_end')
+                    ->label('Period ends')
+                    ->dateTime()
+                    ->sortable()
+                    ->placeholder('—'),
+                TextColumn::make('grace_ends_at')
+                    ->label('Grace until')
+                    ->dateTime()
+                    ->placeholder('—')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('suspended_at')
+                    ->label('Suspended')
+                    ->dateTime()
+                    ->placeholder('—')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(SubscriptionStatus::class),
+                SelectFilter::make('plan')
+                    ->relationship('plan', 'name'),
+            ])
+            ->recordActions([
+                EditAction::make()->label('Manage'),
+            ])
+            ->emptyStateHeading('No subscriptions')
+            ->emptyStateDescription('Merchant-billed subscriptions appear here when checkout completes; Manual ones are created here directly.');
+    }
+}

--- a/app/Filament/Widgets/BillingTotals.php
+++ b/app/Filament/Widgets/BillingTotals.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\BillingInterval;
+use App\Enums\SubscriptionStatus;
+use App\Models\Subscription;
+use Filament\Widgets\StatsOverviewWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+
+/**
+ * The four numbers an operator checks daily: recurring revenue, live
+ * subscriptions, trials about to convert or walk, and payments in trouble.
+ *
+ * MRR is computed from local rows — each active recurring subscription's
+ * price normalised to a month — so it costs one query and no API call. It
+ * is the operator's dial, not the accountant's number: proration, discounts
+ * and tax live at the merchant.
+ *
+ * Hidden entirely while billing is disabled, and from anybody who cannot
+ * see subscriptions.
+ */
+class BillingTotals extends StatsOverviewWidget
+{
+    protected static ?int $sort = 5;
+
+    public static function canView(): bool
+    {
+        return (bool) config('registry.billing.enabled')
+            && (auth()->user()?->can('ViewAny:Subscription') ?? false);
+    }
+
+    protected function getStats(): array
+    {
+        $active = Subscription::query()
+            ->whereIn('status', [SubscriptionStatus::Active, SubscriptionStatus::Trialing])
+            ->whereNull('suspended_at')
+            ->count();
+
+        $trialsEnding = Subscription::query()
+            ->where('status', SubscriptionStatus::Trialing)
+            ->whereBetween('trial_ends_at', [now(), now()->addDays(7)])
+            ->count();
+
+        $pastDue = Subscription::query()
+            ->whereIn('status', [SubscriptionStatus::PastDue, SubscriptionStatus::Unpaid])
+            ->count();
+
+        return [
+            Stat::make('Monthly recurring revenue', $this->mrr()),
+            Stat::make('Active subscriptions', (string) $active),
+            Stat::make('Trials ending this week', (string) $trialsEnding),
+            Stat::make('Past due', (string) $pastDue)
+                ->color($pastDue > 0 ? 'danger' : 'success'),
+        ];
+    }
+
+    private function mrr(): string
+    {
+        $subscriptions = Subscription::query()
+            ->where('status', SubscriptionStatus::Active)
+            ->whereNull('suspended_at')
+            ->with('price')
+            ->get();
+
+        $byCurrency = [];
+
+        foreach ($subscriptions as $subscription) {
+            $price = $subscription->price;
+
+            if ($price === null || ! $price->interval->recurring()) {
+                continue;
+            }
+
+            $monthly = match ($price->interval) {
+                BillingInterval::Month => $price->amount / max(1, $price->interval_count),
+                BillingInterval::Year => $price->amount / (12 * max(1, $price->interval_count)),
+                BillingInterval::OneTime => 0,
+            };
+
+            $byCurrency[$price->currency] = ($byCurrency[$price->currency] ?? 0)
+                + (int) round($monthly * $subscription->quantity);
+        }
+
+        if ($byCurrency === []) {
+            return '—';
+        }
+
+        return collect($byCurrency)
+            ->map(fn (int $amount, string $currency): string => strtoupper($currency).' '.number_format($amount / 100, 2))
+            ->join(' + ');
+    }
+}

--- a/app/Http/Controllers/Billing/BillingController.php
+++ b/app/Http/Controllers/Billing/BillingController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Billing;
+
+use App\Http\Controllers\Controller;
+use App\Merchants\UnsupportedMerchantException;
+use App\Models\BillingCustomer;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * The customer area: subscription status, invoices, tokens, and the door to
+ * the merchant's portal — everything a paying customer manages, none of it
+ * inside /admin.
+ *
+ * A customer is a User with no role; the panel is structurally closed to
+ * them and this is their whole surface. The pages show only what belongs to
+ * the signed-in user's own billing customer (or the one their team holds and
+ * names them contact for), which is the entire authorization story here.
+ */
+class BillingController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+
+        $user = $request->user();
+        $customer = $this->customerFor($user);
+
+        return response()->view('billing.index', [
+            'repository' => Repository::default(),
+            'user' => $user,
+            'customer' => $customer?->load([
+                'subscriptions.plan',
+                'subscriptions.price',
+                'invoices' => fn ($query) => $query->orderByDesc('issued_at')->limit(24),
+            ]),
+            'tokens' => $customer !== null
+                ? $user->tokens()->whereNotNull('subscription_id')->get()
+                : collect(),
+        ]);
+    }
+
+    /** One hop into the merchant's card-and-invoices portal, and back. */
+    public function portal(Request $request): RedirectResponse
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+
+        $customer = $this->customerFor($request->user());
+
+        abort_if($customer === null, 404);
+
+        try {
+            return redirect()->away(
+                $customer->client()->portalUrl($customer, route('billing.index')),
+            );
+        } catch (UnsupportedMerchantException $e) {
+            return redirect()->route('billing.index')->with('status', $e->getMessage());
+        }
+    }
+
+    /**
+     * The signed-in user's billing customer: their own, or the team one that
+     * names them as billing contact.
+     */
+    private function customerFor(?User $user): ?BillingCustomer
+    {
+        if ($user === null) {
+            return null;
+        }
+
+        return $user->billingCustomer
+            ?? BillingCustomer::query()
+                ->where('billing_contact_user_id', $user->getKey())
+                ->first();
+    }
+}

--- a/app/Http/Controllers/Billing/CheckoutController.php
+++ b/app/Http/Controllers/Billing/CheckoutController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Billing;
+
+use App\Http\Controllers\Controller;
+use App\Models\PlanPrice;
+use App\Services\Billing\CheckoutBuilder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * The buy button: hands the signed-in user to the merchant's hosted
+ * checkout for one price.
+ *
+ * The one gate beyond "the plan is on sale" is a verified email for
+ * self-registered accounts — the address is where the receipt, the dunning
+ * notices and the trial warning go, and a fabricated one must not start a
+ * trial. Accounts an administrator or SSO created carry a role or an
+ * external identity and were never anonymous.
+ */
+class CheckoutController extends Controller
+{
+    public function store(Request $request, PlanPrice $price): RedirectResponse
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+        abort_unless($price->active && $price->plan->purchasable(), 404);
+
+        $user = $request->user();
+
+        if ($user->email_verified_at === null && ! $user->roles()->exists()) {
+            return redirect()->route('billing.index')
+                ->with('status', 'Verify your email address before buying — the link is in your inbox.');
+        }
+
+        $session = app(CheckoutBuilder::class)->start($user, $price);
+
+        abort_if($session->redirectUrl === null, 500);
+
+        return redirect()->away($session->redirectUrl);
+    }
+}

--- a/app/Http/Controllers/Billing/RegisterController.php
+++ b/app/Http/Controllers/Billing/RegisterController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers\Billing;
+
+use App\Http\Controllers\Controller;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Public self-serve signup — the one registration path this app has, and it
+ * exists only to buy things.
+ *
+ * Deliberately narrow. The account it creates holds no role, which is what
+ * keeps it out of /admin entirely (User::canAccessPanel asks for one), no
+ * grants, and no access to anything a subscription has not granted. Gated
+ * behind BILLING_PUBLIC_SIGNUP on top of BILLING_ENABLED, because plenty of
+ * registries sell to accounts that already exist without wanting an open
+ * registration form on the internet.
+ *
+ * The honeypot field is the cheap half of abuse control; the throttle on the
+ * POST is the other. Email verification is required before checkout — see
+ * CheckoutController — so a mistyped or fabricated address cannot buy.
+ */
+class RegisterController extends Controller
+{
+    public function show(): Response
+    {
+        $this->gate();
+
+        return response()->view('billing.register', [
+            'repository' => Repository::default(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $this->gate();
+
+        // The honeypot: a field humans never see and bots dutifully fill.
+        if ($request->filled('website')) {
+            return redirect()->route('billing.index');
+        }
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:12', 'confirmed'],
+        ]);
+
+        $user = User::query()->create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+        ]);
+
+        $user->notify(new \App\Notifications\Billing\VerifyBillingEmail(
+            URL::temporarySignedRoute('billing.verify', now()->addDay(), ['user' => $user->getKey()]),
+        ));
+
+        Auth::login($user);
+        $request->session()->regenerate();
+
+        return redirect()->route('billing.index')
+            ->with('status', 'Check your inbox — buying needs a verified address.');
+    }
+
+    public function verify(Request $request, User $user): RedirectResponse
+    {
+        abort_unless($request->hasValidSignature(), 403);
+
+        if ($user->email_verified_at === null) {
+            $user->forceFill(['email_verified_at' => now()])->save();
+        }
+
+        return redirect()->route('billing.index')->with('status', 'Email verified.');
+    }
+
+    public function resend(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        if ($user !== null && $user->email_verified_at === null) {
+            $user->notify(new \App\Notifications\Billing\VerifyBillingEmail(
+                URL::temporarySignedRoute('billing.verify', now()->addDay(), ['user' => $user->getKey()]),
+            ));
+        }
+
+        return back()->with('status', 'Verification email sent.');
+    }
+
+    private function gate(): void
+    {
+        abort_unless(
+            (bool) config('registry.billing.enabled') && (bool) config('registry.billing.public_signup'),
+            404,
+        );
+    }
+}

--- a/app/Http/Controllers/Billing/RegisterController.php
+++ b/app/Http/Controllers/Billing/RegisterController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Billing;
 use App\Http\Controllers\Controller;
 use App\Models\Repository;
 use App\Models\User;
+use App\Notifications\Billing\VerifyBillingEmail;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -59,7 +60,7 @@ class RegisterController extends Controller
             'password' => Hash::make($data['password']),
         ]);
 
-        $user->notify(new \App\Notifications\Billing\VerifyBillingEmail(
+        $user->notify(new VerifyBillingEmail(
             URL::temporarySignedRoute('billing.verify', now()->addDay(), ['user' => $user->getKey()]),
         ));
 
@@ -86,7 +87,7 @@ class RegisterController extends Controller
         $user = $request->user();
 
         if ($user !== null && $user->email_verified_at === null) {
-            $user->notify(new \App\Notifications\Billing\VerifyBillingEmail(
+            $user->notify(new VerifyBillingEmail(
                 URL::temporarySignedRoute('billing.verify', now()->addDay(), ['user' => $user->getKey()]),
             ));
         }

--- a/app/Http/Controllers/Billing/SubscriptionTokenController.php
+++ b/app/Http/Controllers/Billing/SubscriptionTokenController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Billing;
+
+use App\Http\Controllers\Controller;
+use App\Models\Subscription;
+use App\Models\Token;
+use App\Services\Billing\SubscriptionTokens;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Token management inside the customer area, inside the plan's cap.
+ *
+ * Only tokens issued under one of the customer's subscriptions are managed
+ * here — a personal token made on the panel's ApiTokens page is somebody
+ * else's story. The cap is enforced by SubscriptionTokens, the same path
+ * the activation token took, so there is exactly one place it can be wrong.
+ */
+class SubscriptionTokenController extends Controller
+{
+    public function store(Request $request, Subscription $subscription): RedirectResponse
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+        abort_unless($subscription->customer?->contact()?->is($request->user()) ?? false, 403);
+        abort_unless($subscription->grantsAccess(), 403);
+
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+        ]);
+
+        $token = app(SubscriptionTokens::class)->issueFor($subscription, $data['name']);
+
+        if ($token === null) {
+            return back()->with('status', 'Your plan\'s token limit is reached — revoke one first.');
+        }
+
+        return back()->with('plainToken', $token->plainText);
+    }
+
+    public function destroy(Request $request, Token $token): RedirectResponse
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+
+        $subscription = $token->subscription;
+
+        abort_unless($subscription?->customer?->contact()?->is($request->user()) ?? false, 403);
+
+        $token->delete();
+
+        return back()->with('status', 'Token revoked.');
+    }
+}

--- a/app/Http/Controllers/Billing/WelcomeController.php
+++ b/app/Http/Controllers/Billing/WelcomeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Billing;
 
 use App\Enums\MerchantProvider;
 use App\Http\Controllers\Controller;
+use App\Models\MerchantEvent;
 use App\Models\MerchantReference;
 use App\Models\Repository;
 use App\Models\Subscription;
@@ -58,7 +59,28 @@ class WelcomeController extends Controller
             return null;
         }
 
+        // A one-time purchase is mapped by its session id. A subscription
+        // checkout's single reference slot holds the durable subscription id
+        // instead, so the session is traced through the recorded event.
         $resolved = MerchantReference::resolve($merchant, $sessionId);
+
+        if ($resolved instanceof Subscription) {
+            return $resolved;
+        }
+
+        $payload = MerchantEvent::query()
+            ->where('merchant', $merchant)
+            ->where('payload->id', $sessionId)
+            ->first()
+            ?->payload;
+
+        $subscriptionId = $payload['subscription'] ?? null;
+
+        if (! is_string($subscriptionId)) {
+            return null;
+        }
+
+        $resolved = MerchantReference::resolve($merchant, $subscriptionId);
 
         return $resolved instanceof Subscription ? $resolved : null;
     }

--- a/app/Http/Controllers/Billing/WelcomeController.php
+++ b/app/Http/Controllers/Billing/WelcomeController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Billing;
+
+use App\Enums\MerchantProvider;
+use App\Http\Controllers\Controller;
+use App\Models\MerchantReference;
+use App\Models\Repository;
+use App\Models\Subscription;
+use App\Services\Billing\SubscriptionTokens;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * Where checkout lands: the purchase confirmed, and the activation token —
+ * shown here exactly once, because a page the buyer is already looking at is
+ * the only place a credential can be handed over without writing it down.
+ *
+ * The subscription row is created by the checkout.completed webhook, which
+ * races this redirect and usually wins. When it has not arrived yet the page
+ * says so and refreshes itself; nothing here talks to the merchant.
+ */
+class WelcomeController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+
+        $sessionId = (string) $request->query('session', '');
+        $subscription = $this->subscriptionForSession($sessionId);
+
+        $plainToken = null;
+
+        if ($subscription !== null
+            && $subscription->customer?->contact()?->is($request->user())
+            && $subscription->plan->auto_issue_token
+            && ! $subscription->tokens()->exists()) {
+            $plainToken = app(SubscriptionTokens::class)->issueActivationToken($subscription)?->plainText;
+        }
+
+        return response()->view('billing.welcome', [
+            'repository' => Repository::default(),
+            'subscription' => $subscription,
+            'plainToken' => $plainToken,
+            'registryUrl' => rtrim((string) config('app.url'), '/'),
+        ]);
+    }
+
+    private function subscriptionForSession(string $sessionId): ?Subscription
+    {
+        if ($sessionId === '') {
+            return null;
+        }
+
+        $merchant = MerchantProvider::tryFrom((string) config('registry.billing.merchant'));
+
+        if ($merchant === null) {
+            return null;
+        }
+
+        $resolved = MerchantReference::resolve($merchant, $sessionId);
+
+        return $resolved instanceof Subscription ? $resolved : null;
+    }
+}

--- a/app/Http/Controllers/ComposerRepositoryController.php
+++ b/app/Http/Controllers/ComposerRepositoryController.php
@@ -13,6 +13,7 @@ use App\Models\Repository;
 use App\Models\ReservedVendor;
 use App\Models\Token;
 use App\Services\ArchiveStore;
+use App\Services\Billing\VersionCeiling;
 use App\Services\CreateVersionFromZip;
 use App\Services\Mirror\MirrorService;
 use App\Support\ComposerName;
@@ -576,6 +577,14 @@ class ComposerRepositoryController extends Controller
 
         $state = $this->versionState($record, $dev);
 
+        // The one mark billing leaves on this endpoint. Null for everyone but
+        // a caller whose only path to the package is a frozen entitlement —
+        // and everything below is arranged so that null costs nothing new:
+        // the ceiling folds into the ETag, the payload cache is keyed by the
+        // ETag, so every uncapped caller shares the exact entry they always
+        // shared and each distinct ceiling gets its own.
+        $ceiling = app(VersionCeiling::class)->ceilingFor($this->token($request), $record);
+
         $response = response('', 200, [
             'Content-Type' => 'application/json',
             // `no-cache` rather than a freshness lifetime: a response carrying
@@ -589,7 +598,7 @@ class ComposerRepositoryController extends Controller
             'Vary' => 'Authorization',
         ]);
 
-        $etag = $this->etag($repository, $record, $dev, $state);
+        $etag = $this->etag($repository, $record, $dev, $state, $ceiling);
 
         $response->setLastModified($this->lastModified($repository, $record, $state));
         $response->setEtag($etag, weak: true);
@@ -598,7 +607,7 @@ class ComposerRepositoryController extends Controller
             return $response;
         }
 
-        return $response->setContent($this->payload($repository, $record, $dev, $etag));
+        return $response->setContent($this->payload($repository, $record, $dev, $etag, $ceiling));
     }
 
     /**
@@ -692,7 +701,7 @@ class ComposerRepositoryController extends Controller
      *
      * Only the payload is cached. Who may see it is decided per request, above.
      */
-    private function payload(Repository $repository, Package $package, bool $dev, string $etag): string
+    private function payload(Repository $repository, Package $package, bool $dev, string $etag, ?string $ceiling = null): string
     {
         $key = 'composer:metadata:'.$package->getKey().':'.($dev ? 'dev' : 'stable').":{$etag}";
 
@@ -702,7 +711,7 @@ class ComposerRepositoryController extends Controller
             return $cached;
         }
 
-        $json = $this->renderMetadata($repository, $package, $dev);
+        $json = $this->renderMetadata($repository, $package, $dev, $ceiling);
 
         $ceiling = (int) config('registry.metadata_cache.max_kilobytes') * 1024;
 
@@ -810,7 +819,7 @@ class ComposerRepositoryController extends Controller
      *
      * @param  array{count: int, changed: ?CarbonImmutable, newest: int}  $state
      */
-    private function etag(Repository $repository, Package $package, bool $dev, array $state): string
+    private function etag(Repository $repository, Package $package, bool $dev, array $state, ?string $ceiling = null): string
     {
         // xxh128 because this is a cache validator, not a signature: it has to
         // be collision-resistant against accident, never against an attacker.
@@ -825,6 +834,12 @@ class ComposerRepositoryController extends Controller
             $state['count'],
             $state['changed']?->getTimestamp() ?? 0,
             $state['newest'],
+            // The version ceiling a frozen entitlement pins, or '' for the
+            // one shared document everybody else reads. In the tag by value
+            // for the same reason the name is: the payload cache is keyed by
+            // this fingerprint, so folding it here is what buckets the cache
+            // by ceiling without a second mechanism.
+            $ceiling ?? '',
         ]));
     }
 
@@ -849,7 +864,7 @@ class ComposerRepositoryController extends Controller
      * otherwise two spellings of one package share a validator and differ in
      * what they answer.
      */
-    private function renderMetadata(Repository $repository, Package $package, bool $dev): string
+    private function renderMetadata(Repository $repository, Package $package, bool $dev, ?string $ceiling = null): string
     {
         $name = (string) $package->name;
 
@@ -860,6 +875,16 @@ class ComposerRepositoryController extends Controller
 
         $versions = $package->versions()
             ->where('is_dev', $dev)
+            // A pinned ceiling admits releases up to itself and nothing else.
+            // Dev flavours empty out entirely — a branch has no position on a
+            // release line, and dev-main is precisely the ongoing work a
+            // lapsed perpetual licence stopped paying for. Rows whose `order`
+            // was never backfilled are excluded too: unknown-position sorts
+            // outside the ceiling, which is the only safe reading.
+            ->when($ceiling !== null, fn (Builder $query) => $query
+                ->where('is_dev', false)
+                ->whereNotNull('order')
+                ->where('order', '<=', $ceiling))
             // Releases sort by the normalizer's order string, whose lexical
             // order is semantic order (1.10.0 above 1.9.0). Branches have no
             // release line to sort along, so dev versions keep name order.
@@ -935,6 +960,22 @@ class ComposerRepositoryController extends Controller
         $versions = $record->versions()->where('reference', $reference)->get();
 
         abort_if($versions->isEmpty(), 404, "Reference {$reference} is not a known version of {$name}.");
+
+        // A frozen entitlement's ceiling guards the archive as well as the
+        // metadata. The metadata filter means a fresh resolve never asks for
+        // an out-of-window version, so what lands here is a stale lock file —
+        // which deserves a sentence naming the real problem, not a bare 403.
+        // Any row sharing the reference being inside the ceiling is enough: a
+        // tag and a branch can share a commit, and owning the tag is owning
+        // the bytes.
+        $ceilings = app(VersionCeiling::class);
+        $ceiling = $ceilings->ceilingFor($this->token($request), $record);
+
+        abort_unless(
+            $versions->contains(fn (PackageVersion $version): bool => $ceilings->permits($version, $ceiling)),
+            403,
+            "Your subscription includes {$name} up to the versions released while it was active; {$reference} is newer. Renew to install current releases.",
+        );
 
         $disk = $this->archives->disk();
 

--- a/app/Http/Controllers/MerchantWebhookController.php
+++ b/app/Http/Controllers/MerchantWebhookController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\MerchantProvider;
+use App\Jobs\ProcessMerchantEvent;
+use App\Merchants\UnsupportedMerchantException;
+use App\Merchants\Values\NormalisedEvent;
+use App\Models\MerchantEvent;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * Receives a merchant's webhooks: verify, record, acknowledge, process later.
+ *
+ * The same discipline as the git-provider webhooks. The signature is checked
+ * against the raw body before anything is believed; a verified delivery is
+ * written to merchant_events *before* the 2xx goes out, so a deploy
+ * mid-delivery loses nothing; and the unique event id makes a redelivery an
+ * acknowledged no-op rather than a double-processed payment. Everything that
+ * acts on the event happens on the queue, where it can retry without the
+ * merchant re-signing anything.
+ */
+class MerchantWebhookController extends Controller
+{
+    public function __invoke(Request $request, string $merchant): Response
+    {
+        if (! config('registry.billing.enabled')) {
+            abort(404);
+        }
+
+        $provider = MerchantProvider::tryFrom($merchant);
+
+        if ($provider === null || ! $provider->receivesWebhooks()) {
+            abort(404);
+        }
+
+        try {
+            $event = $provider->client()->verifySignature($request);
+        } catch (UnsupportedMerchantException) {
+            // An invalid signature is indistinguishable from an attacker;
+            // say only "no". 400 rather than 401: there is no credential to
+            // challenge for, and merchants disable endpoints that 401.
+            return response('Rejected.', 400);
+        }
+
+        if ($event->kind === NormalisedEvent::IGNORE) {
+            // Verified, deliberately unrecorded: merchants emit dozens of
+            // event types nobody subscribed to, and an inbox of them would
+            // bury the rows an investigator actually looks for.
+            return response()->noContent();
+        }
+
+        try {
+            $stored = MerchantEvent::query()->create([
+                'merchant' => $provider,
+                'external_id' => $event->externalId,
+                'type' => $event->type,
+                'payload' => $event->payload,
+                'received_at' => now(),
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            // A redelivery of something already recorded. Acknowledged so
+            // the merchant stops retrying; not reprocessed.
+            return response()->noContent();
+        }
+
+        ProcessMerchantEvent::dispatch($stored->getKey(), $event->kind, $event->occurredAt);
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Pages/PricingController.php
+++ b/app/Http/Controllers/Pages/PricingController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Pages;
+
+use App\Http\Controllers\Controller;
+use App\Models\Plan;
+use App\Models\Repository;
+use Illuminate\Http\Response;
+
+/**
+ * The public pricing page: every listed plan, and a page per plan.
+ *
+ * Anonymous like the package pages, on the same layout, for the same reason —
+ * the plan a package's page names should be a link that answers. Only plans
+ * marked `listed` appear; an unlisted plan's page still answers by slug, so a
+ * negotiated tier can be sent as a link without being advertised.
+ */
+class PricingController extends Controller
+{
+    public function index(): Response
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+
+        $plans = Plan::query()
+            ->listed()
+            ->with(['prices' => fn ($query) => $query->where('active', true)->orderByDesc('default')->orderBy('amount')])
+            ->get();
+
+        return response()->view('pages.pricing', [
+            'repository' => Repository::default(),
+            'plans' => $plans,
+            'canonical' => route('pages.pricing'),
+        ]);
+    }
+
+    public function show(Plan $plan): Response
+    {
+        abort_unless((bool) config('registry.billing.enabled'), 404);
+        abort_unless($plan->active, 404);
+
+        return response()->view('pages.plan', [
+            'repository' => Repository::default(),
+            'plan' => $plan->load([
+                'prices' => fn ($query) => $query->where('active', true)->orderByDesc('default')->orderBy('amount'),
+                'packages',
+                'repositories',
+            ]),
+            'canonical' => route('pages.pricing.plan', $plan),
+        ]);
+    }
+}

--- a/app/Jobs/ProcessMerchantEvent.php
+++ b/app/Jobs/ProcessMerchantEvent.php
@@ -9,7 +9,6 @@ use App\Models\BillingCustomer;
 use App\Models\Invoice;
 use App\Models\MerchantEvent;
 use App\Models\MerchantReference;
-use App\Models\Plan;
 use App\Models\PlanPrice;
 use App\Models\Subscription;
 use App\Notifications\Billing\BillingAlert;

--- a/app/Jobs/ProcessMerchantEvent.php
+++ b/app/Jobs/ProcessMerchantEvent.php
@@ -122,16 +122,19 @@ class ProcessMerchantEvent implements ShouldQueue
 
         $subscription = $this->findOrCreateSubscription($event, $customer, $price, $remoteSubscriptionId);
 
-        // Remember the session id too: the welcome page holds nothing else.
-        MerchantReference::remember($subscription, $event->merchant, (string) $payload['id']);
-
         if (is_string($remoteSubscriptionId)) {
             $remote = $event->merchant->client()->fetchSubscription($remoteSubscriptionId);
             (new SubscriptionProjector)->apply($subscription, $remote);
         } else {
-            // A one-time purchase: no remote subscription exists. Active from
-            // now; the updates window is the period, and the reconciler
-            // expires it when the window closes.
+            // A one-time purchase: no remote subscription exists, so the
+            // session id can take the row's one reference slot. A
+            // subscription checkout keeps that slot for the subscription id
+            // every later webhook resolves by; the welcome page reaches
+            // those through the recorded event instead.
+            MerchantReference::remember($subscription, $event->merchant, (string) $payload['id']);
+
+            // Active from now; the updates window is the period, and the
+            // reconciler expires it when the window closes.
             $months = $price->plan->updates_window_months;
 
             $subscription->forceFill([

--- a/app/Jobs/ProcessMerchantEvent.php
+++ b/app/Jobs/ProcessMerchantEvent.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\SubscriptionStatus;
+use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteInvoice;
+use App\Models\BillingCustomer;
+use App\Models\Invoice;
+use App\Models\MerchantEvent;
+use App\Models\MerchantReference;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use App\Notifications\Billing\BillingAlert;
+use App\Notifications\Billing\PaymentFailed;
+use App\Notifications\Billing\SubscriptionActivated;
+use App\Notifications\Billing\SubscriptionLapsed;
+use App\Services\AdminNotifier;
+use App\Services\Billing\EntitlementProjector;
+use App\Services\Billing\SubscriptionProjector;
+use Carbon\CarbonImmutable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Throwable;
+
+/**
+ * Acts on one verified merchant event, off the request path.
+ *
+ * The recorded merchant_events row is re-read and marked processed or failed,
+ * so the inbox is also the ledger of what has actually been acted on — a
+ * failed row plus its error is the queue of work still owed, and the panel's
+ * replay action re-dispatches exactly this job.
+ *
+ * Subscription state is never taken from the payload. The event is a doorbell:
+ * it says which subscription moved, and the current truth is fetched fresh
+ * from the merchant — which makes out-of-order deliveries harmless twice over
+ * (the fetch is current, and SubscriptionProjector discards stale moments).
+ */
+class ProcessMerchantEvent implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $timeout = 60;
+
+    public bool $deleteWhenMissingModels = true;
+
+    public function __construct(
+        public readonly int $eventId,
+        public readonly string $kind,
+        public readonly CarbonImmutable $occurredAt,
+    ) {}
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [30, 120];
+    }
+
+    public function handle(): void
+    {
+        $event = MerchantEvent::query()->find($this->eventId);
+
+        if ($event === null || $event->processed_at !== null) {
+            return;
+        }
+
+        try {
+            match ($this->kind) {
+                NormalisedEvent::CHECKOUT_COMPLETED => $this->checkoutCompleted($event),
+                NormalisedEvent::SUBSCRIPTION_CHANGED => $this->subscriptionChanged($event),
+                NormalisedEvent::INVOICE_PAID => $this->invoicePaid($event),
+                NormalisedEvent::INVOICE_PAYMENT_FAILED => $this->invoicePaymentFailed($event),
+                NormalisedEvent::INVOICE_REFUNDED => $this->invoiceRefunded($event),
+                NormalisedEvent::DISPUTE_OPENED => $this->disputeOpened($event),
+                default => null,
+            };
+
+            $event->markProcessed();
+        } catch (Throwable $e) {
+            $event->markFailed($e->getMessage());
+
+            throw $e;
+        }
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $event = MerchantEvent::query()->find($this->eventId);
+
+        if ($event === null) {
+            return;
+        }
+
+        app(AdminNotifier::class)->send(new BillingAlert(
+            'A merchant event failed processing',
+            "{$event->merchant->getLabel()} event {$event->type} ({$event->external_id}) gave up after retries: ".($exception?->getMessage() ?? 'unknown error'),
+            url('/admin'),
+        ));
+    }
+
+    /**
+     * A checkout finished. Create (or find) the local subscription the
+     * payment produced; the activation token is minted by the welcome page,
+     * which is the only place the buyer can be shown it.
+     */
+    private function checkoutCompleted(MerchantEvent $event): void
+    {
+        $payload = $event->payload;
+
+        $customer = $this->customerFrom($payload['customer'] ?? null);
+        $price = $this->priceFrom($payload['metadata']['plan_price_id'] ?? null);
+
+        if ($customer === null || $price === null) {
+            throw new \RuntimeException('Checkout session names no known customer or price.');
+        }
+
+        $remoteSubscriptionId = $payload['subscription'] ?? null;
+
+        $subscription = $this->findOrCreateSubscription($event, $customer, $price, $remoteSubscriptionId);
+
+        // Remember the session id too: the welcome page holds nothing else.
+        MerchantReference::remember($subscription, $event->merchant, (string) $payload['id']);
+
+        if (is_string($remoteSubscriptionId)) {
+            $remote = $event->merchant->client()->fetchSubscription($remoteSubscriptionId);
+            (new SubscriptionProjector)->apply($subscription, $remote);
+        } else {
+            // A one-time purchase: no remote subscription exists. Active from
+            // now; the updates window is the period, and the reconciler
+            // expires it when the window closes.
+            $months = $price->plan->updates_window_months;
+
+            $subscription->forceFill([
+                'status' => SubscriptionStatus::Active,
+                'current_period_start' => now(),
+                'current_period_end' => $months !== null ? now()->addMonths($months) : null,
+                'last_event_at' => now(),
+            ])->save();
+
+            (new EntitlementProjector)->project($subscription);
+        }
+
+        $customer->contact()?->notify(new SubscriptionActivated($subscription));
+    }
+
+    private function subscriptionChanged(MerchantEvent $event): void
+    {
+        $externalId = (string) ($event->payload['id'] ?? '');
+
+        $local = MerchantReference::resolve($event->merchant, $externalId);
+
+        if (! $local instanceof Subscription) {
+            // A subscription this app never sold — created in the merchant's
+            // own dashboard, or racing its checkout.completed event, which
+            // will create the row and fetch fresh state itself.
+            return;
+        }
+
+        $wasGranting = $local->grantsAccess();
+
+        $remote = $event->merchant->client()->fetchSubscription($externalId);
+        (new SubscriptionProjector)->apply($local, $remote);
+
+        $local->refresh();
+
+        if ($wasGranting && ! $local->grantsAccess()) {
+            $local->customer?->contact()?->notify(new SubscriptionLapsed($local));
+        }
+    }
+
+    private function invoicePaid(MerchantEvent $event): void
+    {
+        $this->mirrorInvoice($event);
+    }
+
+    private function invoicePaymentFailed(MerchantEvent $event): void
+    {
+        $invoice = $this->mirrorInvoice($event);
+
+        $subscription = $invoice?->subscription;
+
+        if ($subscription !== null) {
+            $subscription->customer?->contact()?->notify(new PaymentFailed($subscription));
+        }
+    }
+
+    /**
+     * A full refund withdraws access immediately — the operator's chosen
+     * policy. Partial refunds update the mirror and change nothing else.
+     */
+    private function invoiceRefunded(MerchantEvent $event): void
+    {
+        $payload = $event->payload;
+
+        $invoiceExternalId = $payload['invoice'] ?? null;
+
+        if (! is_string($invoiceExternalId)) {
+            return;
+        }
+
+        $invoice = MerchantReference::resolve($event->merchant, $invoiceExternalId);
+
+        if (! $invoice instanceof Invoice) {
+            return;
+        }
+
+        $invoice->forceFill([
+            'amount_refunded' => (int) ($payload['amount_refunded'] ?? $invoice->amount_refunded),
+            'refunded_at' => now(),
+        ])->save();
+
+        if (! $invoice->fullyRefunded()) {
+            return;
+        }
+
+        $subscription = $invoice->subscription;
+
+        if ($subscription !== null && $subscription->grantsAccess()) {
+            $subscription->forceFill([
+                'status' => SubscriptionStatus::Canceled,
+                'canceled_at' => now(),
+                'ends_at' => now(),
+                'grace_ends_at' => null,
+                'last_event_at' => now(),
+            ])->save();
+
+            (new EntitlementProjector)->project($subscription);
+
+            $subscription->customer?->contact()?->notify(new SubscriptionLapsed($subscription));
+        }
+    }
+
+    /**
+     * A dispute is the customer telling their bank this charge was not
+     * legitimate. Access is withdrawn at once — by suspension, which no
+     * lapse behaviour softens — and a person is told, because the next steps
+     * (evidence, refund, reinstatement) are theirs.
+     */
+    private function disputeOpened(MerchantEvent $event): void
+    {
+        $normalised = new NormalisedEvent(
+            externalId: $event->external_id,
+            type: $event->type,
+            kind: $this->kind,
+            payload: $event->payload,
+            occurredAt: $this->occurredAt,
+        );
+
+        $customerExternalId = $event->merchant->client()->customerExternalId($normalised);
+        $customer = $this->customerFrom($customerExternalId);
+
+        $projector = new EntitlementProjector;
+
+        if ($customer !== null) {
+            foreach ($customer->subscriptions as $subscription) {
+                if ($subscription->suspended_at === null) {
+                    $subscription->forceFill([
+                        'suspended_at' => now(),
+                        'suspension_reason' => 'Payment disputed',
+                    ])->save();
+                }
+            }
+
+            $projector->projectCustomer($customer);
+        }
+
+        app(AdminNotifier::class)->send(new BillingAlert(
+            'A payment was disputed',
+            $customer !== null
+                ? "{$customer->name} disputed a charge. Their subscriptions are suspended pending review."
+                : "A charge was disputed by a customer this registry cannot match (merchant customer: {$customerExternalId}). Review it at the merchant.",
+            url('/admin'),
+        ));
+    }
+
+    private function mirrorInvoice(MerchantEvent $event): ?Invoice
+    {
+        // The payload is the invoice object; normalise it through the driver
+        // so this job never learns Stripe's field names.
+        $remote = $event->merchant->client()->invoiceFromPayload($event->payload);
+
+        return $this->writeInvoice($event, $remote);
+    }
+
+    private function writeInvoice(MerchantEvent $event, RemoteInvoice $remote): ?Invoice
+    {
+        $customer = $this->customerFrom($remote->customerExternalId);
+
+        if ($customer === null) {
+            return null;
+        }
+
+        $subscription = $remote->subscriptionExternalId !== null
+            ? MerchantReference::resolve($event->merchant, $remote->subscriptionExternalId)
+            : null;
+
+        $existing = MerchantReference::resolve($event->merchant, $remote->externalId);
+
+        $invoice = $existing instanceof Invoice ? $existing : new Invoice;
+
+        $invoice->forceFill([
+            'billing_customer_id' => $customer->getKey(),
+            'subscription_id' => $subscription instanceof Subscription ? $subscription->getKey() : null,
+            'merchant' => $event->merchant,
+            'number' => $remote->number,
+            'currency' => $remote->currency,
+            'subtotal' => $remote->subtotal,
+            'tax' => $remote->tax,
+            'total' => $remote->total,
+            'amount_refunded' => $remote->amountRefunded,
+            'status' => $remote->status,
+            'hosted_url' => $remote->hostedUrl,
+            'pdf_url' => $remote->pdfUrl,
+            'issued_at' => $remote->issuedAt,
+            'paid_at' => $remote->paidAt,
+            'refunded_at' => $remote->refundedAt,
+        ])->save();
+
+        MerchantReference::remember($invoice, $event->merchant, $remote->externalId);
+
+        return $invoice;
+    }
+
+    private function findOrCreateSubscription(MerchantEvent $event, BillingCustomer $customer, PlanPrice $price, ?string $remoteSubscriptionId): Subscription
+    {
+        if (is_string($remoteSubscriptionId)) {
+            $existing = MerchantReference::resolve($event->merchant, $remoteSubscriptionId);
+
+            if ($existing instanceof Subscription) {
+                return $existing;
+            }
+        }
+
+        $subscription = Subscription::query()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'plan_id' => $price->plan_id,
+            'plan_price_id' => $price->getKey(),
+            'merchant' => $event->merchant,
+            'status' => SubscriptionStatus::Incomplete,
+            'quantity' => 1,
+        ]);
+
+        if (is_string($remoteSubscriptionId)) {
+            MerchantReference::remember($subscription, $event->merchant, $remoteSubscriptionId);
+        }
+
+        return $subscription;
+    }
+
+    private function customerFrom(?string $externalId): ?BillingCustomer
+    {
+        if (! is_string($externalId) || $externalId === '') {
+            return null;
+        }
+
+        return BillingCustomer::query()
+            ->where('merchant_customer_id', $externalId)
+            ->first();
+    }
+
+    private function priceFrom(mixed $id): ?PlanPrice
+    {
+        return is_numeric($id) ? PlanPrice::query()->find((int) $id) : null;
+    }
+}

--- a/app/Jobs/ReprojectPlanEntitlements.php
+++ b/app/Jobs/ReprojectPlanEntitlements.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Plan;
+use App\Services\Billing\EntitlementProjector;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Re-projects every subscription on a plan after the plan changed.
+ *
+ * Adding a package to a plan is adding it for everyone already subscribed,
+ * and removing one is the reverse — the projector computes both from current
+ * state, so this job is nothing but "run it for each affected customer".
+ * Unique per plan: two quick saves collapse into one sweep.
+ */
+class ReprojectPlanEntitlements implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $timeout = 600;
+
+    public bool $deleteWhenMissingModels = true;
+
+    public function __construct(public readonly int $planId) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->planId;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [30, 120];
+    }
+
+    public function handle(EntitlementProjector $projector): void
+    {
+        $plan = Plan::query()->find($this->planId);
+
+        if ($plan === null) {
+            return;
+        }
+
+        $plan->subscriptions()
+            ->with('customer')
+            ->chunkById(100, function ($subscriptions) use ($projector): void {
+                foreach ($subscriptions->pluck('customer')->filter()->unique('id') as $customer) {
+                    $projector->projectCustomer($customer);
+                }
+            });
+    }
+}

--- a/app/Merchants/Manual/ManualClient.php
+++ b/app/Merchants/Manual/ManualClient.php
@@ -7,6 +7,7 @@ use App\Merchants\UnsupportedMerchantException;
 use App\Merchants\Values\CheckoutRequest;
 use App\Merchants\Values\CheckoutSession;
 use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteInvoice;
 use App\Merchants\Values\RemoteSubscription;
 use App\Models\BillingCustomer;
 use App\Models\Plan;
@@ -84,7 +85,10 @@ class ManualClient implements MerchantClient
         return [];
     }
 
-    public function invoiceFromPayload(array $payload): \App\Merchants\Values\RemoteInvoice
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function invoiceFromPayload(array $payload): RemoteInvoice
     {
         throw new UnsupportedMerchantException(
             'Manual has no invoices to translate: nothing bills its customers.'

--- a/app/Merchants/Manual/ManualClient.php
+++ b/app/Merchants/Manual/ManualClient.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Merchants\Manual;
+
+use App\Merchants\MerchantClient;
+use App\Merchants\UnsupportedMerchantException;
+use App\Merchants\Values\CheckoutRequest;
+use App\Merchants\Values\CheckoutSession;
+use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteSubscription;
+use App\Models\BillingCustomer;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+/**
+ * The merchant with nobody behind it: subscriptions an administrator made.
+ *
+ * Comped accounts, wire transfers, purchase orders, sponsorships — money (or
+ * its absence) that never touches a payment processor, recorded as
+ * first-class subscriptions so the entitlement projector treats them exactly
+ * like paid ones. Also the proof that MerchantClient holds for a driver with
+ * no network at all, which is what keeps the contract honest.
+ *
+ * The sync methods succeed by minting a local pseudo-id: there is no remote
+ * side to be out of sync with. The interactive methods refuse — there is no
+ * checkout to hold and no portal to visit — and the refusal message is what
+ * a customer-area page shows when a Manual customer clicks where a card
+ * button would be.
+ */
+class ManualClient implements MerchantClient
+{
+    public function syncProduct(Plan $plan): string
+    {
+        return 'manual_product_'.$plan->getKey();
+    }
+
+    public function syncPrice(PlanPrice $price): string
+    {
+        return 'manual_price_'.$price->getKey();
+    }
+
+    public function ensureCustomer(BillingCustomer $customer): string
+    {
+        return 'manual_customer_'.($customer->getKey() ?? Str::lower(Str::random(12)));
+    }
+
+    public function startCheckout(CheckoutRequest $request): CheckoutSession
+    {
+        throw new UnsupportedMerchantException(
+            'Manual subscriptions have no checkout: an administrator creates them in the panel.'
+        );
+    }
+
+    public function portalUrl(BillingCustomer $customer, string $returnUrl): string
+    {
+        throw new UnsupportedMerchantException(
+            'Manual customers have no billing portal: there is no card on file to manage.'
+        );
+    }
+
+    public function changePrice(Subscription $subscription, PlanPrice $price): void
+    {
+        // Nothing remote to move; the local row is the whole record.
+    }
+
+    public function cancel(Subscription $subscription, bool $immediately): void
+    {
+        // Nothing remote to cancel. SubscriptionProjector applies the local
+        // cancellation directly for Manual subscriptions.
+    }
+
+    public function fetchSubscription(string $externalId): RemoteSubscription
+    {
+        throw new UnsupportedMerchantException(
+            'Manual subscriptions have no remote record to fetch: the local row is the truth.'
+        );
+    }
+
+    public function fetchInvoices(BillingCustomer $customer): iterable
+    {
+        return [];
+    }
+
+    public function invoiceFromPayload(array $payload): \App\Merchants\Values\RemoteInvoice
+    {
+        throw new UnsupportedMerchantException(
+            'Manual has no invoices to translate: nothing bills its customers.'
+        );
+    }
+
+    public function customerExternalId(NormalisedEvent $event): ?string
+    {
+        return null;
+    }
+
+    public function verifySignature(Request $request): NormalisedEvent
+    {
+        throw new UnsupportedMerchantException(
+            'Manual is not a webhook sender: nothing signs deliveries for it.'
+        );
+    }
+}

--- a/app/Merchants/MerchantClient.php
+++ b/app/Merchants/MerchantClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Merchants;
 
+use App\Enums\MerchantProvider;
 use App\Merchants\Values\CheckoutRequest;
 use App\Merchants\Values\CheckoutSession;
 use App\Merchants\Values\NormalisedEvent;
@@ -29,7 +30,7 @@ use Illuminate\Http\Request;
  * remembered in MerchantReference rather than as columns, so one row can be
  * known to several merchants.
  *
- * @see \App\Enums\MerchantProvider
+ * @see MerchantProvider
  * @see docs/plans/ecommerce-subscriptions.md
  */
 interface MerchantClient
@@ -94,6 +95,8 @@ interface MerchantClient
     /**
      * Translate one of this merchant's own invoice payloads — the object a
      * webhook carried — into the canonical shape, without fetching anything.
+     *
+     * @param  array<string, mixed>  $payload
      */
     public function invoiceFromPayload(array $payload): RemoteInvoice;
 

--- a/app/Merchants/MerchantClient.php
+++ b/app/Merchants/MerchantClient.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Merchants;
+
+use App\Merchants\Values\CheckoutRequest;
+use App\Merchants\Values\CheckoutSession;
+use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteInvoice;
+use App\Merchants\Values\RemoteSubscription;
+use App\Models\BillingCustomer;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use Illuminate\Http\Request;
+
+/**
+ * What a payment merchant does for this registry.
+ *
+ * The billing layer's counterpart of RepositoryClient: one interface, one
+ * implementation per merchant, resolved through MerchantProvider::client().
+ * Everything above this line speaks the canonical vocabulary — Plan rows,
+ * SubscriptionStatus, integer minor units — and everything below it
+ * translates. A driver that cannot do one of these honestly throws
+ * UnsupportedMerchantException rather than pretending.
+ *
+ * The local database is the source of truth for the catalog and the merchant
+ * is the source of truth for the billing clock; the sync methods push the
+ * former out, the fetch methods pull the latter back, and external ids are
+ * remembered in MerchantReference rather than as columns, so one row can be
+ * known to several merchants.
+ *
+ * @see \App\Enums\MerchantProvider
+ * @see docs/plans/ecommerce-subscriptions.md
+ */
+interface MerchantClient
+{
+    /**
+     * Ensure the plan exists at the merchant as a sellable product, and
+     * return its external id there.
+     */
+    public function syncProduct(Plan $plan): string;
+
+    /**
+     * Ensure the price exists at the merchant, attached to its plan's
+     * product, and return its external id. Merchants treat prices as
+     * immutable — a changed amount is a new external price, and the old one
+     * is archived, never edited.
+     */
+    public function syncPrice(PlanPrice $price): string;
+
+    /**
+     * Ensure the customer exists at the merchant, with the identity and tax
+     * details an invoice needs, and return its external id.
+     */
+    public function ensureCustomer(BillingCustomer $customer): string;
+
+    /**
+     * Begin a purchase, returning where to send the buyer.
+     */
+    public function startCheckout(CheckoutRequest $request): CheckoutSession;
+
+    /**
+     * Where this customer manages their card, invoices and cancellation —
+     * the merchant-hosted portal, entered with a one-time URL.
+     */
+    public function portalUrl(BillingCustomer $customer, string $returnUrl): string;
+
+    /**
+     * Move a subscription to a different price — an upgrade or downgrade.
+     * Proration is the merchant's own policy, configured there.
+     */
+    public function changePrice(Subscription $subscription, PlanPrice $price): void;
+
+    /**
+     * Cancel at the merchant: immediately, or at the end of the period
+     * already paid for. The local record is not touched here — the
+     * merchant's confirming event (or the reconciler) is what moves it,
+     * so the two clocks cannot disagree.
+     */
+    public function cancel(Subscription $subscription, bool $immediately): void;
+
+    /**
+     * The merchant's current record of one subscription, for the reconciler.
+     */
+    public function fetchSubscription(string $externalId): RemoteSubscription;
+
+    /**
+     * The merchant's invoices for a customer, newest first, for backfill.
+     *
+     * @return iterable<RemoteInvoice>
+     */
+    public function fetchInvoices(BillingCustomer $customer): iterable;
+
+    /**
+     * Translate one of this merchant's own invoice payloads — the object a
+     * webhook carried — into the canonical shape, without fetching anything.
+     */
+    public function invoiceFromPayload(array $payload): RemoteInvoice;
+
+    /**
+     * The merchant's customer id an event concerns — read from the payload
+     * when it carries one, fetched when it does not (a Stripe dispute names
+     * only a charge). Null when the event is about nobody in particular.
+     */
+    public function customerExternalId(NormalisedEvent $event): ?string;
+
+    /**
+     * Verify a webhook delivery's signature against the raw body and
+     * translate it into the canonical event vocabulary. Throws
+     * UnsupportedMerchantException when the signature does not hold —
+     * the caller answers 4xx and records nothing.
+     */
+    public function verifySignature(Request $request): NormalisedEvent;
+}

--- a/app/Merchants/Stripe/StripeClient.php
+++ b/app/Merchants/Stripe/StripeClient.php
@@ -1,0 +1,472 @@
+<?php
+
+namespace App\Merchants\Stripe;
+
+use App\Enums\BillingInterval;
+use App\Enums\SubscriptionStatus;
+use App\Merchants\MerchantClient;
+use App\Merchants\UnsupportedMerchantException;
+use App\Merchants\Values\CheckoutRequest;
+use App\Merchants\Values\CheckoutSession;
+use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteInvoice;
+use App\Merchants\Values\RemoteSubscription;
+use App\Models\BillingCustomer;
+use App\Models\MerchantReference;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
+use Stripe\Exception\SignatureVerificationException;
+use Stripe\StripeClient as StripeSdk;
+use Stripe\Webhook;
+
+/**
+ * The Stripe driver.
+ *
+ * Hosted surfaces throughout: Checkout for purchases, the Billing Portal for
+ * cards, invoices and self-service cancellation. Card data never touches this
+ * app, which is what keeps it at PCI SAQ-A.
+ *
+ * Stripe treats prices as immutable, so syncPrice() archives-and-recreates
+ * when an amount changes rather than editing — existing subscriptions keep
+ * the price object they were sold under, exactly as the local plan_prices
+ * rows keep retired prices for the subscriptions on them.
+ *
+ * Everything Stripe says is translated here and nowhere else: statuses into
+ * SubscriptionStatus, event names into NormalisedEvent kinds, timestamps
+ * into CarbonImmutable. If a caller can tell this is Stripe, something in
+ * this file has leaked.
+ */
+class StripeClient implements MerchantClient
+{
+    public function __construct(
+        private readonly StripeSdk $stripe,
+        private readonly ?string $webhookSecret,
+    ) {}
+
+    /**
+     * Built from config/services.php, where every other integration keeps
+     * its credentials. Named rather than a constructor default so a test
+     * can hand in a mocked SDK.
+     */
+    public static function fromConfig(): self
+    {
+        $secret = (string) config('services.stripe.secret');
+
+        if ($secret === '') {
+            throw new UnsupportedMerchantException(
+                'Stripe is not configured: set STRIPE_SECRET before selling through it.'
+            );
+        }
+
+        return new self(
+            new StripeSdk($secret),
+            config('services.stripe.webhook_secret'),
+        );
+    }
+
+    public function syncProduct(Plan $plan): string
+    {
+        $existing = MerchantReference::externalId($plan, \App\Enums\MerchantProvider::Stripe);
+
+        $payload = [
+            'name' => $plan->name,
+            'description' => $plan->description ?: null,
+            'active' => $plan->active,
+            'metadata' => ['plan_id' => (string) $plan->getKey(), 'plan_slug' => $plan->slug],
+        ];
+
+        if ($existing !== null) {
+            $this->stripe->products->update($existing, $payload);
+
+            return $existing;
+        }
+
+        return $this->stripe->products->create($payload)->id;
+    }
+
+    public function syncPrice(PlanPrice $price): string
+    {
+        $product = $this->syncProduct($price->plan);
+        $existing = MerchantReference::externalId($price, \App\Enums\MerchantProvider::Stripe);
+
+        if ($existing !== null) {
+            $remote = $this->stripe->prices->retrieve($existing);
+
+            if ($this->matches($remote, $price, $product)) {
+                // Only activity can be edited on a price; everything else
+                // matching means there is nothing to do but keep it aligned.
+                if ($remote->active !== $price->active) {
+                    $this->stripe->prices->update($existing, ['active' => $price->active]);
+                }
+
+                return $existing;
+            }
+
+            // A changed amount is a new price. Archive the old object so the
+            // dashboard stops offering it; subscriptions on it are untouched.
+            $this->stripe->prices->update($existing, ['active' => false]);
+        }
+
+        $payload = [
+            'product' => $product,
+            'currency' => $price->currency,
+            'unit_amount' => $price->amount,
+            'active' => $price->active,
+            'metadata' => ['plan_price_id' => (string) $price->getKey()],
+        ];
+
+        if ($price->interval->recurring()) {
+            $payload['recurring'] = [
+                'interval' => $price->interval->value,
+                'interval_count' => $price->interval_count,
+            ];
+        }
+
+        return $this->stripe->prices->create($payload)->id;
+    }
+
+    public function ensureCustomer(BillingCustomer $customer): string
+    {
+        $payload = [
+            'name' => $customer->company_name ?: $customer->name,
+            'email' => $customer->email,
+            'metadata' => ['billing_customer_id' => (string) $customer->getKey()],
+        ];
+
+        if (is_array($customer->address) && $customer->address !== []) {
+            $payload['address'] = array_intersect_key(
+                $customer->address,
+                array_flip(['line1', 'line2', 'city', 'state', 'postal_code', 'country']),
+            );
+        }
+
+        if ($customer->merchant_customer_id !== null) {
+            $this->stripe->customers->update($customer->merchant_customer_id, $payload);
+
+            return $customer->merchant_customer_id;
+        }
+
+        return $this->stripe->customers->create($payload)->id;
+    }
+
+    public function startCheckout(CheckoutRequest $request): CheckoutSession
+    {
+        $customerId = $this->ensureCustomer($request->customer);
+        $priceId = $this->syncPrice($request->price);
+        $plan = $request->price->plan;
+
+        $payload = [
+            'customer' => $customerId,
+            'mode' => $request->price->interval->recurring() ? 'subscription' : 'payment',
+            'line_items' => [['price' => $priceId, 'quantity' => $request->quantity]],
+            'success_url' => $request->successUrl,
+            'cancel_url' => $request->cancelUrl,
+            // Promotion codes are authored in the Stripe dashboard; the
+            // checkout page offers the field and validates the code, so this
+            // app never keeps a coupon table of its own.
+            'allow_promotion_codes' => true,
+            'metadata' => [
+                'billing_customer_id' => (string) $request->customer->getKey(),
+                'plan_id' => (string) $plan->getKey(),
+                'plan_price_id' => (string) $request->price->getKey(),
+            ],
+        ];
+
+        if ($request->collectTax) {
+            $payload['automatic_tax'] = ['enabled' => true];
+            $payload['customer_update'] = ['address' => 'auto', 'name' => 'auto'];
+        }
+
+        if ($request->collectBusinessDetails) {
+            $payload['tax_id_collection'] = ['enabled' => true];
+        }
+
+        if ($request->price->interval->recurring()) {
+            $payload['subscription_data'] = array_filter([
+                'trial_period_days' => $plan->trial_days > 0 ? $plan->trial_days : null,
+                'metadata' => ['plan_id' => (string) $plan->getKey()],
+            ]);
+        } else {
+            // A one-time purchase still produces an invoice, which is what
+            // the mirror and the customer's records hang off.
+            $payload['invoice_creation'] = ['enabled' => true];
+        }
+
+        $session = $this->stripe->checkout->sessions->create($payload);
+
+        return new CheckoutSession($session->id, $session->url);
+    }
+
+    public function portalUrl(BillingCustomer $customer, string $returnUrl): string
+    {
+        if ($customer->merchant_customer_id === null) {
+            throw new UnsupportedMerchantException(
+                'This customer has no Stripe record yet, so there is no portal to open.'
+            );
+        }
+
+        return $this->stripe->billingPortal->sessions->create([
+            'customer' => $customer->merchant_customer_id,
+            'return_url' => $returnUrl,
+        ])->url;
+    }
+
+    public function changePrice(Subscription $subscription, PlanPrice $price): void
+    {
+        $externalId = $this->subscriptionExternalId($subscription);
+        $priceId = $this->syncPrice($price);
+
+        $remote = $this->stripe->subscriptions->retrieve($externalId);
+
+        $this->stripe->subscriptions->update($externalId, [
+            'items' => [[
+                'id' => $remote->items->data[0]->id,
+                'price' => $priceId,
+                'quantity' => $subscription->quantity,
+            ]],
+            'proration_behavior' => 'create_prorations',
+        ]);
+    }
+
+    public function cancel(Subscription $subscription, bool $immediately): void
+    {
+        $externalId = $this->subscriptionExternalId($subscription);
+
+        if ($immediately) {
+            $this->stripe->subscriptions->cancel($externalId);
+
+            return;
+        }
+
+        $this->stripe->subscriptions->update($externalId, ['cancel_at_period_end' => true]);
+    }
+
+    public function fetchSubscription(string $externalId): RemoteSubscription
+    {
+        return $this->normaliseSubscription(
+            $this->stripe->subscriptions->retrieve($externalId, ['expand' => ['discounts']]),
+        );
+    }
+
+    public function fetchInvoices(BillingCustomer $customer): iterable
+    {
+        if ($customer->merchant_customer_id === null) {
+            return;
+        }
+
+        $invoices = $this->stripe->invoices->all([
+            'customer' => $customer->merchant_customer_id,
+            'limit' => 100,
+        ]);
+
+        foreach ($invoices->autoPagingIterator() as $invoice) {
+            yield $this->normaliseInvoice($invoice);
+        }
+    }
+
+    public function verifySignature(Request $request): NormalisedEvent
+    {
+        if (! $this->webhookSecret) {
+            throw new UnsupportedMerchantException(
+                'Stripe webhooks are not configured: set STRIPE_WEBHOOK_SECRET.'
+            );
+        }
+
+        try {
+            // Raw body, exactly as it arrived — the signed bytes are the
+            // verified bytes, the same rule the git-provider webhooks follow.
+            $event = Webhook::constructEvent(
+                $request->getContent(),
+                (string) $request->header('Stripe-Signature'),
+                $this->webhookSecret,
+            );
+        } catch (SignatureVerificationException|\UnexpectedValueException $e) {
+            throw new UnsupportedMerchantException('Stripe webhook rejected: '.$e->getMessage(), previous: $e);
+        }
+
+        return new NormalisedEvent(
+            externalId: $event->id,
+            type: $event->type,
+            kind: $this->kindOf($event->type),
+            payload: $event->data->object->toArray(),
+            occurredAt: CarbonImmutable::createFromTimestamp($event->created),
+        );
+    }
+
+    public function invoiceFromPayload(array $payload): RemoteInvoice
+    {
+        return $this->normaliseInvoice(json_decode((string) json_encode($payload)));
+    }
+
+    /**
+     * Most Stripe payloads name their customer; a dispute names only its
+     * charge, and the charge knows the customer.
+     */
+    public function customerExternalId(NormalisedEvent $event): ?string
+    {
+        $customer = $event->payload['customer'] ?? null;
+
+        if (is_string($customer) && $customer !== '') {
+            return $customer;
+        }
+
+        $charge = $event->payload['charge'] ?? null;
+
+        if ($event->kind === NormalisedEvent::DISPUTE_OPENED && is_string($charge)) {
+            $customer = $this->stripe->charges->retrieve($charge)->customer;
+
+            return is_string($customer) ? $customer : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Stripe's event names, folded into the small vocabulary the processor
+     * switches on. Everything unlisted is verified, recorded and ignored —
+     * which is the honest treatment of an event nobody asked to act on.
+     */
+    private function kindOf(string $type): string
+    {
+        return match ($type) {
+            'customer.subscription.created',
+            'customer.subscription.updated',
+            'customer.subscription.deleted',
+            'customer.subscription.paused',
+            'customer.subscription.resumed' => NormalisedEvent::SUBSCRIPTION_CHANGED,
+            'invoice.paid' => NormalisedEvent::INVOICE_PAID,
+            'invoice.payment_failed' => NormalisedEvent::INVOICE_PAYMENT_FAILED,
+            'charge.refunded' => NormalisedEvent::INVOICE_REFUNDED,
+            'charge.dispute.created' => NormalisedEvent::DISPUTE_OPENED,
+            'checkout.session.completed' => NormalisedEvent::CHECKOUT_COMPLETED,
+            default => NormalisedEvent::IGNORE,
+        };
+    }
+
+    /**
+     * @param  \Stripe\Subscription  $remote
+     */
+    public function normaliseSubscription(object $remote): RemoteSubscription
+    {
+        $item = $remote->items->data[0] ?? null;
+
+        // Newer Stripe API versions carry the period on the item; older ones
+        // on the subscription. Read whichever this account's version filled.
+        $periodStart = $item->current_period_start ?? $remote->current_period_start ?? null;
+        $periodEnd = $item->current_period_end ?? $remote->current_period_end ?? null;
+
+        return new RemoteSubscription(
+            externalId: $remote->id,
+            customerExternalId: (string) $remote->customer,
+            status: $this->status($remote->status),
+            priceExternalId: $item?->price?->id,
+            quantity: (int) ($item->quantity ?? 1),
+            trialEndsAt: $this->time($remote->trial_end ?? null),
+            currentPeriodStart: $this->time($periodStart),
+            currentPeriodEnd: $this->time($periodEnd),
+            cancelAt: $this->time($remote->cancel_at ?? null),
+            canceledAt: $this->time($remote->canceled_at ?? null),
+            endedAt: $this->time($remote->ended_at ?? null),
+            couponCode: $remote->discounts[0]->coupon->id ?? null,
+            asOf: CarbonImmutable::now(),
+        );
+    }
+
+    /**
+     * @param  \Stripe\Invoice  $remote
+     */
+    public function normaliseInvoice(object $remote): RemoteInvoice
+    {
+        return new RemoteInvoice(
+            externalId: $remote->id,
+            customerExternalId: (string) $remote->customer,
+            subscriptionExternalId: $this->invoiceSubscriptionId($remote),
+            number: $remote->number ?? null,
+            currency: $remote->currency,
+            subtotal: (int) $remote->subtotal,
+            tax: (int) ($remote->tax ?? 0),
+            total: (int) $remote->total,
+            amountRefunded: (int) ($remote->amount_refunded ?? 0),
+            status: (string) $remote->status,
+            hostedUrl: $remote->hosted_invoice_url ?? null,
+            pdfUrl: $remote->invoice_pdf ?? null,
+            issuedAt: $this->time($remote->created ?? null),
+            paidAt: $this->time($remote->status_transitions->paid_at ?? null),
+            refundedAt: null,
+        );
+    }
+
+    /**
+     * The subscription an invoice belongs to. Newer API versions moved it
+     * from a top-level field into the line items' parent details.
+     */
+    private function invoiceSubscriptionId(object $remote): ?string
+    {
+        if (isset($remote->subscription) && $remote->subscription !== null) {
+            return (string) $remote->subscription;
+        }
+
+        foreach ($remote->lines->data ?? [] as $line) {
+            $id = $line->parent?->subscription_item_details?->subscription ?? null;
+
+            if ($id !== null) {
+                return (string) $id;
+            }
+        }
+
+        return null;
+    }
+
+    private function status(string $stripe): SubscriptionStatus
+    {
+        return match ($stripe) {
+            'trialing' => SubscriptionStatus::Trialing,
+            'active' => SubscriptionStatus::Active,
+            'past_due' => SubscriptionStatus::PastDue,
+            'paused' => SubscriptionStatus::Paused,
+            'canceled' => SubscriptionStatus::Canceled,
+            'unpaid' => SubscriptionStatus::Unpaid,
+            'incomplete' => SubscriptionStatus::Incomplete,
+            'incomplete_expired' => SubscriptionStatus::Expired,
+            default => SubscriptionStatus::Incomplete,
+        };
+    }
+
+    private function time(?int $timestamp): ?CarbonImmutable
+    {
+        return $timestamp !== null ? CarbonImmutable::createFromTimestamp($timestamp) : null;
+    }
+
+    /**
+     * @param  \Stripe\Price  $remote
+     */
+    private function matches(object $remote, PlanPrice $price, string $product): bool
+    {
+        $intervalMatches = $price->interval === BillingInterval::OneTime
+            ? $remote->recurring === null
+            : $remote->recurring !== null
+                && $remote->recurring->interval === $price->interval->value
+                && (int) $remote->recurring->interval_count === $price->interval_count;
+
+        return $remote->currency === $price->currency
+            && (int) $remote->unit_amount === $price->amount
+            && (string) $remote->product === $product
+            && $intervalMatches;
+    }
+
+    private function subscriptionExternalId(Subscription $subscription): string
+    {
+        $id = MerchantReference::externalId($subscription, \App\Enums\MerchantProvider::Stripe);
+
+        if ($id === null) {
+            throw new UnsupportedMerchantException(
+                'This subscription has no Stripe record: it was never sold there.'
+            );
+        }
+
+        return $id;
+    }
+}

--- a/app/Merchants/Stripe/StripeClient.php
+++ b/app/Merchants/Stripe/StripeClient.php
@@ -3,6 +3,7 @@
 namespace App\Merchants\Stripe;
 
 use App\Enums\BillingInterval;
+use App\Enums\MerchantProvider;
 use App\Enums\SubscriptionStatus;
 use App\Merchants\MerchantClient;
 use App\Merchants\UnsupportedMerchantException;
@@ -19,6 +20,8 @@ use App\Models\Subscription;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
 use Stripe\Exception\SignatureVerificationException;
+use Stripe\Invoice;
+use Stripe\Price;
 use Stripe\StripeClient as StripeSdk;
 use Stripe\Webhook;
 
@@ -69,7 +72,7 @@ class StripeClient implements MerchantClient
 
     public function syncProduct(Plan $plan): string
     {
-        $existing = MerchantReference::externalId($plan, \App\Enums\MerchantProvider::Stripe);
+        $existing = MerchantReference::externalId($plan, MerchantProvider::Stripe);
 
         $payload = [
             'name' => $plan->name,
@@ -90,7 +93,7 @@ class StripeClient implements MerchantClient
     public function syncPrice(PlanPrice $price): string
     {
         $product = $this->syncProduct($price->plan);
-        $existing = MerchantReference::externalId($price, \App\Enums\MerchantProvider::Stripe);
+        $existing = MerchantReference::externalId($price, MerchantProvider::Stripe);
 
         if ($existing !== null) {
             $remote = $this->stripe->prices->retrieve($existing);
@@ -296,6 +299,9 @@ class StripeClient implements MerchantClient
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public function invoiceFromPayload(array $payload): RemoteInvoice
     {
         return $this->normaliseInvoice(json_decode((string) json_encode($payload)));
@@ -376,7 +382,7 @@ class StripeClient implements MerchantClient
     }
 
     /**
-     * @param  \Stripe\Invoice  $remote
+     * @param  Invoice  $remote
      */
     public function normaliseInvoice(object $remote): RemoteInvoice
     {
@@ -405,12 +411,12 @@ class StripeClient implements MerchantClient
      */
     private function invoiceSubscriptionId(object $remote): ?string
     {
-        if (isset($remote->subscription) && $remote->subscription !== null) {
+        if (isset($remote->subscription)) {
             return (string) $remote->subscription;
         }
 
         foreach ($remote->lines->data ?? [] as $line) {
-            $id = $line->parent?->subscription_item_details?->subscription ?? null;
+            $id = $line->parent?->subscription_item_details?->subscription;
 
             if ($id !== null) {
                 return (string) $id;
@@ -441,7 +447,7 @@ class StripeClient implements MerchantClient
     }
 
     /**
-     * @param  \Stripe\Price  $remote
+     * @param  Price  $remote
      */
     private function matches(object $remote, PlanPrice $price, string $product): bool
     {
@@ -459,7 +465,7 @@ class StripeClient implements MerchantClient
 
     private function subscriptionExternalId(Subscription $subscription): string
     {
-        $id = MerchantReference::externalId($subscription, \App\Enums\MerchantProvider::Stripe);
+        $id = MerchantReference::externalId($subscription, MerchantProvider::Stripe);
 
         if ($id === null) {
             throw new UnsupportedMerchantException(

--- a/app/Merchants/StubClient.php
+++ b/app/Merchants/StubClient.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Merchants;
+
+use App\Enums\MerchantProvider;
+use App\Merchants\Values\CheckoutRequest;
+use App\Merchants\Values\CheckoutSession;
+use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteSubscription;
+use App\Models\BillingCustomer;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use Illuminate\Http\Request;
+
+/**
+ * The driver for merchants the enum may one day name but nothing implements.
+ *
+ * The same shape as App\Sources\StubClient, for the same reason: it lets the
+ * enum stay complete while drivers land one by one, and it documents by
+ * refusal exactly which methods a new driver owes.
+ */
+class StubClient implements MerchantClient
+{
+    public function __construct(private readonly MerchantProvider $merchant) {}
+
+    public function syncProduct(Plan $plan): string
+    {
+        throw $this->unsupported();
+    }
+
+    public function syncPrice(PlanPrice $price): string
+    {
+        throw $this->unsupported();
+    }
+
+    public function ensureCustomer(BillingCustomer $customer): string
+    {
+        throw $this->unsupported();
+    }
+
+    public function startCheckout(CheckoutRequest $request): CheckoutSession
+    {
+        throw $this->unsupported();
+    }
+
+    public function portalUrl(BillingCustomer $customer, string $returnUrl): string
+    {
+        throw $this->unsupported();
+    }
+
+    public function changePrice(Subscription $subscription, PlanPrice $price): void
+    {
+        throw $this->unsupported();
+    }
+
+    public function cancel(Subscription $subscription, bool $immediately): void
+    {
+        throw $this->unsupported();
+    }
+
+    public function fetchSubscription(string $externalId): RemoteSubscription
+    {
+        throw $this->unsupported();
+    }
+
+    public function fetchInvoices(BillingCustomer $customer): iterable
+    {
+        throw $this->unsupported();
+    }
+
+    public function invoiceFromPayload(array $payload): \App\Merchants\Values\RemoteInvoice
+    {
+        throw $this->unsupported();
+    }
+
+    public function customerExternalId(NormalisedEvent $event): ?string
+    {
+        throw $this->unsupported();
+    }
+
+    public function verifySignature(Request $request): NormalisedEvent
+    {
+        throw $this->unsupported();
+    }
+
+    private function unsupported(): UnsupportedMerchantException
+    {
+        return new UnsupportedMerchantException(
+            "{$this->merchant->getLabel()} is not supported yet: the merchant is declared, but no driver implements it."
+        );
+    }
+}

--- a/app/Merchants/StubClient.php
+++ b/app/Merchants/StubClient.php
@@ -6,6 +6,7 @@ use App\Enums\MerchantProvider;
 use App\Merchants\Values\CheckoutRequest;
 use App\Merchants\Values\CheckoutSession;
 use App\Merchants\Values\NormalisedEvent;
+use App\Merchants\Values\RemoteInvoice;
 use App\Merchants\Values\RemoteSubscription;
 use App\Models\BillingCustomer;
 use App\Models\Plan;
@@ -69,7 +70,10 @@ class StubClient implements MerchantClient
         throw $this->unsupported();
     }
 
-    public function invoiceFromPayload(array $payload): \App\Merchants\Values\RemoteInvoice
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function invoiceFromPayload(array $payload): RemoteInvoice
     {
         throw $this->unsupported();
     }

--- a/app/Merchants/UnsupportedMerchantException.php
+++ b/app/Merchants/UnsupportedMerchantException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Merchants;
+
+use RuntimeException;
+
+/**
+ * Raised where a merchant cannot do what was asked of it — a stub driver's
+ * everything, or a real driver's genuine gap, like asking the Manual driver
+ * for a card-management portal it does not have. The message says which, so
+ * a caller showing it to a person has something honest to show.
+ */
+class UnsupportedMerchantException extends RuntimeException {}

--- a/app/Merchants/Values/CheckoutRequest.php
+++ b/app/Merchants/Values/CheckoutRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Merchants\Values;
+
+use App\Models\BillingCustomer;
+use App\Models\PlanPrice;
+
+/**
+ * Everything a driver needs to start a purchase, gathered before any
+ * merchant is spoken to.
+ *
+ * The pair of URLs is the hosted-checkout shape; when an embedded flow is
+ * added later it will read the same request and ignore them, which is why
+ * they are here rather than in a Stripe-only parameter bag.
+ */
+final readonly class CheckoutRequest
+{
+    public function __construct(
+        public BillingCustomer $customer,
+        public PlanPrice $price,
+        public int $quantity,
+        public ?string $couponCode,
+        public string $successUrl,
+        public string $cancelUrl,
+        public bool $collectTax,
+        public bool $collectBusinessDetails,
+    ) {}
+}

--- a/app/Merchants/Values/CheckoutSession.php
+++ b/app/Merchants/Values/CheckoutSession.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Merchants\Values;
+
+/**
+ * What starting a checkout produced.
+ *
+ * Today: a URL to redirect the buyer to, and the merchant's id for the
+ * session so the completion webhook can be matched back. An embedded flow
+ * later adds a client secret beside them without reshaping the contract.
+ */
+final readonly class CheckoutSession
+{
+    public function __construct(
+        public string $externalId,
+        public ?string $redirectUrl,
+        public ?string $clientSecret = null,
+    ) {}
+}

--- a/app/Merchants/Values/NormalisedEvent.php
+++ b/app/Merchants/Values/NormalisedEvent.php
@@ -28,6 +28,9 @@ final readonly class NormalisedEvent
 
     public const string IGNORE = 'ignore';
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public function __construct(
         public string $externalId,
         public string $type,

--- a/app/Merchants/Values/NormalisedEvent.php
+++ b/app/Merchants/Values/NormalisedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Merchants\Values;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * A verified webhook delivery, reduced to what the processor acts on.
+ *
+ * `kind` is this app's own small vocabulary — the processor switches on it,
+ * never on a merchant's event names. A driver maps its dozens of event types
+ * down to these few, and anything that maps to Ignore was verified, recorded
+ * and deliberately not acted upon.
+ */
+final readonly class NormalisedEvent
+{
+    public const string SUBSCRIPTION_CHANGED = 'subscription_changed';
+
+    public const string INVOICE_PAID = 'invoice_paid';
+
+    public const string INVOICE_PAYMENT_FAILED = 'invoice_payment_failed';
+
+    public const string INVOICE_REFUNDED = 'invoice_refunded';
+
+    public const string DISPUTE_OPENED = 'dispute_opened';
+
+    public const string CHECKOUT_COMPLETED = 'checkout_completed';
+
+    public const string IGNORE = 'ignore';
+
+    public function __construct(
+        public string $externalId,
+        public string $type,
+        public string $kind,
+        public array $payload,
+        public CarbonImmutable $occurredAt,
+    ) {}
+}

--- a/app/Merchants/Values/RemoteInvoice.php
+++ b/app/Merchants/Values/RemoteInvoice.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Merchants\Values;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * A merchant's invoice, normalised for mirroring into the invoices table.
+ * Amounts are integer minor units, as everywhere.
+ */
+final readonly class RemoteInvoice
+{
+    public function __construct(
+        public string $externalId,
+        public string $customerExternalId,
+        public ?string $subscriptionExternalId,
+        public ?string $number,
+        public string $currency,
+        public int $subtotal,
+        public int $tax,
+        public int $total,
+        public int $amountRefunded,
+        public string $status,
+        public ?string $hostedUrl,
+        public ?string $pdfUrl,
+        public ?CarbonImmutable $issuedAt,
+        public ?CarbonImmutable $paidAt,
+        public ?CarbonImmutable $refundedAt,
+    ) {}
+}

--- a/app/Merchants/Values/RemoteSubscription.php
+++ b/app/Merchants/Values/RemoteSubscription.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Merchants\Values;
+
+use App\Enums\SubscriptionStatus;
+use Carbon\CarbonImmutable;
+
+/**
+ * A merchant's subscription, translated into the canonical vocabulary.
+ *
+ * The one shape SubscriptionProjector reads, whether it arrived in a webhook
+ * or a reconciler pull. Drivers do all their translating before this object
+ * exists; nothing downstream knows what the merchant called anything.
+ */
+final readonly class RemoteSubscription
+{
+    public function __construct(
+        public string $externalId,
+        public string $customerExternalId,
+        public SubscriptionStatus $status,
+        public ?string $priceExternalId,
+        public int $quantity,
+        public ?CarbonImmutable $trialEndsAt,
+        public ?CarbonImmutable $currentPeriodStart,
+        public ?CarbonImmutable $currentPeriodEnd,
+        public ?CarbonImmutable $cancelAt,
+        public ?CarbonImmutable $canceledAt,
+        public ?CarbonImmutable $endedAt,
+        public ?string $couponCode,
+        public CarbonImmutable $asOf,
+    ) {}
+}

--- a/app/Models/BillingCustomer.php
+++ b/app/Models/BillingCustomer.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MerchantProvider;
+use App\Merchants\MerchantClient;
+use App\Models\Concerns\LogsAuditableChanges;
+use Database\Factories\BillingCustomerFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * The party that pays: a User or a Team with a card on file at a merchant.
+ *
+ * Deliberately a separate thing from the account. Most users never have one,
+ * a team's members must not inherit the card, and everything here — company
+ * name, tax id, the address an invoice names — is billing material with no
+ * meaning elsewhere in the app. The account answers "who is this"; this row
+ * answers "who gets charged".
+ *
+ * @see docs/plans/ecommerce-subscriptions.md
+ */
+#[Fillable(['name', 'email', 'company_name', 'tax_id', 'address', 'merchant', 'billing_contact_user_id'])]
+class BillingCustomer extends Model
+{
+    /** @use HasFactory<BillingCustomerFactory> */
+    use HasFactory, LogsAuditableChanges, SoftDeletes;
+
+    /**
+     * Who the invoices name — not the merchant ids, which are plumbing, and
+     * not the address, whose churn is noise beside the identity fields.
+     *
+     * @return list<string>
+     */
+    protected function auditedAttributes(): array
+    {
+        return ['name', 'email', 'company_name', 'tax_id', 'merchant', 'billable_type', 'billable_id'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'address' => 'array',
+            'merchant' => MerchantProvider::class,
+        ];
+    }
+
+    /**
+     * The account behind the money: a User, or a Team.
+     *
+     * @return MorphTo<Model, $this>
+     */
+    public function billable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return HasMany<Subscription, $this>
+     */
+    public function subscriptions(): HasMany
+    {
+        return $this->hasMany(Subscription::class);
+    }
+
+    /**
+     * @return HasMany<Invoice, $this>
+     */
+    public function invoices(): HasMany
+    {
+        return $this->hasMany(Invoice::class);
+    }
+
+    /**
+     * @return HasMany<Entitlement, $this>
+     */
+    public function entitlements(): HasMany
+    {
+        return $this->hasMany(Entitlement::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function billingContact(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'billing_contact_user_id');
+    }
+
+    /** The merchant driver this customer is billed through. */
+    public function client(): MerchantClient
+    {
+        return $this->merchant->client();
+    }
+
+    /**
+     * The one human to email about this customer's billing: the account
+     * itself when it is a person, the nominated contact when it is a team.
+     * Null only for a team that never nominated anyone, which the checkout
+     * flow does not allow but an admin-created customer can be.
+     */
+    public function contact(): ?User
+    {
+        $billable = $this->billable;
+
+        if ($billable instanceof User) {
+            return $billable;
+        }
+
+        return $this->billingContact;
+    }
+
+    /**
+     * Every user this customer's subscriptions grant access to — the person
+     * themselves, or the team's whole membership. The entitlement projector
+     * asks this to know whose pivot rows to write; nothing else should, so
+     * that the answer has exactly one definition.
+     *
+     * @return list<User>
+     */
+    public function beneficiaries(): array
+    {
+        $billable = $this->billable;
+
+        if ($billable instanceof User) {
+            return [$billable];
+        }
+
+        if ($billable instanceof Team) {
+            return $billable->users()->get()->all();
+        }
+
+        return [];
+    }
+}

--- a/app/Models/Entitlement.php
+++ b/app/Models/Entitlement.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\EntitlementFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * The projector's ledger: one thing one subscription grants, and up to
+ * which version.
+ *
+ * The grant pivots answer "who can see what" on the Composer hot path and
+ * never learn what billing is. This table answers the questions only billing
+ * asks — which subscription granted a package, and whether a version ceiling
+ * caps it. The metadata and dist paths read it only for a package reached
+ * through a subscription; everything else in the app never touches it.
+ *
+ * Rows outlive their usefulness on purpose: a lapsed freeze-at-version
+ * entitlement with its pinned ceiling *is* the perpetual licence.
+ */
+#[Fillable(['billing_customer_id', 'grantable_type', 'grantable_id', 'version_ceiling', 'active', 'starts_at', 'ends_at'])]
+class Entitlement extends Model
+{
+    /** @use HasFactory<EntitlementFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'active' => 'boolean',
+            'starts_at' => 'datetime',
+            'ends_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Subscription, $this>
+     */
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+
+    /**
+     * @return BelongsTo<BillingCustomer, $this>
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(BillingCustomer::class, 'billing_customer_id');
+    }
+
+    /**
+     * What was granted: a Repository or a Package.
+     *
+     * @return MorphTo<Model, $this>
+     */
+    public function grantable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MerchantProvider;
+use Database\Factories\InvoiceFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A local mirror of an invoice the merchant issued.
+ *
+ * The merchant renders and hosts the documents; these rows are what lets the
+ * customer area and the panel show billing history without a live API call,
+ * and what survives a merchant migration. Written by webhooks, backfilled by
+ * the reconciler, never authored here.
+ */
+#[Fillable([
+    'subscription_id', 'merchant', 'number', 'currency', 'subtotal', 'tax',
+    'total', 'amount_refunded', 'status', 'hosted_url', 'pdf_url',
+    'issued_at', 'paid_at', 'refunded_at',
+])]
+class Invoice extends Model
+{
+    /** @use HasFactory<InvoiceFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'merchant' => MerchantProvider::class,
+            'subtotal' => 'integer',
+            'tax' => 'integer',
+            'total' => 'integer',
+            'amount_refunded' => 'integer',
+            'issued_at' => 'datetime',
+            'paid_at' => 'datetime',
+            'refunded_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<BillingCustomer, $this>
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(BillingCustomer::class, 'billing_customer_id');
+    }
+
+    /**
+     * @return BelongsTo<Subscription, $this>
+     */
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+
+    /** Whether the merchant returned the whole charge. */
+    public function fullyRefunded(): bool
+    {
+        return $this->total > 0 && $this->amount_refunded >= $this->total;
+    }
+}

--- a/app/Models/MerchantEvent.php
+++ b/app/Models/MerchantEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MerchantProvider;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+
+/**
+ * The inbox: one verified webhook delivery from a merchant.
+ *
+ * Written before anything acts, processed on the queue, kept afterwards as
+ * the forensic record of what the merchant said and when. The unique
+ * (merchant, external_id) pair is the idempotency guarantee — a redelivery
+ * inserts nothing and is acknowledged without running twice.
+ */
+#[Fillable(['merchant', 'external_id', 'type', 'payload', 'received_at'])]
+class MerchantEvent extends Model
+{
+    use Prunable;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'merchant' => MerchantProvider::class,
+            'payload' => 'array',
+            'received_at' => 'datetime',
+            'processed_at' => 'datetime',
+            'failed_at' => 'datetime',
+        ];
+    }
+
+    public function markProcessed(): void
+    {
+        $this->forceFill(['processed_at' => now(), 'failed_at' => null, 'error' => null])->save();
+    }
+
+    public function markFailed(string $error): void
+    {
+        $this->forceFill(['failed_at' => now(), 'error' => $error])->save();
+    }
+
+    /**
+     * Processed events older than a year age out with the nightly
+     * `model:prune`. Failed and unprocessed rows are kept indefinitely —
+     * they are the queue of things still owed an action, and pruning one
+     * would be silently dropping a payment event.
+     */
+    public function prunable()
+    {
+        return static::query()
+            ->whereNotNull('processed_at')
+            ->where('received_at', '<', now()->subYear());
+    }
+}

--- a/app/Models/MerchantEvent.php
+++ b/app/Models/MerchantEvent.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\MerchantProvider;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Prunable;
 
@@ -49,8 +50,10 @@ class MerchantEvent extends Model
      * `model:prune`. Failed and unprocessed rows are kept indefinitely —
      * they are the queue of things still owed an action, and pruning one
      * would be silently dropping a payment event.
+     *
+     * @return Builder<static>
      */
-    public function prunable()
+    public function prunable(): Builder
     {
         return static::query()
             ->whereNotNull('processed_at')

--- a/app/Models/MerchantReference.php
+++ b/app/Models/MerchantReference.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * Stripe object finds the local row it is about. One local row can be known
  * to several merchants at once — that is the portability story in one table.
  */
-#[Fillable(['merchant', 'external_id', 'synced_at'])]
+#[Fillable(['referenceable_type', 'referenceable_id', 'merchant', 'external_id', 'synced_at'])]
 class MerchantReference extends Model
 {
     /**

--- a/app/Models/MerchantReference.php
+++ b/app/Models/MerchantReference.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MerchantProvider;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * The mapping between a local row and its counterpart at a merchant.
+ *
+ * The local catalog is the source of truth; this is how a pushed Plan
+ * remembers its Stripe Product id, and how an incoming webhook naming a
+ * Stripe object finds the local row it is about. One local row can be known
+ * to several merchants at once — that is the portability story in one table.
+ */
+#[Fillable(['merchant', 'external_id', 'synced_at'])]
+class MerchantReference extends Model
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'merchant' => MerchantProvider::class,
+            'synced_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function referenceable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * The local row a merchant's object id refers to, or null when the
+     * merchant is talking about something this app never synced.
+     */
+    public static function resolve(MerchantProvider $merchant, string $externalId): ?Model
+    {
+        return static::query()
+            ->where('merchant', $merchant)
+            ->where('external_id', $externalId)
+            ->first()
+            ?->referenceable;
+    }
+
+    /**
+     * Record (or refresh) the mapping for a local row at a merchant.
+     */
+    public static function remember(Model $local, MerchantProvider $merchant, string $externalId): self
+    {
+        return static::query()->updateOrCreate(
+            [
+                'referenceable_type' => $local->getMorphClass(),
+                'referenceable_id' => $local->getKey(),
+                'merchant' => $merchant,
+            ],
+            ['external_id' => $externalId, 'synced_at' => now()],
+        );
+    }
+
+    /** The external id a local row is known by at a merchant, if it is. */
+    public static function externalId(Model $local, MerchantProvider $merchant): ?string
+    {
+        return static::query()
+            ->where('referenceable_type', $local->getMorphClass())
+            ->where('referenceable_id', $local->getKey())
+            ->where('merchant', $merchant)
+            ->value('external_id');
+    }
+}

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -129,7 +129,12 @@ class Plan extends Model
         return $this->prices()->where('active', true)->orderByDesc('default')->orderBy('amount');
     }
 
-    /** Plans the public pricing page lists, in their configured order. */
+    /**
+     * Plans the public pricing page lists, in their configured order.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
     public function scopeListed(Builder $query): Builder
     {
         return $query->where('active', true)->where('listed', true)->orderBy('sort');

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\BillingModel;
+use App\Enums\CancellationTiming;
+use App\Enums\LapseBehaviour;
+use App\Models\Concerns\LogsAuditableChanges;
+use Database\Factories\PlanFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * What is for sale: a named bundle of entitlements and every lifecycle
+ * decision that governs a subscription to it, held as data.
+ *
+ * The plan is the configuration object of the whole billing layer. What it
+ * grants, how it charges, what lapsing does, how cancellation times out, how
+ * many tokens it permits — all properties of the plan, so the same registry
+ * can sell a strict per-seat subscription beside a perpetual licence beside a
+ * comped sponsorship without any of them being a special case in code.
+ *
+ * Local rows are the source of truth; CatalogSync mirrors them out to
+ * merchants and MerchantReference remembers the mapping.
+ *
+ * @see docs/plans/ecommerce-subscriptions.md
+ */
+#[Fillable([
+    'name', 'slug', 'description', 'active', 'listed', 'billing_model',
+    'trial_days', 'token_limit', 'updates_window_months', 'lapse_behaviour',
+    'grace_days', 'cancellation', 'auto_issue_token', 'sort',
+])]
+class Plan extends Model
+{
+    /** @use HasFactory<PlanFactory> */
+    use HasFactory, LogsAuditableChanges, SoftDeletes;
+
+    /**
+     * Everything commercial about a plan is worth an audit line: each of
+     * these changes what customers get or pay for.
+     *
+     * @return list<string>
+     */
+    protected function auditedAttributes(): array
+    {
+        return [
+            'name', 'slug', 'active', 'listed', 'billing_model', 'trial_days',
+            'token_limit', 'updates_window_months', 'lapse_behaviour',
+            'grace_days', 'cancellation', 'auto_issue_token',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'active' => 'boolean',
+            'listed' => 'boolean',
+            'billing_model' => BillingModel::class,
+            'trial_days' => 'integer',
+            'token_limit' => 'integer',
+            'updates_window_months' => 'integer',
+            'lapse_behaviour' => LapseBehaviour::class,
+            'grace_days' => 'integer',
+            'cancellation' => CancellationTiming::class,
+            'auto_issue_token' => 'boolean',
+            'sort' => 'integer',
+        ];
+    }
+
+    /**
+     * @return HasMany<PlanPrice, $this>
+     */
+    public function prices(): HasMany
+    {
+        return $this->hasMany(PlanPrice::class);
+    }
+
+    /**
+     * @return HasMany<PlanEntitlement, $this>
+     */
+    public function entitlements(): HasMany
+    {
+        return $this->hasMany(PlanEntitlement::class);
+    }
+
+    /**
+     * The entitlements as their targets, for the form pickers — the same
+     * table as entitlements() above, read through the morph so Filament can
+     * sync it like any other relationship.
+     *
+     * @return MorphToMany<Package, $this>
+     */
+    public function packages(): MorphToMany
+    {
+        return $this->morphedByMany(Package::class, 'grantable', 'plan_entitlements');
+    }
+
+    /**
+     * @return MorphToMany<Repository, $this>
+     */
+    public function repositories(): MorphToMany
+    {
+        return $this->morphedByMany(Repository::class, 'grantable', 'plan_entitlements');
+    }
+
+    /**
+     * @return HasMany<Subscription, $this>
+     */
+    public function subscriptions(): HasMany
+    {
+        return $this->hasMany(Subscription::class);
+    }
+
+    /**
+     * The prices the buy button offers, defaults first.
+     *
+     * @return HasMany<PlanPrice, $this>
+     */
+    public function activePrices(): HasMany
+    {
+        return $this->prices()->where('active', true)->orderByDesc('default')->orderBy('amount');
+    }
+
+    /** Plans the public pricing page lists, in their configured order. */
+    public function scopeListed(Builder $query): Builder
+    {
+        return $query->where('active', true)->where('listed', true)->orderBy('sort');
+    }
+
+    /** Whether a stranger can buy this plan right now. */
+    public function purchasable(): bool
+    {
+        return $this->active && $this->activePrices()->exists();
+    }
+}

--- a/app/Models/PlanEntitlement.php
+++ b/app/Models/PlanEntitlement.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PlanEntitlementFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * One thing a plan grants: a Repository wholesale, or a Package by name —
+ * the same two shapes a grant has always had.
+ *
+ * The template only. When a subscription activates, the projector copies
+ * these into Entitlement rows and pivot grants for the actual beneficiaries;
+ * editing a plan's entitlements re-projects every active subscription, so
+ * adding a package to a plan is adding it for everyone on the plan.
+ */
+#[Fillable(['grantable_type', 'grantable_id'])]
+class PlanEntitlement extends Model
+{
+    /** @use HasFactory<PlanEntitlementFactory> */
+    use HasFactory;
+
+    public $timestamps = false;
+
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
+    public function plan(): BelongsTo
+    {
+        return $this->belongsTo(Plan::class);
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function grantable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/PlanPrice.php
+++ b/app/Models/PlanPrice.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\BillingInterval;
+use Database\Factories\PlanPriceFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * One way to pay for a plan: an amount, a currency, an interval.
+ *
+ * Rows rather than columns on the plan so one plan can sell monthly and
+ * yearly at once, and so a price can retire without breaking the
+ * subscriptions already on it — a retired price stops being offered and
+ * keeps being charged.
+ *
+ * Amounts are integer minor units (1999 is $19.99), the only representation
+ * of money that survives arithmetic, and the one merchants speak natively.
+ */
+#[Fillable(['currency', 'amount', 'interval', 'interval_count', 'active', 'default'])]
+class PlanPrice extends Model
+{
+    /** @use HasFactory<PlanPriceFactory> */
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'amount' => 'integer',
+            'interval' => BillingInterval::class,
+            'interval_count' => 'integer',
+            'active' => 'boolean',
+            'default' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
+    public function plan(): BelongsTo
+    {
+        return $this->belongsTo(Plan::class);
+    }
+
+    /**
+     * The amount as a human reads it — "$19.99/month" — for the panel and
+     * the pricing page. Minor-unit maths stays here so nothing else divides
+     * by 100 and gets a yen price wrong; the zero-decimal currencies are the
+     * short list Stripe documents.
+     */
+    public function display(): string
+    {
+        $zeroDecimal = in_array($this->currency, ['jpy', 'krw', 'vnd', 'clp', 'pyg', 'rwf', 'ugx', 'vuv', 'xaf', 'xof', 'xpf', 'bif', 'djf', 'gnf', 'kmf', 'mga'], true);
+
+        $amount = $zeroDecimal
+            ? number_format($this->amount)
+            : number_format($this->amount / 100, 2);
+
+        $money = strtoupper($this->currency).' '.$amount;
+
+        return match ($this->interval) {
+            BillingInterval::OneTime => $money,
+            default => $this->interval_count === 1
+                ? "{$money}/{$this->interval->value}"
+                : "{$money} every {$this->interval_count} {$this->interval->value}s",
+        };
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -30,7 +30,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @see SubscriptionProjector
  * @see EntitlementProjector
  */
-#[Fillable(['plan_id', 'plan_price_id', 'merchant', 'status', 'quantity', 'coupon_code'])]
+#[Fillable(['billing_customer_id', 'plan_id', 'plan_price_id', 'merchant', 'status', 'quantity', 'coupon_code'])]
 class Subscription extends Model
 {
     /** @use HasFactory<SubscriptionFactory> */

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\MerchantProvider;
+use App\Enums\SubscriptionStatus;
+use App\Merchants\MerchantClient;
+use App\Models\Concerns\LogsAuditableChanges;
+use Database\Factories\SubscriptionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * A customer's purchase of a plan — a local mirror of the merchant's record.
+ *
+ * The merchant owns the billing clock. This row is a projection of what it
+ * last said, written by verified webhooks and repaired by the nightly
+ * reconciler; nothing local ever decides that a renewal happened. What *is*
+ * decided locally is what the money means: the entitlement projector turns
+ * this row's status into grants, and the plan's lapse behaviour into their
+ * withdrawal.
+ *
+ * @see \App\Services\Billing\SubscriptionProjector
+ * @see \App\Services\Billing\EntitlementProjector
+ */
+#[Fillable(['plan_id', 'plan_price_id', 'merchant', 'status', 'quantity', 'coupon_code'])]
+class Subscription extends Model
+{
+    /** @use HasFactory<SubscriptionFactory> */
+    use HasFactory, LogsAuditableChanges, SoftDeletes;
+
+    /**
+     * The commercial identity and the two administrative acts. The clock
+     * columns move on every merchant event and would bury the audit log in
+     * bookkeeping.
+     *
+     * @return list<string>
+     */
+    protected function auditedAttributes(): array
+    {
+        return ['plan_id', 'plan_price_id', 'merchant', 'status', 'suspended_at', 'suspension_reason'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'merchant' => MerchantProvider::class,
+            'status' => SubscriptionStatus::class,
+            'quantity' => 'integer',
+            'trial_ends_at' => 'datetime',
+            'current_period_start' => 'datetime',
+            'current_period_end' => 'datetime',
+            'grace_ends_at' => 'datetime',
+            'cancel_at' => 'datetime',
+            'canceled_at' => 'datetime',
+            'ends_at' => 'datetime',
+            'suspended_at' => 'datetime',
+            'last_event_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<BillingCustomer, $this>
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(BillingCustomer::class, 'billing_customer_id');
+    }
+
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
+    public function plan(): BelongsTo
+    {
+        return $this->belongsTo(Plan::class);
+    }
+
+    /**
+     * @return BelongsTo<PlanPrice, $this>
+     */
+    public function price(): BelongsTo
+    {
+        return $this->belongsTo(PlanPrice::class, 'plan_price_id');
+    }
+
+    /**
+     * @return HasMany<Entitlement, $this>
+     */
+    public function entitlements(): HasMany
+    {
+        return $this->hasMany(Entitlement::class);
+    }
+
+    /**
+     * The access tokens this subscription issued — what a token_limit counts
+     * and what LapseBehaviour::RevokeTokens revokes.
+     *
+     * @return HasMany<Token, $this>
+     */
+    public function tokens(): HasMany
+    {
+        return $this->hasMany(Token::class);
+    }
+
+    /**
+     * @return HasMany<Invoice, $this>
+     */
+    public function invoices(): HasMany
+    {
+        return $this->hasMany(Invoice::class);
+    }
+
+    public function client(): MerchantClient
+    {
+        return $this->merchant->client();
+    }
+
+    /**
+     * Whether this subscription grants access right now. Suspension wins
+     * over everything — it is the administrative hard stop — and the grace
+     * window extends a lapsed status without rewriting it, so the panel can
+     * still show *why* the clock is running.
+     */
+    public function grantsAccess(): bool
+    {
+        if ($this->suspended_at !== null) {
+            return false;
+        }
+
+        if ($this->status->grantsAccess()) {
+            return true;
+        }
+
+        return $this->grace_ends_at !== null && $this->grace_ends_at->isFuture();
+    }
+
+    /** The subscriptions the nightly reconciler re-pulls from the merchant. */
+    public function scopeReconcilable(Builder $query): Builder
+    {
+        return $query
+            ->whereIn('status', SubscriptionStatus::reconcilable())
+            ->where('merchant', '!=', MerchantProvider::Manual->value)
+            ->orderBy('current_period_end');
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -6,6 +6,8 @@ use App\Enums\MerchantProvider;
 use App\Enums\SubscriptionStatus;
 use App\Merchants\MerchantClient;
 use App\Models\Concerns\LogsAuditableChanges;
+use App\Services\Billing\EntitlementProjector;
+use App\Services\Billing\SubscriptionProjector;
 use Database\Factories\SubscriptionFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
@@ -25,8 +27,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * this row's status into grants, and the plan's lapse behaviour into their
  * withdrawal.
  *
- * @see \App\Services\Billing\SubscriptionProjector
- * @see \App\Services\Billing\EntitlementProjector
+ * @see SubscriptionProjector
+ * @see EntitlementProjector
  */
 #[Fillable(['plan_id', 'plan_price_id', 'merchant', 'status', 'quantity', 'coupon_code'])]
 class Subscription extends Model
@@ -142,7 +144,12 @@ class Subscription extends Model
         return $this->grace_ends_at !== null && $this->grace_ends_at->isFuture();
     }
 
-    /** The subscriptions the nightly reconciler re-pulls from the merchant. */
+    /**
+     * The subscriptions the nightly reconciler re-pulls from the merchant.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
     public function scopeReconcilable(Builder $query): Builder
     {
         return $query

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -61,6 +61,7 @@ class Subscription extends Model
             'current_period_start' => 'datetime',
             'current_period_end' => 'datetime',
             'grace_ends_at' => 'datetime',
+            'grace_notified_at' => 'datetime',
             'cancel_at' => 'datetime',
             'canceled_at' => 'datetime',
             'ends_at' => 'datetime',

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 /**
  * A group of people that holds package and repository grants.
@@ -70,5 +71,19 @@ class Team extends Model
     public function repositories(): BelongsToMany
     {
         return $this->belongsToMany(Repository::class);
+    }
+
+    /**
+     * The billing identity behind this team, when somebody pays for it.
+     *
+     * A team subscription grants to every member through the same pivots a
+     * team's manual grants use; the customer row is where the card, the
+     * invoices and the nominated billing contact live.
+     *
+     * @return MorphOne<BillingCustomer, $this>
+     */
+    public function billingCustomer(): MorphOne
+    {
+        return $this->morphOne(BillingCustomer::class, 'billable');
     }
 }

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -10,6 +10,7 @@ use DateTimeInterface;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Gate;
@@ -72,6 +73,22 @@ class Token extends Model
     }
 
     /**
+     * The subscription this token was issued under, when it was.
+     *
+     * Set for the activation token a purchase mints and for any token counted
+     * against a plan's token_limit; null for every token that predates
+     * billing or was issued outside it. What LapseBehaviour::RevokeTokens
+     * revokes is exactly the tokens carrying its subscription's id — never a
+     * personal token the same user issued for something else.
+     *
+     * @return BelongsTo<Subscription, $this>
+     */
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class);
+    }
+
+    /**
      * Issue a token for a principal, returning the only copy of its plain
      * text that will ever exist.
      *
@@ -82,6 +99,7 @@ class Token extends Model
         string $name,
         array $abilities,
         ?DateTimeInterface $expiresAt = null,
+        ?Subscription $subscription = null,
     ): NewToken {
         $plain = 'pp_'.Str::random(40);
 
@@ -98,6 +116,7 @@ class Token extends Model
             'token_prefix' => substr($plain, 0, 8),
             'token' => hash('sha256', $plain),
             'expires_at' => $expiresAt,
+            'subscription_id' => $subscription?->getKey(),
         ])->save();
 
         return new NewToken($token, $plain);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -92,6 +93,20 @@ class User extends Authenticatable implements FilamentUser
     public function teams(): BelongsToMany
     {
         return $this->belongsToMany(Team::class);
+    }
+
+    /**
+     * The billing identity behind this account, when it has bought anything.
+     *
+     * MorphOne rather than a column here: a customer is a different thing
+     * from an account, most accounts never have one, and everything commercial
+     * hangs off the customer row rather than the user.
+     *
+     * @return MorphOne<BillingCustomer, $this>
+     */
+    public function billingCustomer(): MorphOne
+    {
+        return $this->morphOne(BillingCustomer::class, 'billable');
     }
 
     /**

--- a/app/Notifications/Billing/BillingAlert.php
+++ b/app/Notifications/Billing/BillingAlert.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use App\Notifications\Concerns\AnnouncedByMail;
+use App\Notifications\Concerns\RoutedByAdminNotifier;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Slack\BlockKit\Blocks\SectionBlock;
+use Illuminate\Notifications\Slack\SlackMessage;
+
+/**
+ * An admin-side billing event that needs a person: a dispute opened, a
+ * merchant event that failed processing, reconcile drift.
+ *
+ * One class rather than one per event because these differ only in their
+ * words and their urgency — the routing (bell, mail, Slack) is identical,
+ * and each carries a link to the record that needs looking at.
+ */
+class BillingAlert extends Notification implements ShouldQueue
+{
+    use AnnouncedByMail, Queueable, RoutedByAdminNotifier;
+
+    public function __construct(
+        private readonly string $alertTitle,
+        private readonly string $alertBody,
+        private readonly string $url,
+        private readonly string $tone = 'danger',
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toDatabase(object $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->status($this->tone)
+            ->icon('heroicon-o-credit-card')
+            ->title($this->title())
+            ->body($this->body())
+            ->actions([
+                Action::make('view')
+                    ->label('View')
+                    ->url($this->url)
+                    ->markAsRead(),
+            ])
+            ->getDatabaseMessage();
+    }
+
+    public function toSlack(object $notifiable): SlackMessage
+    {
+        return (new SlackMessage)
+            ->text("{$this->title()} — {$this->body()}")
+            ->headerBlock($this->title())
+            ->sectionBlock(fn (SectionBlock $block) => $block->text($this->body())->markdown());
+    }
+
+    protected function mailTone(): string
+    {
+        return $this->tone;
+    }
+
+    /**
+     * @return array{label: string, url: string}
+     */
+    protected function mailAction(): array
+    {
+        return ['label' => 'View', 'url' => $this->url];
+    }
+
+    protected function title(): string
+    {
+        return $this->alertTitle;
+    }
+
+    protected function body(): string
+    {
+        return $this->alertBody;
+    }
+}

--- a/app/Notifications/Billing/CustomerBillingMail.php
+++ b/app/Notifications/Billing/CustomerBillingMail.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * The customer-facing half of billing mail.
+ *
+ * The admin announcements route through RoutedByAdminNotifier because their
+ * audience is "everyone with a role"; these go to exactly one person — the
+ * payer, or a team's billing contact — and never to the bell or Slack, which
+ * a customer cannot see. The rendering reuses mail.announcement so a billing
+ * email and an admin email are recognisably from the same registry, with the
+ * footer pointing at the customer's own billing area rather than the panel.
+ */
+abstract class CustomerBillingMail extends Notification
+{
+    abstract protected function title(): string;
+
+    abstract protected function body(): string;
+
+    /**
+     * @return array{label: string, url: string}
+     */
+    protected function mailAction(): array
+    {
+        return ['label' => 'Manage billing', 'url' => route('billing.index')];
+    }
+
+    protected function mailTone(): string
+    {
+        return 'info';
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $action = $this->mailAction();
+
+        return (new MailMessage)
+            ->subject($this->title())
+            ->view('mail.announcement', [
+                'appName' => (string) config('app.name'),
+                'title' => $this->title(),
+                'body' => $this->body(),
+                'actionLabel' => $action['label'],
+                'actionUrl' => $action['url'],
+                'tone' => $this->mailTone(),
+                'email' => $notifiable->email ?? null,
+                'preferencesUrl' => route('billing.index'),
+            ]);
+    }
+}

--- a/app/Notifications/Billing/PaymentFailed.php
+++ b/app/Notifications/Billing/PaymentFailed.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use App\Models\Subscription;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * A renewal charge failed. Access continues while the merchant retries —
+ * this email exists so the customer fixes the card before the retries run
+ * out, not after their CI goes red.
+ */
+class PaymentFailed extends CustomerBillingMail implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public readonly Subscription $subscription) {}
+
+    protected function mailTone(): string
+    {
+        return 'warning';
+    }
+
+    protected function mailAction(): array
+    {
+        return ['label' => 'Update payment method', 'url' => route('billing.portal')];
+    }
+
+    protected function title(): string
+    {
+        return "A payment for {$this->subscription->plan->name} failed";
+    }
+
+    protected function body(): string
+    {
+        return 'The charge will be retried automatically. Your access continues in the meantime — updating your card is usually all it takes.';
+    }
+}

--- a/app/Notifications/Billing/SubscriptionActivated.php
+++ b/app/Notifications/Billing/SubscriptionActivated.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use App\Models\Subscription;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * The purchase worked and access is on.
+ *
+ * Deliberately does not carry the activation token: the welcome page shows
+ * it once, and a credential in an inbox is the exact shape this registry
+ * already avoids putting setup links in.
+ */
+class SubscriptionActivated extends CustomerBillingMail implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public readonly Subscription $subscription) {}
+
+    protected function mailTone(): string
+    {
+        return 'success';
+    }
+
+    protected function title(): string
+    {
+        return "Your {$this->subscription->plan->name} subscription is active";
+    }
+
+    protected function body(): string
+    {
+        return 'Access to the packages your plan includes is on. Tokens, invoices and your card are managed from your billing area.';
+    }
+}

--- a/app/Notifications/Billing/SubscriptionLapsed.php
+++ b/app/Notifications/Billing/SubscriptionLapsed.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use App\Enums\LapseBehaviour;
+use App\Models\Subscription;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * The subscription stopped granting access, and what that means under this
+ * plan — withdrawn, frozen at the versions already released, or tokens
+ * revoked — said plainly rather than left to be discovered by a failing
+ * composer install.
+ */
+class SubscriptionLapsed extends CustomerBillingMail implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public readonly Subscription $subscription) {}
+
+    protected function mailTone(): string
+    {
+        return 'danger';
+    }
+
+    protected function title(): string
+    {
+        return "Your {$this->subscription->plan->name} subscription has ended";
+    }
+
+    protected function body(): string
+    {
+        return match ($this->subscription->plan->lapse_behaviour) {
+            LapseBehaviour::FreezeAtVersion => 'Versions released while you were subscribed remain yours to install. New releases need the subscription renewed.',
+            LapseBehaviour::RevokeTokens => 'Access has been withdrawn and the subscription\'s tokens revoked. Renewing restores access; new tokens are issued from your billing area.',
+            LapseBehaviour::None => 'Your access continues. Renew any time to keep supporting the packages.',
+            LapseBehaviour::WithdrawEntitlement => 'Access to the plan\'s packages has been withdrawn. Renewing restores it exactly as it was.',
+        };
+    }
+}

--- a/app/Notifications/Billing/TrialEnding.php
+++ b/app/Notifications/Billing/TrialEnding.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use App\Models\Subscription;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * The trial converts to a charge in a few days — the one email that saves a
+ * surprise invoice, sent once per subscription by the nightly reconcile.
+ */
+class TrialEnding extends CustomerBillingMail implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public readonly Subscription $subscription) {}
+
+    protected function title(): string
+    {
+        return "Your {$this->subscription->plan->name} trial ends soon";
+    }
+
+    protected function body(): string
+    {
+        $ends = $this->subscription->trial_ends_at?->toFormattedDateString() ?? 'soon';
+
+        return "Your trial ends on {$ends}, when the first charge is made. Cancel before then from your billing area if you do not want to continue.";
+    }
+}

--- a/app/Notifications/Billing/VerifyBillingEmail.php
+++ b/app/Notifications/Billing/VerifyBillingEmail.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Notifications\Billing;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * The signed link that proves a self-registered address is real — required
+ * before checkout, so a fabricated address cannot buy a trial.
+ */
+class VerifyBillingEmail extends CustomerBillingMail implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private readonly string $url) {}
+
+    protected function mailAction(): array
+    {
+        return ['label' => 'Verify email', 'url' => $this->url];
+    }
+
+    protected function title(): string
+    {
+        return 'Verify your email address';
+    }
+
+    protected function body(): string
+    {
+        return 'Confirm this address to finish setting up your account. The link is valid for a day; ask for another from your billing page if it expires.';
+    }
+}

--- a/app/Policies/BillingCustomerPolicy.php
+++ b/app/Policies/BillingCustomerPolicy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\BillingCustomer;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+/**
+ * Shield's generated shape, kept by hand like the rest of them.
+ *
+ * Billing permissions are commercial power — a plan decides what is for
+ * sale, a subscription decides who has paid access — so they are handed out
+ * like Update:Team rather than bundled into anything package-shaped.
+ */
+class BillingCustomerPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:BillingCustomer');
+    }
+
+    public function view(AuthUser $authUser, BillingCustomer $model): bool
+    {
+        return $authUser->can('View:BillingCustomer');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:BillingCustomer');
+    }
+
+    public function update(AuthUser $authUser, BillingCustomer $model): bool
+    {
+        return $authUser->can('Update:BillingCustomer');
+    }
+
+    public function delete(AuthUser $authUser, BillingCustomer $model): bool
+    {
+        return $authUser->can('Delete:BillingCustomer');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:BillingCustomer');
+    }
+
+    public function restore(AuthUser $authUser, BillingCustomer $model): bool
+    {
+        return $authUser->can('Restore:BillingCustomer');
+    }
+
+    public function forceDelete(AuthUser $authUser, BillingCustomer $model): bool
+    {
+        return $authUser->can('ForceDelete:BillingCustomer');
+    }
+}

--- a/app/Policies/InvoicePolicy.php
+++ b/app/Policies/InvoicePolicy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Invoice;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+/**
+ * Shield's generated shape, kept by hand like the rest of them.
+ *
+ * Billing permissions are commercial power — a plan decides what is for
+ * sale, a subscription decides who has paid access — so they are handed out
+ * like Update:Team rather than bundled into anything package-shaped.
+ */
+class InvoicePolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Invoice');
+    }
+
+    public function view(AuthUser $authUser, Invoice $model): bool
+    {
+        return $authUser->can('View:Invoice');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:Invoice');
+    }
+
+    public function update(AuthUser $authUser, Invoice $model): bool
+    {
+        return $authUser->can('Update:Invoice');
+    }
+
+    public function delete(AuthUser $authUser, Invoice $model): bool
+    {
+        return $authUser->can('Delete:Invoice');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:Invoice');
+    }
+
+    public function restore(AuthUser $authUser, Invoice $model): bool
+    {
+        return $authUser->can('Restore:Invoice');
+    }
+
+    public function forceDelete(AuthUser $authUser, Invoice $model): bool
+    {
+        return $authUser->can('ForceDelete:Invoice');
+    }
+}

--- a/app/Policies/PlanPolicy.php
+++ b/app/Policies/PlanPolicy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Plan;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+/**
+ * Shield's generated shape, kept by hand like the rest of them.
+ *
+ * Billing permissions are commercial power — a plan decides what is for
+ * sale, a subscription decides who has paid access — so they are handed out
+ * like Update:Team rather than bundled into anything package-shaped.
+ */
+class PlanPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Plan');
+    }
+
+    public function view(AuthUser $authUser, Plan $model): bool
+    {
+        return $authUser->can('View:Plan');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:Plan');
+    }
+
+    public function update(AuthUser $authUser, Plan $model): bool
+    {
+        return $authUser->can('Update:Plan');
+    }
+
+    public function delete(AuthUser $authUser, Plan $model): bool
+    {
+        return $authUser->can('Delete:Plan');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:Plan');
+    }
+
+    public function restore(AuthUser $authUser, Plan $model): bool
+    {
+        return $authUser->can('Restore:Plan');
+    }
+
+    public function forceDelete(AuthUser $authUser, Plan $model): bool
+    {
+        return $authUser->can('ForceDelete:Plan');
+    }
+}

--- a/app/Policies/SubscriptionPolicy.php
+++ b/app/Policies/SubscriptionPolicy.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Subscription;
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User as AuthUser;
+
+/**
+ * Shield's generated shape, kept by hand like the rest of them.
+ *
+ * Billing permissions are commercial power — a plan decides what is for
+ * sale, a subscription decides who has paid access — so they are handed out
+ * like Update:Team rather than bundled into anything package-shaped.
+ */
+class SubscriptionPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('ViewAny:Subscription');
+    }
+
+    public function view(AuthUser $authUser, Subscription $model): bool
+    {
+        return $authUser->can('View:Subscription');
+    }
+
+    public function create(AuthUser $authUser): bool
+    {
+        return $authUser->can('Create:Subscription');
+    }
+
+    public function update(AuthUser $authUser, Subscription $model): bool
+    {
+        return $authUser->can('Update:Subscription');
+    }
+
+    public function delete(AuthUser $authUser, Subscription $model): bool
+    {
+        return $authUser->can('Delete:Subscription');
+    }
+
+    public function deleteAny(AuthUser $authUser): bool
+    {
+        return $authUser->can('DeleteAny:Subscription');
+    }
+
+    public function restore(AuthUser $authUser, Subscription $model): bool
+    {
+        return $authUser->can('Restore:Subscription');
+    }
+
+    public function forceDelete(AuthUser $authUser, Subscription $model): bool
+    {
+        return $authUser->can('ForceDelete:Subscription');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -218,6 +218,19 @@ class AppServiceProvider extends ServiceProvider
         // on every request. The GitHub App's own hook names no package in its
         // path — it delivers for every installed repository at once — so the
         // address budget is the only one that applies to it.
+        // Self-serve signup: the cheapest endpoint on the site to abuse
+        // and the least legitimate reason to hit it twice in a minute.
+        RateLimiter::for('registration', function (Request $request): array {
+            return [Limit::perMinute(5)->by('address:'.$request->ip())];
+        });
+
+        // The payment merchant's deliveries. Rarer than the git providers'
+        // by orders of magnitude, and each unverified request still costs a
+        // signature check — so a tight per-address limit loses nothing.
+        RateLimiter::for('merchant-webhooks', function (Request $request): array {
+            return [Limit::perMinute(120)->by('address:'.$request->ip())];
+        });
+
         RateLimiter::for('webhooks', function (Request $request): array {
             $limits = [Limit::perMinute(300)->by('address:'.$request->ip())];
 

--- a/app/Services/Billing/CatalogSync.php
+++ b/app/Services/Billing/CatalogSync.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Enums\MerchantProvider;
+use App\Models\MerchantReference;
+use App\Models\Plan;
+
+/**
+ * Pushes the local catalog out to a merchant and remembers the mapping.
+ *
+ * The local rows are the source of truth: plans and prices are authored in
+ * the panel, and this makes the merchant agree — creating what it lacks,
+ * updating what drifted, archiving prices that changed. Run before a plan's
+ * first checkout, from the panel action, or wholesale from
+ * `billing:sync-catalog`; running it twice is running it once, because the
+ * drivers converge rather than append.
+ */
+final class CatalogSync
+{
+    /** Push one plan and all its prices. */
+    public function syncPlan(Plan $plan, MerchantProvider $merchant): void
+    {
+        $client = $merchant->client();
+
+        MerchantReference::remember($plan, $merchant, $client->syncProduct($plan));
+
+        foreach ($plan->prices as $price) {
+            MerchantReference::remember($price, $merchant, $client->syncPrice($price));
+        }
+    }
+
+    /** Push every active plan. */
+    public function syncAll(MerchantProvider $merchant): int
+    {
+        $count = 0;
+
+        foreach (Plan::query()->where('active', true)->with('prices')->get() as $plan) {
+            $this->syncPlan($plan, $merchant);
+            $count++;
+        }
+
+        return $count;
+    }
+}

--- a/app/Services/Billing/CheckoutBuilder.php
+++ b/app/Services/Billing/CheckoutBuilder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Enums\MerchantProvider;
+use App\Merchants\Values\CheckoutRequest;
+use App\Merchants\Values\CheckoutSession;
+use App\Models\BillingCustomer;
+use App\Models\PlanPrice;
+use App\Models\Team;
+use App\Models\User;
+
+/**
+ * Turns "this account wants to buy this price" into a merchant checkout.
+ *
+ * The one place a BillingCustomer is created for a first-time buyer, and the
+ * one place the checkout's success/cancel URLs are decided — so the welcome
+ * page always receives the session id it needs to find (or finish) the
+ * subscription the payment produced.
+ */
+final class CheckoutBuilder
+{
+    /**
+     * Begin a checkout for the account, creating its billing customer on
+     * first purchase.
+     */
+    public function start(User|Team $billable, PlanPrice $price, ?User $contact = null): CheckoutSession
+    {
+        $merchant = MerchantProvider::from((string) config('registry.billing.merchant'));
+        $customer = $this->customerFor($billable, $merchant, $contact);
+
+        $client = $merchant->client();
+
+        // First purchase of this plan through this merchant syncs it there;
+        // afterwards the sync is a fast no-op convergence check.
+        (new CatalogSync)->syncPlan($price->plan, $merchant);
+
+        $session = $client->startCheckout(new CheckoutRequest(
+            customer: $customer,
+            price: $price,
+            quantity: 1,
+            couponCode: null,
+            successUrl: route('billing.welcome').'?session={CHECKOUT_SESSION_ID}',
+            cancelUrl: route('pages.pricing'),
+            collectTax: $merchant->supportsTax(),
+            collectBusinessDetails: true,
+        ));
+
+        return $session;
+    }
+
+    /**
+     * The account's billing customer at this merchant, created on first use
+     * with the identity fields checkout will refine.
+     */
+    public function customerFor(User|Team $billable, MerchantProvider $merchant, ?User $contact = null): BillingCustomer
+    {
+        $existing = $billable->billingCustomer;
+
+        if ($existing !== null && $existing->merchant === $merchant) {
+            return $existing;
+        }
+
+        $contact ??= $billable instanceof User ? $billable : null;
+
+        $customer = new BillingCustomer([
+            'name' => $billable->name,
+            'email' => $contact?->email ?? '',
+            'merchant' => $merchant,
+            'billing_contact_user_id' => $billable instanceof Team ? $contact?->getKey() : null,
+        ]);
+
+        $customer->billable()->associate($billable);
+        $customer->save();
+
+        if ($merchant !== MerchantProvider::Manual) {
+            $customer->forceFill([
+                'merchant_customer_id' => $merchant->client()->ensureCustomer($customer),
+            ])->save();
+        }
+
+        return $customer;
+    }
+}

--- a/app/Services/Billing/CheckoutBuilder.php
+++ b/app/Services/Billing/CheckoutBuilder.php
@@ -65,7 +65,7 @@ final class CheckoutBuilder
 
         $customer = new BillingCustomer([
             'name' => $billable->name,
-            'email' => $contact?->email ?? '',
+            'email' => (string) $contact?->email,
             'merchant' => $merchant,
             'billing_contact_user_id' => $billable instanceof Team ? $contact?->getKey() : null,
         ]);

--- a/app/Services/Billing/EntitlementProjector.php
+++ b/app/Services/Billing/EntitlementProjector.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Enums\GrantSource;
+use App\Enums\LapseBehaviour;
+use App\Models\BillingCustomer;
+use App\Models\Entitlement;
+use App\Models\Package;
+use App\Models\Repository;
+use App\Models\Subscription;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Turns subscriptions into grants — the one writer of every pivot row whose
+ * source says 'subscription'.
+ *
+ * Billing never gets a branch in the visibility scopes. What a subscription
+ * grants is written into the same four pivot tables manual grants live in,
+ * marked with its source, and everything downstream — the Composer surface,
+ * the panel, the exports — keeps reading exactly what it always read. This
+ * class is the projection: given a customer, it computes what their
+ * subscriptions currently grant and makes the pivots say so, no more and no
+ * less. Manual rows are never touched in either direction.
+ *
+ * Idempotent by construction. It computes the desired state and diffs, so
+ * running it twice is running it once, and it is safe to call on every
+ * webhook, every reconcile, and every plan edit. It projects the *customer*,
+ * not the subscription that changed: two subscriptions can grant the same
+ * package, and only the union says whether the pivot row stays.
+ *
+ * The Entitlement ledger is maintained alongside: which subscription granted
+ * what, and up to which version. The pivots answer "who sees what" on the
+ * hot path; the ledger answers the questions only billing asks.
+ *
+ * @see \App\Enums\GrantSource for the two-writers contract
+ * @see docs/plans/ecommerce-subscriptions.md
+ */
+final class EntitlementProjector
+{
+    public function __construct(
+        private readonly VersionCeiling $ceilings = new VersionCeiling,
+    ) {}
+
+    /** Re-project the customer behind one subscription that changed. */
+    public function project(Subscription $subscription): void
+    {
+        $customer = $subscription->customer;
+
+        if ($customer !== null) {
+            $this->projectCustomer($customer);
+        }
+    }
+
+    /**
+     * Recompute every subscription-sourced grant this customer's billable
+     * should hold, and make the ledger and the pivots agree.
+     */
+    public function projectCustomer(BillingCustomer $customer): void
+    {
+        DB::transaction(function () use ($customer): void {
+            $desired = [];
+
+            $subscriptions = $customer->subscriptions()
+                ->with(['plan.entitlements', 'entitlements'])
+                ->get();
+
+            foreach ($subscriptions as $subscription) {
+                foreach ($this->syncLedger($subscription) as $key => $pair) {
+                    $desired[$key] = $pair;
+                }
+            }
+
+            $this->syncPivots($customer, $desired);
+        });
+    }
+
+    /**
+     * Bring one subscription's ledger rows in line with its status, and
+     * return the grants it currently supports as "type:id" keyed pairs.
+     *
+     * @return array<string, array{class-string, int}>
+     */
+    private function syncLedger(Subscription $subscription): array
+    {
+        // Suspension is the administrative hard stop: it bypasses the plan's
+        // lapse behaviour on purpose, because softening a suspension with a
+        // frozen-ceiling keepsake would defeat the act.
+        if ($subscription->suspended_at !== null) {
+            $this->deactivateAll($subscription);
+
+            return [];
+        }
+
+        if ($subscription->grantsAccess()) {
+            return $this->activate($subscription);
+        }
+
+        // Never activated: a checkout that expired incomplete, a subscription
+        // created lapsed. There is nothing to withdraw, freeze or keep.
+        if ($subscription->entitlements->isEmpty()) {
+            return [];
+        }
+
+        return match ($subscription->plan->lapse_behaviour) {
+            LapseBehaviour::None => $this->keep($subscription),
+            LapseBehaviour::FreezeAtVersion => $this->freeze($subscription),
+            LapseBehaviour::WithdrawEntitlement => $this->withdraw($subscription),
+            LapseBehaviour::RevokeTokens => $this->withdrawAndRevoke($subscription),
+        };
+    }
+
+    /**
+     * The subscription grants: ensure a live, uncapped ledger row per plan
+     * entitlement, and retire rows the plan no longer names — which is also
+     * what unwinds a freeze after a renewal, since the expanded per-package
+     * rows a frozen repository grant left behind are not in the plan.
+     *
+     * @return array<string, array{class-string, int}>
+     */
+    private function activate(Subscription $subscription): array
+    {
+        $pairs = [];
+
+        foreach ($subscription->plan->entitlements as $planned) {
+            $subscription->entitlements()->updateOrCreate(
+                [
+                    'grantable_type' => $planned->grantable_type,
+                    'grantable_id' => $planned->grantable_id,
+                ],
+                [
+                    'billing_customer_id' => $subscription->billing_customer_id,
+                    'active' => true,
+                    'version_ceiling' => null,
+                    'starts_at' => $subscription->entitlements
+                        ->first(fn (Entitlement $row): bool => $row->grantable_type === $planned->grantable_type
+                            && $row->grantable_id === $planned->grantable_id)
+                        ?->starts_at ?? now(),
+                    'ends_at' => null,
+                ],
+            );
+
+            $pairs[$this->key($planned->grantable_type, $planned->grantable_id)] = [$planned->grantable_type, $planned->grantable_id];
+        }
+
+        $subscription->entitlements()
+            ->where('active', true)
+            ->where(function ($query) use ($subscription): void {
+                foreach ($subscription->plan->entitlements as $planned) {
+                    $query->whereNot(fn ($row) => $row
+                        ->where('grantable_type', $planned->grantable_type)
+                        ->where('grantable_id', $planned->grantable_id));
+                }
+            })
+            ->update(['active' => false, 'ends_at' => now()]);
+
+        return $pairs;
+    }
+
+    /**
+     * LapseBehaviour::None — the rows stay exactly as they are.
+     *
+     * @return array<string, array{class-string, int}>
+     */
+    private function keep(Subscription $subscription): array
+    {
+        $pairs = [];
+
+        foreach ($subscription->entitlements()->where('active', true)->get() as $row) {
+            $pairs[$this->key($row->grantable_type, (int) $row->grantable_id)] = [$row->grantable_type, (int) $row->grantable_id];
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * LapseBehaviour::FreezeAtVersion — pin every active grant at the highest
+     * version that exists right now.
+     *
+     * A package grant gets its ceiling in place. A repository grant means
+     * "every package, present and future", which a frozen licence is exactly
+     * not — so it is expanded into per-package rows, each with its own
+     * ceiling, and the repository row is retired. A package added to the
+     * repository after the freeze is never granted; renewal restores the
+     * repository row through activate() and retires the expansion.
+     *
+     * Ceilings are ??= — a freeze that runs twice must not move the pin.
+     *
+     * @return array<string, array{class-string, int}>
+     */
+    private function freeze(Subscription $subscription): array
+    {
+        $pairs = [];
+
+        foreach ($subscription->entitlements()->where('active', true)->get() as $row) {
+            if ($row->grantable_type === Package::class) {
+                $package = Package::query()->find($row->grantable_id);
+
+                $row->forceFill([
+                    'version_ceiling' => $row->version_ceiling
+                        ?? ($package !== null ? $this->ceilings->currentCeiling($package) : VersionCeiling::NOTHING),
+                    'ends_at' => $row->ends_at ?? now(),
+                ])->save();
+
+                $pairs[$this->key(Package::class, (int) $row->grantable_id)] = [Package::class, (int) $row->grantable_id];
+
+                continue;
+            }
+
+            foreach (Package::query()->where('repository_id', $row->grantable_id)->get() as $package) {
+                $subscription->entitlements()->updateOrCreate(
+                    [
+                        'grantable_type' => Package::class,
+                        'grantable_id' => $package->getKey(),
+                    ],
+                    [
+                        'billing_customer_id' => $subscription->billing_customer_id,
+                        'active' => true,
+                        'version_ceiling' => $this->ceilings->currentCeiling($package),
+                        'starts_at' => $row->starts_at,
+                        'ends_at' => now(),
+                    ],
+                );
+
+                $pairs[$this->key(Package::class, (int) $package->getKey())] = [Package::class, (int) $package->getKey()];
+            }
+
+            $row->forceFill(['active' => false, 'ends_at' => $row->ends_at ?? now()])->save();
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * @return array<string, array{class-string, int}>
+     */
+    private function withdraw(Subscription $subscription): array
+    {
+        $this->deactivateAll($subscription);
+
+        return [];
+    }
+
+    /**
+     * @return array<string, array{class-string, int}>
+     */
+    private function withdrawAndRevoke(Subscription $subscription): array
+    {
+        $this->deactivateAll($subscription);
+
+        // One at a time so each revocation lands in the audit log — the same
+        // reason User::booted() deletes tokens the slow way.
+        $subscription->tokens()->get()->each->delete();
+
+        return [];
+    }
+
+    private function deactivateAll(Subscription $subscription): void
+    {
+        $subscription->entitlements()
+            ->where('active', true)
+            ->update(['active' => false, 'ends_at' => now()]);
+    }
+
+    /**
+     * Make the billable's subscription-sourced pivot rows match the desired
+     * set. A User's grants go in the user pivots; a Team's in the team
+     * pivots, where membership churn keeps working exactly as it does for
+     * manual team grants. Rows whose source is 'manual' are invisible here.
+     *
+     * @param  array<string, array{class-string, int}>  $desired
+     */
+    private function syncPivots(BillingCustomer $customer, array $desired): void
+    {
+        $billable = $customer->billable;
+
+        if (! $billable instanceof User && ! $billable instanceof Team) {
+            return;
+        }
+
+        [$packageTable, $repositoryTable, $ownerColumn] = $billable instanceof Team
+            ? ['package_team', 'repository_team', 'team_id']
+            : ['package_user', 'repository_user', 'user_id'];
+
+        $packages = [];
+        $repositories = [];
+
+        foreach ($desired as [$type, $id]) {
+            if ($type === Package::class) {
+                $packages[] = $id;
+            } elseif ($type === Repository::class) {
+                $repositories[] = $id;
+            }
+        }
+
+        $changes = [
+            'packages' => $this->syncPivotTable($packageTable, 'package_id', $ownerColumn, $billable->getKey(), $packages),
+            'repositories' => $this->syncPivotTable($repositoryTable, 'repository_id', $ownerColumn, $billable->getKey(), $repositories),
+        ];
+
+        // The pivot writes bypass the relations, so the audit trail that
+        // AuditedBelongsToMany gives manual grants is written by hand here —
+        // one line per projection that changed anything, attributing the
+        // change to the subscriptions rather than to a person.
+        $added = $changes['packages']['added'] + $changes['repositories']['added'];
+        $removed = $changes['packages']['removed'] + $changes['repositories']['removed'];
+
+        if ($added > 0 || $removed > 0) {
+            activity('audit')
+                ->performedOn($billable)
+                ->event('subscription_grants_projected')
+                ->withProperties([
+                    'billing_customer_id' => $customer->getKey(),
+                    'packages_granted' => $changes['packages']['added'],
+                    'packages_withdrawn' => $changes['packages']['removed'],
+                    'repositories_granted' => $changes['repositories']['added'],
+                    'repositories_withdrawn' => $changes['repositories']['removed'],
+                ])
+                ->log('subscription_grants_projected');
+        }
+    }
+
+    /**
+     * @param  list<int>  $desiredIds
+     * @return array{added: int, removed: int}
+     */
+    private function syncPivotTable(string $table, string $targetColumn, string $ownerColumn, int|string $ownerId, array $desiredIds): array
+    {
+        $desiredIds = array_values(array_unique($desiredIds));
+
+        $existing = DB::table($table)
+            ->where($ownerColumn, $ownerId)
+            ->where('source', GrantSource::Subscription->value)
+            ->pluck($targetColumn)
+            ->all();
+
+        $missing = array_diff($desiredIds, $existing);
+        $stale = array_diff($existing, $desiredIds);
+
+        if ($stale !== []) {
+            DB::table($table)
+                ->where($ownerColumn, $ownerId)
+                ->where('source', GrantSource::Subscription->value)
+                ->whereIn($targetColumn, $stale)
+                ->delete();
+        }
+
+        if ($missing !== []) {
+            DB::table($table)->insert(array_map(
+                fn (int $id): array => [
+                    $targetColumn => $id,
+                    $ownerColumn => $ownerId,
+                    'source' => GrantSource::Subscription->value,
+                ],
+                array_values($missing),
+            ));
+        }
+
+        return ['added' => count($missing), 'removed' => count($stale)];
+    }
+
+    private function key(string $type, int|string $id): string
+    {
+        return "{$type}:{$id}";
+    }
+}

--- a/app/Services/Billing/EntitlementProjector.php
+++ b/app/Services/Billing/EntitlementProjector.php
@@ -35,7 +35,7 @@ use Illuminate\Support\Facades\DB;
  * what, and up to which version. The pivots answer "who sees what" on the
  * hot path; the ledger answers the questions only billing asks.
  *
- * @see \App\Enums\GrantSource for the two-writers contract
+ * @see GrantSource for the two-writers contract
  * @see docs/plans/ecommerce-subscriptions.md
  */
 final class EntitlementProjector
@@ -137,7 +137,7 @@ final class EntitlementProjector
                     'starts_at' => $subscription->entitlements
                         ->first(fn (Entitlement $row): bool => $row->grantable_type === $planned->grantable_type
                             && $row->grantable_id === $planned->grantable_id)
-                        ?->starts_at ?? now(),
+                        ->starts_at ?? now(),
                     'ends_at' => null,
                 ],
             );

--- a/app/Services/Billing/SubscriptionProjector.php
+++ b/app/Services/Billing/SubscriptionProjector.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Merchants\Values\RemoteSubscription;
+use App\Models\Subscription;
+
+/**
+ * Applies a merchant's truth to the local subscription row, then re-projects
+ * the grants behind it.
+ *
+ * One entry point for both of the paths merchant truth arrives by — a
+ * verified webhook and the nightly reconciler — so there is exactly one
+ * translation of "what Stripe said" into "what the row says", and the two
+ * paths cannot drift.
+ *
+ * Out-of-order deliveries are the failure mode this class exists to survive:
+ * webhooks carry no ordering guarantee, and a delayed `updated` arriving
+ * after a `deleted` must not resurrect access. Every RemoteSubscription
+ * carries the moment it describes, the row keeps the newest moment already
+ * applied, and anything older is discarded unapplied.
+ */
+final class SubscriptionProjector
+{
+    public function __construct(
+        private readonly EntitlementProjector $entitlements = new EntitlementProjector,
+    ) {}
+
+    public function apply(Subscription $subscription, RemoteSubscription $remote): void
+    {
+        if ($subscription->last_event_at?->gt($remote->asOf)) {
+            return;
+        }
+
+        $subscription->forceFill([
+            'status' => $remote->status,
+            'quantity' => $remote->quantity,
+            'trial_ends_at' => $remote->trialEndsAt,
+            'current_period_start' => $remote->currentPeriodStart,
+            'current_period_end' => $remote->currentPeriodEnd,
+            'cancel_at' => $remote->cancelAt,
+            'canceled_at' => $remote->canceledAt,
+            'ends_at' => $remote->endedAt,
+            'coupon_code' => $remote->couponCode ?? $subscription->coupon_code,
+            'last_event_at' => $remote->asOf,
+        ]);
+
+        $this->stampGrace($subscription);
+
+        $subscription->save();
+
+        $this->entitlements->project($subscription);
+    }
+
+    /**
+     * Start the plan's own grace clock the moment the status stops granting,
+     * and stop it the moment granting resumes.
+     *
+     * The clock starts once per lapse — a second Unpaid event must not push
+     * the deadline out — and only when the plan configures a grace of its
+     * own on top of whatever dunning the merchant already ran.
+     */
+    private function stampGrace(Subscription $subscription): void
+    {
+        if ($subscription->status->grantsAccess()) {
+            $subscription->grace_ends_at = null;
+
+            return;
+        }
+
+        $graceDays = $subscription->plan->grace_days;
+
+        if ($graceDays === null || $graceDays === 0) {
+            return;
+        }
+
+        // Only a money lapse earns grace: an Incomplete checkout never had
+        // access to extend, and Suspended is the operator's hard stop.
+        if (! $subscription->status->isLapse()) {
+            return;
+        }
+
+        $subscription->grace_ends_at ??= now()->addDays($graceDays);
+    }
+}

--- a/app/Services/Billing/SubscriptionProjector.php
+++ b/app/Services/Billing/SubscriptionProjector.php
@@ -64,6 +64,7 @@ final class SubscriptionProjector
     {
         if ($subscription->status->grantsAccess()) {
             $subscription->grace_ends_at = null;
+            $subscription->grace_notified_at = null;
 
             return;
         }

--- a/app/Services/Billing/SubscriptionTokens.php
+++ b/app/Services/Billing/SubscriptionTokens.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Enums\TokenAbility;
+use App\Models\Subscription;
+use App\Models\Token;
+use App\Support\NewToken;
+
+/**
+ * The tokens a subscription owns: the activation token a purchase mints, and
+ * the seat count the plan's token_limit holds the line on.
+ *
+ * A subscription's tokens always belong to a person — the buyer, or a team's
+ * billing contact — and carry only repository:read: they exist so `composer
+ * install` works minutes after paying, not to administer the registry. More
+ * tokens up to the cap are issued from the customer area through the same
+ * path, so the cap has one enforcement point.
+ */
+final class SubscriptionTokens
+{
+    /**
+     * The token activation mints, shown once on the welcome page — or null
+     * when the plan does not auto-issue, the cap is already spent, or there
+     * is nobody to own it (a team customer with no billing contact).
+     */
+    public function issueActivationToken(Subscription $subscription): ?NewToken
+    {
+        if (! $subscription->plan->auto_issue_token) {
+            return null;
+        }
+
+        return $this->issueFor($subscription, "{$subscription->plan->name} subscription");
+    }
+
+    /**
+     * Issue one more token under this subscription, inside the cap.
+     */
+    public function issueFor(Subscription $subscription, string $name): ?NewToken
+    {
+        $owner = $subscription->customer?->contact();
+
+        if ($owner === null || ! $this->withinLimit($subscription)) {
+            return null;
+        }
+
+        return Token::issue(
+            $owner,
+            $name,
+            [TokenAbility::RepositoryRead],
+            expiresAt: null,
+            subscription: $subscription,
+        );
+    }
+
+    /**
+     * Whether the plan's token_limit leaves room for one more. Revoked
+     * tokens do not count — the soft delete keeps them out of the relation —
+     * so rolling a credential never eats a seat.
+     */
+    public function withinLimit(Subscription $subscription): bool
+    {
+        $limit = $subscription->plan->token_limit;
+
+        return $limit === null || $subscription->tokens()->count() < $limit;
+    }
+}

--- a/app/Services/Billing/VersionCeiling.php
+++ b/app/Services/Billing/VersionCeiling.php
@@ -2,9 +2,16 @@
 
 namespace App\Services\Billing;
 
+use App\Models\BillingCustomer;
+use App\Models\Entitlement;
 use App\Models\Package;
 use App\Models\PackageVersion;
+use App\Models\Repository;
+use App\Models\Team;
+use App\Models\Token;
+use App\Models\User;
 use App\Support\VersionNormalizer;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Computes and applies the version ceiling a frozen entitlement carries.
@@ -60,6 +67,112 @@ final class VersionCeiling
         $orders = $versions->map(fn (string $version): string => $this->normalizer->order($version));
 
         return $orders->max() ?? self::NOTHING;
+    }
+
+    /**
+     * The ceiling that applies to this credential for this package — null
+     * for the overwhelming majority of requests, which is also the answer
+     * that costs one indexed query.
+     *
+     * A ceiling applies only when a frozen entitlement is the *only* reason
+     * the caller can see the package. Every wider path wins over it: an
+     * anonymous reader of a public repository, a deploy token, an unscoped
+     * role, a manual grant (personal or a team's), or any live subscription
+     * granting the same package uncapped. Where several frozen entitlements
+     * apply, the most generous ceiling does.
+     *
+     * Asked on the metadata and dist paths, so the order of checks is the
+     * cost model: the entitlement lookup runs first because "no ceilinged
+     * entitlement" — everyone who never bought a perpetual licence — answers
+     * in that one query, and the manual-grant checks run only behind it.
+     */
+    public function ceilingFor(?Token $token, Package $package): ?string
+    {
+        $principal = $token?->tokenable;
+
+        if (! $principal instanceof User) {
+            // Anonymous readers reach only public repositories, and deploy
+            // tokens are machine credentials no subscription ever issued.
+            return null;
+        }
+
+        if ($principal->hasUnscopedAccess()) {
+            return null;
+        }
+
+        if ($package->composerRepository->public) {
+            return null;
+        }
+
+        $ceilings = Entitlement::query()
+            ->where('active', true)
+            ->whereIn('billing_customer_id', $this->customerIdsFor($principal))
+            ->where(function ($query) use ($package): void {
+                $query
+                    ->where(fn ($q) => $q
+                        ->where('grantable_type', Package::class)
+                        ->where('grantable_id', $package->getKey()))
+                    ->orWhere(fn ($q) => $q
+                        ->where('grantable_type', Repository::class)
+                        ->where('grantable_id', $package->repository_id));
+            })
+            ->pluck('version_ceiling');
+
+        // No entitlement reaches this package, or a live one grants it
+        // uncapped — either way the subscription layer imposes nothing.
+        if ($ceilings->isEmpty() || $ceilings->containsStrict(null)) {
+            return null;
+        }
+
+        if ($this->hasManualGrant($principal, $package)) {
+            return null;
+        }
+
+        return $ceilings->max();
+    }
+
+    /**
+     * The billing customers whose entitlements reach this user: their own,
+     * and every team's they belong to. A subquery rather than a fetched
+     * list, so the whole resolution stays one round trip.
+     */
+    private function customerIdsFor(User $user)
+    {
+        return BillingCustomer::query()
+            ->select('id')
+            ->where(function ($query) use ($user): void {
+                $query
+                    ->where(fn ($q) => $q
+                        ->where('billable_type', User::class)
+                        ->where('billable_id', $user->getKey()))
+                    ->orWhere(fn ($q) => $q
+                        ->where('billable_type', Team::class)
+                        ->whereIn('billable_id', DB::table('team_user')
+                            ->select('team_id')
+                            ->where('user_id', $user->getKey())));
+            });
+    }
+
+    /**
+     * Whether a hand-made grant reaches this package — the same four paths
+     * User::isGrantedPackage() and isGrantedRepository() walk, narrowed to
+     * rows the panel wrote, because a subscription row here would make the
+     * frozen entitlement neutralise its own ceiling.
+     */
+    private function hasManualGrant(User $user, Package $package): bool
+    {
+        return $user->packages()->whereKey($package->getKey())->wherePivot('source', 'manual')->exists()
+            || $user->repositories()->whereKey($package->repository_id)->wherePivot('source', 'manual')->exists()
+            || $user->teams()
+                ->whereHas('packages', fn ($query) => $query
+                    ->whereKey($package->getKey())
+                    ->where('package_team.source', 'manual'))
+                ->exists()
+            || $user->teams()
+                ->whereHas('repositories', fn ($query) => $query
+                    ->whereKey($package->repository_id)
+                    ->where('repository_team.source', 'manual'))
+                ->exists();
     }
 
     /**

--- a/app/Services/Billing/VersionCeiling.php
+++ b/app/Services/Billing/VersionCeiling.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services\Billing;
+
+use App\Models\Package;
+use App\Models\PackageVersion;
+use App\Support\VersionNormalizer;
+
+/**
+ * Computes and applies the version ceiling a frozen entitlement carries.
+ *
+ * A ceiling is stored as VersionNormalizer::order()'s sortable spelling of
+ * the highest release that existed when the entitlement froze — not the
+ * human version string — because that is the one representation the metadata
+ * path can filter by in SQL (`order` <= ceiling) without parsing semver per
+ * row per request. package_versions.order is the same spelling, which is the
+ * whole point.
+ *
+ * Dev versions are never inside a ceiling. A branch has no position on a
+ * release line — dev-main today contains code newer than any pinned release,
+ * so admitting it would hand a lapsed licence the ongoing work the ceiling
+ * exists to close off.
+ */
+final class VersionCeiling
+{
+    /**
+     * A ceiling below every real version, for a package that had no releases
+     * at freeze time. Null means "no ceiling", so nothing-yet needs its own
+     * spelling: '!' sorts beneath the zero-padded digits every real order
+     * string starts with.
+     */
+    public const string NOTHING = '!';
+
+    public function __construct(private readonly VersionNormalizer $normalizer = new VersionNormalizer) {}
+
+    /**
+     * The ceiling that pins a package right now: the sortable spelling of
+     * its highest released version.
+     */
+    public function currentCeiling(Package $package): string
+    {
+        $ceiling = PackageVersion::query()
+            ->where('package_id', $package->getKey())
+            ->where('is_dev', false)
+            ->whereNotNull('order')
+            ->max('order');
+
+        if (is_string($ceiling)) {
+            return $ceiling;
+        }
+
+        // Rows synced before the order column existed have none until the
+        // next sync backfills it; compute what it will say rather than
+        // handing out no ceiling at all, which is the one wrong direction.
+        $versions = PackageVersion::query()
+            ->where('package_id', $package->getKey())
+            ->where('is_dev', false)
+            ->pluck('version');
+
+        $orders = $versions->map(fn (string $version): string => $this->normalizer->order($version));
+
+        return $orders->max() ?? self::NOTHING;
+    }
+
+    /**
+     * Whether a version is inside a ceiling. Null ceiling means unlimited —
+     * the shape every live subscription and every manual grant has.
+     */
+    public function permits(PackageVersion $version, ?string $ceiling): bool
+    {
+        if ($ceiling === null) {
+            return true;
+        }
+
+        if ($version->is_dev) {
+            return false;
+        }
+
+        $order = $version->order ?? $this->normalizer->order($version->version);
+
+        return $order <= $ceiling;
+    }
+}

--- a/app/Services/Billing/VersionCeiling.php
+++ b/app/Services/Billing/VersionCeiling.php
@@ -11,6 +11,7 @@ use App\Models\Team;
 use App\Models\Token;
 use App\Models\User;
 use App\Support\VersionNormalizer;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -135,8 +136,10 @@ final class VersionCeiling
      * The billing customers whose entitlements reach this user: their own,
      * and every team's they belong to. A subquery rather than a fetched
      * list, so the whole resolution stays one round trip.
+     *
+     * @return Builder<BillingCustomer>
      */
-    private function customerIdsFor(User $user)
+    private function customerIdsFor(User $user): Builder
     {
         return BillingCustomer::query()
             ->select('id')

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "laravel/tinker": "^3.0",
         "league/flysystem-aws-s3-v3": "^3.35",
         "resend/resend-php": "^1.0",
-        "spatie/laravel-activitylog": "^4.12"
+        "spatie/laravel-activitylog": "^4.12",
+        "stripe/stripe-php": "^21.2"
     },
     "require-dev": {
         "brianium/paratest": "^7.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b7764f954cb6dc88c9b7bae83ac2dce",
+    "content-hash": "c2b35516fee246986000aa749d765980",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -6820,6 +6820,69 @@
                 }
             ],
             "time": "2026-04-27T14:27:52+00:00"
+        },
+        {
+            "name": "stripe/stripe-php",
+            "version": "v21.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stripe/stripe-php.git",
+                "reference": "edf8118f0b96d69f06f372da9168d613d1aed072"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/edf8118f0b96d69f06f372da9168d613d1aed072",
+                "reference": "edf8118f0b96d69f06f372da9168d613d1aed072",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.94.0",
+                "phpstan/phpstan": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/version_check.php",
+                    "lib/agent_plugin_hint.php"
+                ],
+                "psr-4": {
+                    "Stripe\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stripe and contributors",
+                    "homepage": "https://github.com/stripe/stripe-php/contributors"
+                }
+            ],
+            "description": "Stripe PHP Library",
+            "homepage": "https://stripe.com/",
+            "keywords": [
+                "api",
+                "payment processing",
+                "stripe"
+            ],
+            "support": {
+                "issues": "https://github.com/stripe/stripe-php/issues",
+                "source": "https://github.com/stripe/stripe-php/tree/v21.2.0"
+            },
+            "time": "2026-08-10T22:11:35+00:00"
         },
         {
             "name": "symfony/clock",

--- a/config/registry.php
+++ b/config/registry.php
@@ -343,4 +343,37 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Billing
+    |--------------------------------------------------------------------------
+    |
+    | The commercial layer: plans that grant packages, subscriptions that
+    | project into the grant system, and a merchant (Stripe, or Manual for
+    | admin-created subscriptions) behind the money. Off by default — a
+    | registry that has not turned this on serves exactly what it always
+    | served, and none of the billing routes answer.
+    |
+    | `merchant` names the driver checkout sells through; Manual subscriptions
+    | are always available to administrators regardless. `public_signup` opens
+    | /register to strangers so they can buy without an administrator creating
+    | their account first — it is separate from `enabled` because plenty of
+    | registries will sell to accounts that already exist (SSO users,
+    | admin-created customers) without wanting an open registration form.
+    |
+    | `reconcile_lookback_hours` is how far past its last movement a
+    | subscription can be and still get re-pulled by billing:reconcile — the
+    | safety net for webhooks lost during a deploy.
+    |
+    */
+
+    'billing' => [
+        'enabled' => (bool) env('BILLING_ENABLED', false),
+        'merchant' => env('BILLING_MERCHANT', 'stripe'),
+        'public_signup' => (bool) env('BILLING_PUBLIC_SIGNUP', false),
+        'currency' => strtolower((string) env('BILLING_CURRENCY', 'usd')),
+        'terms_url' => env('BILLING_TERMS_URL'),
+        'reconcile_lookback_hours' => (int) env('BILLING_RECONCILE_LOOKBACK_HOURS', 48),
+    ],
+
 ];

--- a/config/registry.php
+++ b/config/registry.php
@@ -361,10 +361,6 @@ return [
     | registries will sell to accounts that already exist (SSO users,
     | admin-created customers) without wanting an open registration form.
     |
-    | `reconcile_lookback_hours` is how far past its last movement a
-    | subscription can be and still get re-pulled by billing:reconcile — the
-    | safety net for webhooks lost during a deploy.
-    |
     */
 
     'billing' => [
@@ -373,7 +369,6 @@ return [
         'public_signup' => (bool) env('BILLING_PUBLIC_SIGNUP', false),
         'currency' => strtolower((string) env('BILLING_CURRENCY', 'usd')),
         'terms_url' => env('BILLING_TERMS_URL'),
-        'reconcile_lookback_hours' => (int) env('BILLING_RECONCILE_LOOKBACK_HOURS', 48),
     ],
 
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -60,4 +60,19 @@ return [
         ],
     ],
 
+    'stripe' => [
+        'secret' => env('STRIPE_SECRET'),
+        'publishable' => env('STRIPE_PUBLISHABLE'),
+
+        // The signing secret of the app's webhook endpoint at Stripe. Setting
+        // it is what turns the /billing/stripe/webhook route on; without it
+        // every delivery is refused unverified.
+        'webhook_secret' => env('STRIPE_WEBHOOK_SECRET'),
+
+        // Whether checkout asks Stripe Tax to compute and collect tax.
+        // Requires Stripe Tax to be enabled on the Stripe account first, or
+        // every checkout session will fail to create.
+        'tax_enabled' => (bool) env('STRIPE_TAX_ENABLED', false),
+    ],
+
 ];

--- a/database/factories/BillingCustomerFactory.php
+++ b/database/factories/BillingCustomerFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\MerchantProvider;
+use App\Models\BillingCustomer;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BillingCustomer>
+ */
+class BillingCustomerFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'billable_type' => User::class,
+            'billable_id' => User::factory(),
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'merchant' => MerchantProvider::Manual,
+        ];
+    }
+
+    public function stripe(): static
+    {
+        return $this->state(fn (): array => [
+            'merchant' => MerchantProvider::Stripe,
+            'merchant_customer_id' => 'cus_'.fake()->unique()->lexify('??????????'),
+        ]);
+    }
+
+    public function forTeam(): static
+    {
+        return $this->state(fn (): array => [
+            'billable_type' => Team::class,
+            'billable_id' => Team::factory(),
+            'billing_contact_user_id' => User::factory(),
+        ]);
+    }
+}

--- a/database/factories/EntitlementFactory.php
+++ b/database/factories/EntitlementFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BillingCustomer;
+use App\Models\Entitlement;
+use App\Models\Package;
+use App\Models\Subscription;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Entitlement>
+ */
+class EntitlementFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'subscription_id' => Subscription::factory(),
+            'billing_customer_id' => BillingCustomer::factory(),
+            'grantable_type' => Package::class,
+            'grantable_id' => Package::factory(),
+            'active' => true,
+            'starts_at' => now()->subDay(),
+        ];
+    }
+}

--- a/database/factories/InvoiceFactory.php
+++ b/database/factories/InvoiceFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\MerchantProvider;
+use App\Models\BillingCustomer;
+use App\Models\Invoice;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Invoice>
+ */
+class InvoiceFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $subtotal = fake()->numberBetween(5, 200) * 100;
+
+        return [
+            'billing_customer_id' => BillingCustomer::factory(),
+            'merchant' => MerchantProvider::Stripe,
+            'number' => strtoupper(fake()->unique()->bothify('INV-####-????')),
+            'currency' => 'usd',
+            'subtotal' => $subtotal,
+            'tax' => 0,
+            'total' => $subtotal,
+            'amount_refunded' => 0,
+            'status' => 'paid',
+            'issued_at' => now(),
+            'paid_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PlanEntitlementFactory.php
+++ b/database/factories/PlanEntitlementFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Package;
+use App\Models\Plan;
+use App\Models\PlanEntitlement;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PlanEntitlement>
+ */
+class PlanEntitlementFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'plan_id' => Plan::factory(),
+            'grantable_type' => Package::class,
+            'grantable_id' => Package::factory(),
+        ];
+    }
+}

--- a/database/factories/PlanFactory.php
+++ b/database/factories/PlanFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\BillingModel;
+use App\Enums\CancellationTiming;
+use App\Enums\LapseBehaviour;
+use App\Models\Plan;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Plan>
+ */
+class PlanFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->words(2, true);
+
+        return [
+            'name' => Str::title($name),
+            'slug' => Str::slug($name),
+            'description' => fake()->sentence(),
+            'active' => true,
+            'listed' => false,
+            'billing_model' => BillingModel::Recurring,
+            'trial_days' => 0,
+            'lapse_behaviour' => LapseBehaviour::WithdrawEntitlement,
+            'cancellation' => CancellationTiming::Immediate,
+            'auto_issue_token' => true,
+        ];
+    }
+
+    public function listed(): static
+    {
+        return $this->state(fn (): array => ['listed' => true]);
+    }
+
+    public function perpetual(int $updatesWindowMonths = 12): static
+    {
+        return $this->state(fn (): array => [
+            'billing_model' => BillingModel::OneTimeWithUpdates,
+            'updates_window_months' => $updatesWindowMonths,
+            'lapse_behaviour' => LapseBehaviour::FreezeAtVersion,
+        ]);
+    }
+}

--- a/database/factories/PlanPriceFactory.php
+++ b/database/factories/PlanPriceFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\BillingInterval;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PlanPrice>
+ */
+class PlanPriceFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'plan_id' => Plan::factory(),
+            'currency' => 'usd',
+            'amount' => fake()->numberBetween(5, 200) * 100,
+            'interval' => BillingInterval::Month,
+            'interval_count' => 1,
+            'active' => true,
+            'default' => true,
+        ];
+    }
+
+    public function yearly(): static
+    {
+        return $this->state(fn (): array => ['interval' => BillingInterval::Year]);
+    }
+
+    public function oneTime(): static
+    {
+        return $this->state(fn (): array => ['interval' => BillingInterval::OneTime]);
+    }
+}

--- a/database/factories/SubscriptionFactory.php
+++ b/database/factories/SubscriptionFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\MerchantProvider;
+use App\Enums\SubscriptionStatus;
+use App\Models\BillingCustomer;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Subscription>
+ */
+class SubscriptionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $plan = Plan::factory();
+
+        return [
+            'billing_customer_id' => BillingCustomer::factory(),
+            'plan_id' => $plan,
+            'plan_price_id' => PlanPrice::factory()->for($plan),
+            'merchant' => MerchantProvider::Manual,
+            'status' => SubscriptionStatus::Active,
+            'quantity' => 1,
+            'current_period_start' => now()->subDay(),
+            'current_period_end' => now()->addMonth(),
+        ];
+    }
+
+    public function status(SubscriptionStatus $status): static
+    {
+        return $this->state(fn (): array => ['status' => $status]);
+    }
+
+    public function suspended(string $reason = 'Suspended in a test'): static
+    {
+        return $this->state(fn (): array => [
+            'suspended_at' => now(),
+            'suspension_reason' => $reason,
+        ]);
+    }
+}

--- a/database/migrations/2026_08_19_000000_create_billing_customers_table.php
+++ b/database/migrations/2026_08_19_000000_create_billing_customers_table.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The party that pays: who the card belongs to, who the invoice names, and
+ * which merchant knows them.
+ *
+ * Polymorphic over User and Team because both really do buy access — a solo
+ * developer subscribes for themselves, a company pays once for a team whose
+ * members come and go. The entitlement projector resolves the difference; the
+ * billing tables never care which kind of billable they carry.
+ *
+ * Deliberately not columns on users/teams: a customer is a different thing
+ * from an account. Most users will never have one, a team's members must not
+ * inherit the card, and the business fields (company name, tax id, address)
+ * are invoice material with no meaning anywhere else in the app.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('billing_customers', function (Blueprint $table) {
+            $table->id();
+
+            // The account behind the money: a User or a Team.
+            $table->morphs('billable');
+
+            // Invoice identity, captured at checkout. Kept apart from the
+            // user's own name/email because the person who pays is routinely
+            // not the person who logs in — accounts-payable addresses, a
+            // company name where the panel shows a person's.
+            $table->string('name');
+            $table->string('email');
+            $table->string('company_name')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->json('address')->nullable();
+
+            // Which driver owns the remote half, and the remote customer's
+            // id there. Nullable because a Manual customer has no remote
+            // half; unique as a pair because one Stripe customer must map to
+            // exactly one row here or webhooks fan out to the wrong account.
+            $table->string('merchant', 32);
+            $table->string('merchant_customer_id')->nullable();
+
+            // A team's subscription still needs one human to email: dunning
+            // notices, trial reminders, the auto-issued token. Teams have no
+            // owner by design, so the nomination lives here, on the billing
+            // relationship that needs it. Null on a User customer, who is
+            // their own contact. nullOnDelete: losing the contact must not
+            // take the paid subscription down with it.
+            $table->foreignId('billing_contact_user_id')->nullable()->constrained('users')->nullOnDelete();
+
+            // Customers are never hard-deleted: invoices reference them and
+            // accounting history has to survive an account cleanup.
+            $table->softDeletes();
+            $table->timestamps();
+
+            $table->unique(['merchant', 'merchant_customer_id']);
+            $table->unique(['billable_type', 'billable_id', 'merchant']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('billing_customers');
+    }
+};

--- a/database/migrations/2026_08_19_000010_create_plans_tables.php
+++ b/database/migrations/2026_08_19_000010_create_plans_tables.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The catalog: what is for sale, at what prices, granting what.
+ *
+ * A plan is the configuration object the whole billing layer hangs off. It
+ * names its entitlements, carries every lifecycle decision as data — what
+ * lapsing does, how cancellation times out, how many tokens it permits — and
+ * is the local source of truth that CatalogSync mirrors out to merchants.
+ * Swapping merchants re-syncs this catalog; it never re-authors it.
+ *
+ * Prices are rows rather than columns so one plan can sell monthly and
+ * yearly, in more than one currency, and retire a price without breaking the
+ * subscriptions already on it. Amounts are integer minor units, never floats:
+ * money in floats is how $19.99 becomes $19.989999.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('plans', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('name');
+
+            // The public page's URL segment, and the stable handle CatalogSync
+            // names the plan by at the merchant.
+            $table->string('slug')->unique();
+
+            $table->text('description')->nullable();
+
+            // `active` gates selling; `listed` gates the public pricing page.
+            // Separate because an unlisted plan is still sellable by direct
+            // link — launch offers, grandfathered tiers, one customer's
+            // negotiated price.
+            $table->boolean('active')->default(true);
+            $table->boolean('listed')->default(false);
+
+            // BillingModel: recurring, or one-time with an updates window.
+            $table->string('billing_model', 32);
+
+            // Days of trial before the first charge. 0 means none.
+            $table->unsignedInteger('trial_days')->default(0);
+
+            // How many access tokens a subscription may hold, null meaning
+            // no cap. The auto-issued activation token counts toward it.
+            $table->unsignedInteger('token_limit')->nullable();
+
+            // Months of updates a one-time purchase includes. Null on
+            // recurring plans, whose window is the billing period itself.
+            $table->unsignedInteger('updates_window_months')->nullable();
+
+            // LapseBehaviour: what stopping payment does to granted access.
+            $table->string('lapse_behaviour', 32);
+
+            // Days of continued access after the merchant reports the
+            // subscription lapsed, before the lapse behaviour runs. Null
+            // means follow the merchant alone: its dunning window (Stripe
+            // retries for ~3 weeks) is already a grace period.
+            $table->unsignedInteger('grace_days')->nullable();
+
+            // CancellationTiming: whether the customer's own cancellation
+            // cuts access immediately or lets the paid period run out.
+            $table->string('cancellation', 32);
+
+            // Whether activation mints a starter token and shows it once, so
+            // the buyer leaves checkout with a working credential.
+            $table->boolean('auto_issue_token')->default(true);
+
+            // Position on the pricing page.
+            $table->unsignedInteger('sort')->default(0);
+
+            // Soft deletes: a retired plan is still what existing
+            // subscriptions point at and what old invoices describe.
+            $table->softDeletes();
+            $table->timestamps();
+        });
+
+        Schema::create('plan_prices', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('plan_id')->constrained()->cascadeOnDelete();
+
+            // ISO 4217, lowercase, e.g. "usd" — the form merchants speak.
+            $table->string('currency', 3);
+
+            // Integer minor units: 1999 is $19.99. Big enough for enterprise
+            // prices in minor units of weak currencies.
+            $table->unsignedBigInteger('amount');
+
+            // BillingInterval (month / year / one_time) and its multiplier —
+            // every 1 month, every 3 months.
+            $table->string('interval', 16);
+            $table->unsignedInteger('interval_count')->default(1);
+
+            // Retired prices stay for the subscriptions on them; `default`
+            // is the one the buy button preselects.
+            $table->boolean('active')->default(true);
+            $table->boolean('default')->default(false);
+
+            $table->timestamps();
+        });
+
+        // What a plan grants, in exactly the vocabulary grants already use: a
+        // repository wholesale, or a package by name. Polymorphic where the
+        // user pivots are two tables, because this one is read only by the
+        // projector — never on the Composer hot path — and a plan's grant
+        // list is one list in the panel.
+        Schema::create('plan_entitlements', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('plan_id')->constrained()->cascadeOnDelete();
+            $table->morphs('grantable');
+
+            $table->unique(['plan_id', 'grantable_type', 'grantable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('plan_entitlements');
+        Schema::dropIfExists('plan_prices');
+        Schema::dropIfExists('plans');
+    }
+};

--- a/database/migrations/2026_08_19_000020_create_subscriptions_tables.php
+++ b/database/migrations/2026_08_19_000020_create_subscriptions_tables.php
@@ -57,6 +57,11 @@ return new class extends Migration
             // the plan follows the merchant's dunning alone.
             $table->timestamp('grace_ends_at')->nullable();
 
+            // When the reconciler's grace-end sweep sent the lapse notice,
+            // so a later run does not mail the customer again. Cleared with
+            // the grace clock when granting resumes.
+            $table->timestamp('grace_notified_at')->nullable();
+
             // Cancellation is two moments: when it was requested, and when it
             // takes effect. `ends_at` is the general "stopped granting" stamp
             // whatever the cause.

--- a/database/migrations/2026_08_19_000020_create_subscriptions_tables.php
+++ b/database/migrations/2026_08_19_000020_create_subscriptions_tables.php
@@ -1,0 +1,127 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Subscriptions, and the ledger of what each one granted.
+ *
+ * The subscription row is a projection: the merchant owns the billing clock
+ * and this table mirrors it, updated by verified webhooks and repaired by the
+ * nightly reconciler. Nothing here decides when a renewal happens; it records
+ * what the merchant said and when it said it, which is why `last_event_at`
+ * exists — an out-of-order webhook must not roll a newer truth back.
+ *
+ * The entitlements table is the projector's own ledger. The grant pivots
+ * answer "who can see what" on the hot path; this answers "which subscription
+ * granted it, and up to which version" — the question the metadata and dist
+ * paths ask only for a package reached through a subscription, and the record
+ * that survives to say what a lapsed perpetual licence still owns.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('billing_customer_id')->constrained()->cascadeOnDelete();
+
+            // What was bought and at which price. Restrict rather than
+            // cascade: deleting a plan out from under live subscriptions is
+            // an operator error the database should refuse.
+            $table->foreignId('plan_id')->constrained()->restrictOnDelete();
+            $table->foreignId('plan_price_id')->constrained()->restrictOnDelete();
+
+            $table->string('merchant', 32);
+
+            // SubscriptionStatus — the canonical vocabulary every driver
+            // normalises into.
+            $table->string('status', 32);
+
+            $table->unsignedInteger('quantity')->default(1);
+
+            // The merchant's clock, mirrored. All nullable: a Manual
+            // subscription fills only what its administrator typed, and a
+            // one-time purchase has an updates window rather than periods.
+            $table->timestamp('trial_ends_at')->nullable();
+            $table->timestamp('current_period_start')->nullable();
+            $table->timestamp('current_period_end')->nullable();
+
+            // When the plan's own grace window closes, stamped by the
+            // projector when the merchant first reports the lapse. Null when
+            // the plan follows the merchant's dunning alone.
+            $table->timestamp('grace_ends_at')->nullable();
+
+            // Cancellation is two moments: when it was requested, and when it
+            // takes effect. `ends_at` is the general "stopped granting" stamp
+            // whatever the cause.
+            $table->timestamp('cancel_at')->nullable();
+            $table->timestamp('canceled_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+
+            // The administrative hard stop. Set and cleared only in the
+            // panel; no merchant event touches it.
+            $table->timestamp('suspended_at')->nullable();
+            $table->string('suspension_reason')->nullable();
+
+            // The code the customer entered, kept for reporting. The merchant
+            // applied the actual discount.
+            $table->string('coupon_code')->nullable();
+
+            // The newest merchant truth already applied, so a delayed webhook
+            // arriving after a fresher one (or after a reconcile) is ignored
+            // rather than applied backwards.
+            $table->timestamp('last_event_at')->nullable();
+
+            $table->softDeletes();
+            $table->timestamps();
+
+            // The reconciler's sweep: every subscription in a status the
+            // merchant might still move, oldest period first.
+            $table->index(['status', 'current_period_end']);
+        });
+
+        Schema::create('entitlements', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('subscription_id')->constrained()->cascadeOnDelete();
+
+            // Denormalised from the subscription so "everything this customer
+            // is entitled to" is one indexed read at request time.
+            $table->foreignId('billing_customer_id')->constrained()->cascadeOnDelete();
+
+            // What was granted: a Repository or a Package, same vocabulary as
+            // plan_entitlements — this is that row, instantiated for one
+            // subscription.
+            $table->morphs('grantable');
+
+            // The highest version this entitlement reaches, normalised, or
+            // null for no ceiling. Pinned by the projector when a
+            // freeze-at-version plan lapses or an updates window closes;
+            // cleared on renewal.
+            $table->string('version_ceiling')->nullable();
+
+            $table->boolean('active')->default(true);
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['subscription_id', 'grantable_type', 'grantable_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('entitlements');
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/database/migrations/2026_08_19_000030_create_invoices_table.php
+++ b/database/migrations/2026_08_19_000030_create_invoices_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * A local mirror of every invoice the merchant issues.
+ *
+ * The merchant renders and hosts the documents; these rows exist so the
+ * customer area and the panel can show billing history without a live API
+ * call, and so the history survives a merchant migration. Written by webhook
+ * (invoice paid, refunded) and backfilled by the reconciler.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('invoices', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('billing_customer_id')->constrained()->cascadeOnDelete();
+
+            // Nullable: a one-off charge can invoice a customer with no
+            // subscription attached.
+            $table->foreignId('subscription_id')->nullable()->constrained()->nullOnDelete();
+
+            $table->string('merchant', 32);
+
+            // The merchant's own invoice number — what the customer quotes
+            // and what accounting reconciles against.
+            $table->string('number')->nullable();
+
+            // Integer minor units throughout, matching plan_prices. Tax is
+            // whatever the merchant computed and collected.
+            $table->string('currency', 3);
+            $table->unsignedBigInteger('subtotal');
+            $table->unsignedBigInteger('tax')->default(0);
+            $table->unsignedBigInteger('total');
+            $table->unsignedBigInteger('amount_refunded')->default(0);
+
+            $table->string('status', 32);
+
+            // Merchant-hosted pages; this app never renders an invoice.
+            $table->string('hosted_url', 2048)->nullable();
+            $table->string('pdf_url', 2048)->nullable();
+
+            $table->timestamp('issued_at')->nullable();
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamp('refunded_at')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['billing_customer_id', 'issued_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('invoices');
+    }
+};

--- a/database/migrations/2026_08_19_000040_create_merchant_reference_tables.php
+++ b/database/migrations/2026_08_19_000040_create_merchant_reference_tables.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The two tables that keep the merchant integration honest.
+ *
+ * merchant_references maps local rows to their remote counterparts. The local
+ * catalog is the source of truth; when CatalogSync pushes a plan to Stripe it
+ * records the Product id here, and when a webhook names a Stripe object this
+ * is how it finds the local row. One local row can be known to several
+ * merchants at once, which is the whole portability story: a second merchant
+ * is a second row in this table, not a second schema.
+ *
+ * merchant_events is the inbox. Every verified webhook is written here before
+ * anything acts on it, and the unique external id is what makes replays
+ * harmless — a merchant retrying a delivery, or an operator replaying a
+ * failed one, inserts nothing twice. Processing happens on the queue against
+ * this row, so a deploy mid-webhook loses nothing.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('merchant_references', function (Blueprint $table) {
+            $table->id();
+
+            // The local row: a Plan, PlanPrice, BillingCustomer,
+            // Subscription or Invoice.
+            $table->morphs('referenceable');
+
+            $table->string('merchant', 32);
+            $table->string('external_id');
+            $table->timestamp('synced_at')->nullable();
+
+            $table->timestamps();
+
+            // One remote object per local row per merchant, and one local
+            // row per remote object — lookups run in both directions.
+            $table->unique(['referenceable_type', 'referenceable_id', 'merchant'], 'merchant_references_local_unique');
+            $table->unique(['merchant', 'external_id']);
+        });
+
+        Schema::create('merchant_events', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('merchant', 32);
+
+            // The merchant's own event id — the idempotency key. Unique is
+            // the dedupe: a redelivered event fails the insert and is
+            // acknowledged without being processed twice.
+            $table->string('external_id');
+
+            // The merchant's event name, verbatim (e.g. Stripe's
+            // "customer.subscription.updated"), for filtering and forensics.
+            $table->string('type');
+
+            $table->json('payload');
+
+            $table->timestamp('received_at');
+            $table->timestamp('processed_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->text('error')->nullable();
+
+            // No updated_at bookkeeping worth keeping; created_at comes from
+            // timestamps() and received_at is the meaningful moment.
+            $table->timestamps();
+
+            $table->unique(['merchant', 'external_id']);
+            $table->index(['merchant', 'processed_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('merchant_events');
+        Schema::dropIfExists('merchant_references');
+    }
+};

--- a/database/migrations/2026_08_19_000050_add_subscription_id_to_access_tokens_table.php
+++ b/database/migrations/2026_08_19_000050_add_subscription_id_to_access_tokens_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Which subscription a token was issued under, when one was.
+ *
+ * Two behaviours need the answer. A plan with a token_limit counts the live
+ * tokens carrying its subscription's id, and LapseBehaviour::RevokeTokens
+ * revokes exactly those — never a personal token the same user issued for
+ * something else, which is the difference between "your subscription ended"
+ * and "your account broke".
+ *
+ * nullOnDelete rather than cascade: tokens are soft-deleted audit history,
+ * and a hard-deleted subscription must not silently hard-delete credentials'
+ * records with it.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('access_tokens', function (Blueprint $table) {
+            $table->foreignId('subscription_id')
+                ->nullable()
+                ->constrained()
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('access_tokens', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('subscription_id');
+        });
+    }
+};

--- a/database/migrations/2026_08_19_000060_add_source_to_grant_pivots.php
+++ b/database/migrations/2026_08_19_000060_add_source_to_grant_pivots.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Gives every grant an author: a person, or the entitlement projector.
+ *
+ * Subscriptions grant access by writing rows into these same four pivots —
+ * that is the design decision that keeps billing off the Composer hot path,
+ * because Package::scopeVisibleTo() and User::packageGrants() keep reading
+ * exactly the tables they already read. But two writers on one table need a
+ * boundary, and this column is it: the projector owns every 'subscription'
+ * row and never touches a 'manual' one, and the panel's grant editors work
+ * the other way around. Cancelling a subscription cannot revoke a grant an
+ * administrator made by name; an administrator tidying a grant list cannot
+ * silently un-sell something that was paid for.
+ *
+ * The unique index widens to include the source, because the same grant can
+ * now legitimately exist twice — given by hand and sold — and each copy must
+ * be withdrawable on its own. The visibility union was documented as
+ * duplicate-tolerant from the day teams landed, so a doubled id changes no
+ * answer anywhere.
+ *
+ * The reader-direction indexes from 2026_08_10_220000 are untouched: they
+ * serve membership tests, which do not care who wrote the row.
+ *
+ * @see \App\Enums\GrantSource
+ * @see \App\Services\Billing\EntitlementProjector
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('package_user', function (Blueprint $table) {
+            $table->string('source', 32)->default('manual');
+            $table->dropUnique(['package_id', 'user_id']);
+            $table->unique(['package_id', 'user_id', 'source']);
+        });
+
+        Schema::table('repository_user', function (Blueprint $table) {
+            $table->string('source', 32)->default('manual');
+            $table->dropUnique(['repository_id', 'user_id']);
+            $table->unique(['repository_id', 'user_id', 'source']);
+        });
+
+        Schema::table('package_team', function (Blueprint $table) {
+            $table->string('source', 32)->default('manual');
+            $table->dropUnique(['package_id', 'team_id']);
+            $table->unique(['package_id', 'team_id', 'source']);
+        });
+
+        Schema::table('repository_team', function (Blueprint $table) {
+            $table->string('source', 32)->default('manual');
+            $table->dropUnique(['repository_id', 'team_id']);
+            $table->unique(['repository_id', 'team_id', 'source']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Narrowing the unique back would fail on a table where a grant
+        // exists under both sources; drop the projector's rows first, which
+        // is also the honest meaning of rolling this feature back.
+        foreach (['package_user', 'repository_user', 'package_team', 'repository_team'] as $pivot) {
+            \Illuminate\Support\Facades\DB::table($pivot)->where('source', 'subscription')->delete();
+        }
+
+        Schema::table('package_user', function (Blueprint $table) {
+            $table->dropUnique(['package_id', 'user_id', 'source']);
+            $table->unique(['package_id', 'user_id']);
+            $table->dropColumn('source');
+        });
+
+        Schema::table('repository_user', function (Blueprint $table) {
+            $table->dropUnique(['repository_id', 'user_id', 'source']);
+            $table->unique(['repository_id', 'user_id']);
+            $table->dropColumn('source');
+        });
+
+        Schema::table('package_team', function (Blueprint $table) {
+            $table->dropUnique(['package_id', 'team_id', 'source']);
+            $table->unique(['package_id', 'team_id']);
+            $table->dropColumn('source');
+        });
+
+        Schema::table('repository_team', function (Blueprint $table) {
+            $table->dropUnique(['repository_id', 'team_id', 'source']);
+            $table->unique(['repository_id', 'team_id']);
+            $table->dropColumn('source');
+        });
+    }
+};

--- a/database/migrations/2026_08_19_000060_add_source_to_grant_pivots.php
+++ b/database/migrations/2026_08_19_000060_add_source_to_grant_pivots.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Enums\GrantSource;
+use App\Services\Billing\EntitlementProjector;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /**
@@ -26,8 +29,8 @@ use Illuminate\Support\Facades\Schema;
  * The reader-direction indexes from 2026_08_10_220000 are untouched: they
  * serve membership tests, which do not care who wrote the row.
  *
- * @see \App\Enums\GrantSource
- * @see \App\Services\Billing\EntitlementProjector
+ * @see GrantSource
+ * @see EntitlementProjector
  */
 return new class extends Migration
 {
@@ -70,7 +73,7 @@ return new class extends Migration
         // exists under both sources; drop the projector's rows first, which
         // is also the honest meaning of rolling this feature back.
         foreach (['package_user', 'repository_user', 'package_team', 'repository_team'] as $pivot) {
-            \Illuminate\Support\Facades\DB::table($pivot)->where('source', 'subscription')->delete();
+            DB::table($pivot)->where('source', 'subscription')->delete();
         }
 
         Schema::table('package_user', function (Blueprint $table) {

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -54,7 +54,7 @@ STRIPE_TAX_ENABLED=true      # Stripe Tax at checkout (enable it at Stripe first
 
 ## Selling something
 
-1. **Billing → Plans → New plan.** Name it, price it, and pick what it
+1. **Commercial → Plans → New plan.** Name it, price it, and pick what it
    grants. The entitlement pickers are scoped to what you yourself can see,
    exactly as the team grant pickers are.
 2. The catalog is local and mirrored out: the first checkout syncs the plan
@@ -103,7 +103,7 @@ document they always shared, byte for byte.
 
 ## Manual subscriptions
 
-**Billing → Subscriptions → New manual subscription** records a
+**Commercial → Subscriptions → New manual subscription** records a
 subscription with no processor behind it — comped accounts, wire
 transfers, purchase orders. The projector treats it exactly like a paid
 one; the activation token is shown to *you* once, to hand over. "Runs

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,0 +1,152 @@
+# Billing
+
+Sell subscriptions that grant package access — plans, Stripe checkout, a
+public pricing page, a customer area, and a Manual merchant for the
+subscriptions no processor is behind.
+
+Everything is off until you turn it on. A registry that never sets
+`BILLING_ENABLED=true` serves exactly what it always served: no routes
+answer, no navigation appears, nothing changes on the Composer surface.
+
+## The model in one paragraph
+
+A **plan** is the configuration object: what it grants (repositories and/or
+packages — the same two shapes a grant has always had), its **prices**
+(monthly, yearly, or one-time), and every lifecycle rule — trial length,
+what lapsing does, how cancellation times out, how many tokens a
+subscription may hold. A **subscription** is a customer's purchase of a
+plan, mirrored from the merchant. The **entitlement projector** turns an
+active subscription into rows in the same grant tables administrators
+write by hand — marked `source = subscription`, so neither writer can
+touch the other's rows — and everything downstream (the Composer
+endpoints, the panel, exports) keeps reading exactly what it always read.
+Billing never adds a branch to the visibility scopes.
+
+## Turning it on
+
+```dotenv
+BILLING_ENABLED=true
+BILLING_MERCHANT=stripe
+STRIPE_SECRET=sk_live_...
+STRIPE_PUBLISHABLE=pk_live_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+Then, at Stripe, add a webhook endpoint for
+`https://your-registry.example/billing/stripe/webhook` subscribed to:
+
+- `checkout.session.completed`
+- `customer.subscription.created`, `.updated`, `.deleted`, `.paused`, `.resumed`
+- `invoice.paid`, `invoice.payment_failed`
+- `charge.refunded`, `charge.dispute.created`
+
+In development, `stripe listen --forward-to localhost:8000/billing/stripe/webhook`
+prints the `whsec_...` to use.
+
+Optionally:
+
+```dotenv
+BILLING_PUBLIC_SIGNUP=true   # open /register to strangers
+BILLING_CURRENCY=usd         # the default currency new prices suggest
+BILLING_TERMS_URL=           # linked from the signup form when set
+STRIPE_TAX_ENABLED=true      # Stripe Tax at checkout (enable it at Stripe first)
+```
+
+## Selling something
+
+1. **Billing → Plans → New plan.** Name it, price it, and pick what it
+   grants. The entitlement pickers are scoped to what you yourself can see,
+   exactly as the team grant pickers are.
+2. The catalog is local and mirrored out: the first checkout syncs the plan
+   to Stripe on its own, or push everything with `php artisan
+   billing:sync-catalog`. Editing a plan's entitlements re-projects every
+   subscriber on the queue.
+3. Mark the plan **Listed** and it appears at `/pricing`; leave it unlisted
+   and it is still sellable by direct link (`/pricing/{slug}`) — launch
+   offers, negotiated tiers.
+
+A buyer signs up (or in), clicks Subscribe, pays on Stripe's hosted
+checkout, and lands on a welcome page that shows their access token
+**once**, with the two `composer config` lines beside it. Cards, invoices
+and self-service cancellation live on Stripe's Billing Portal, reached from
+the customer's own `/billing` page — no card number ever touches this app.
+
+## The lifecycle rules, per plan
+
+| Setting | What it decides |
+| --- | --- |
+| **Billing model** | Recurring, or one-time with an updates window (the perpetual-licence shape). |
+| **Lapse behaviour** | What non-payment does: withdraw access; withdraw and revoke the subscription's tokens; **freeze at version** — everything released while paid stays installable forever, newer releases need renewal; or nothing (sponsorships). |
+| **Grace days** | Continued access after the merchant gives up collecting, on top of its own retries (Stripe retries for ~3 weeks and access continues throughout `past_due`). Empty follows the merchant alone. |
+| **Cancellation** | Whether the customer's own cancellation cuts access immediately or lets the paid period run out. |
+| **Token limit** | How many access tokens a subscription may hold; the auto-issued one counts. |
+
+Four events ignore all of it and withdraw access immediately: a **dispute**
+(suspends every subscription of the customer and alerts admins), a **full
+refund**, an **admin suspension**, and — when the plan says `immediate` — a
+cancellation.
+
+## Version ceilings
+
+When a freeze-at-version subscription lapses (or a one-time purchase's
+updates window closes), each granted package is pinned at the highest
+version that existed at that moment. A pinned client's `/p2` metadata
+contains only versions inside the ceiling, dev branches vanish (a branch is
+precisely the ongoing work the licence stopped paying for), and `/dist`
+refuses newer references with an error that says why — which is what a
+stale lock file deserves, not a bare 403.
+
+Any wider path wins over a ceiling: a manual grant, a live subscription, an
+unscoped role, a public repository. And the ceiling folds into the
+metadata ETag by value, so uncapped clients keep sharing the single cached
+document they always shared, byte for byte.
+
+## Manual subscriptions
+
+**Billing → Subscriptions → New manual subscription** records a
+subscription with no processor behind it — comped accounts, wire
+transfers, purchase orders. The projector treats it exactly like a paid
+one; the activation token is shown to *you* once, to hand over. "Runs
+until" empty means indefinitely; a date makes it lapse there, under the
+plan's lapse behaviour, when the nightly reconcile passes it.
+
+## What keeps it honest
+
+- **Webhooks** are verified against the raw body, recorded in
+  `merchant_events` before they are acknowledged, and processed on the
+  queue. The event id is unique, so a redelivery is an acknowledged no-op.
+  Subscription state is never believed from a payload — the event says
+  which subscription moved and the truth is fetched fresh.
+- **`billing:reconcile`** runs nightly at 04:00: re-pulls every
+  merchant-billed subscription the merchant might still move (repairing
+  whatever a webhook lost during a deploy), crosses the boundaries nobody
+  webhooks about — grace running out, Manual periods ending, updates
+  windows closing — and sends the trial-ending warnings.
+- **Two writers, one table.** Every grant row carries its author
+  (`manual` | `subscription`). Cancelling a subscription cannot revoke a
+  grant an administrator made by name; an administrator tidying grants
+  cannot silently un-sell something paid for.
+
+## Customers and the panel
+
+A customer is a `User` with no role, which is what keeps them out of
+`/admin` entirely — `User::canAccessPanel()` asks for a role. Their whole
+surface is `/billing`. A **Team** can be the customer instead (one payer,
+every member granted through the team's own pivots); it nominates one
+member as billing contact, who receives the billing mail and owns the
+tokens.
+
+## What this is not
+
+- **Not usage-based billing.** Downloads are counted, not priced.
+- **Not an invoice generator.** Stripe renders invoices; this app mirrors
+  them (`invoices` table) so history is browsable without an API call and
+  survives a merchant migration.
+- **Not license enforcement on the package contents.** What a plan sells is
+  access; what the code's license permits is between the maintainer and
+  the consumer, as ever (see docs/licensing.md).
+
+## See also
+
+- [docs/merchant-drivers.md](merchant-drivers.md) — adding a merchant other
+  than Stripe.

--- a/docs/merchant-drivers.md
+++ b/docs/merchant-drivers.md
@@ -1,0 +1,72 @@
+# Merchant drivers
+
+Stripe is the shipped payment merchant, but nothing above the driver layer
+knows that. Adding Paddle, Lemon Squeezy, PayPal — or an internal billing
+system — is implementing one interface.
+
+## The shape
+
+The same pattern as the VCS source drivers (`app/Sources`): one contract,
+one implementation per provider, an enum that is the registry of drivers,
+and a stub that refuses loudly for cases declared ahead of their
+implementations.
+
+```
+app/Merchants/
+  MerchantClient.php          the contract
+  StubClient.php              throws from every method
+  Stripe/StripeClient.php     implemented
+  Manual/ManualClient.php     implemented — the merchant with nobody behind it
+  Values/                     the canonical vocabulary drivers translate into
+```
+
+Two working implementations ship on purpose. `ManualClient` proves the
+contract holds for a driver with no network at all, which is what keeps it
+honest — if your driver can't express something, the gap is real and the
+contract needs the conversation, not a Stripe-shaped workaround.
+
+## Adding a driver
+
+1. **Add the enum case** in `app/Enums/MerchantProvider.php` and answer its
+   capability methods (`supportsHostedCheckout()`, `supportsPortal()`,
+   `supportsTax()`, `receivesWebhooks()`). Point `client()` at your class —
+   or at `new StubClient($this)` to land the case before the driver.
+2. **Implement `MerchantClient`** (`app/Merchants/MerchantClient.php`).
+   The rules that matter:
+   - *Translate everything.* Nothing outside your driver may learn your
+     merchant's vocabulary: statuses normalise into `SubscriptionStatus`
+     (the one question the rest of the app asks is `grantsAccess()`),
+     money is integer minor units, timestamps are `CarbonImmutable`, event
+     names fold into `NormalisedEvent`'s small kind vocabulary.
+   - *The local catalog is the truth.* `syncProduct`/`syncPrice` push it
+     out and return external ids; the mapping is remembered in
+     `merchant_references`, never in columns.
+   - *Verify webhooks against the raw body* in `verifySignature()`, with a
+     constant-time comparison, and throw `UnsupportedMerchantException`
+     when the signature does not hold.
+   - *Refuse honestly.* A method your merchant cannot do throws
+     `UnsupportedMerchantException` with a message fit to show a person —
+     the Manual driver's portal refusal is the template.
+3. **Credentials** go in `config/services.php`, env-driven, like every
+   other integration's.
+4. **Webhooks** already route: `POST /billing/{merchant}/webhook` resolves
+   your enum case by value and calls your `verifySignature()`. Everything
+   after that — the inbox row, the idempotency, the queue, the projection —
+   is shared machinery in `MerchantWebhookController` and
+   `ProcessMerchantEvent`, and none of it is yours to reimplement.
+
+## What you inherit for free
+
+Entitlement projection, lapse behaviours, version ceilings, grace windows,
+the reconciler (`fetchSubscription` is all it asks of you), invoice
+mirroring (`invoiceFromPayload`/`fetchInvoices`), the customer area, the
+panel resources, and the notification set. A driver is a translator, not a
+billing system.
+
+## Testing without the network
+
+`tests/Feature/MerchantWebhookTest.php` computes real Stripe signatures in
+the test and exercises the actual driver's verification — copy that shape.
+For lifecycle behaviour, construct `RemoteSubscription` values by hand and
+feed them to `SubscriptionProjector::apply()`, as
+`tests/Feature/SubscriptionLifecycleTest.php` does; no driver required.

--- a/docs/plans/ecommerce-subscriptions.md
+++ b/docs/plans/ecommerce-subscriptions.md
@@ -1,0 +1,403 @@
+# Ecommerce & subscription layer for Package Pipeline
+
+## Context
+
+Package Pipeline serves private Composer packages, and access is decided by
+*grants*: rows in `package_user` / `repository_user` / `package_team` /
+`repository_team` that `Package::scopeVisibleToUser()` folds into every read on
+the Composer surface, the API, the panel and the exports. Today those grants can
+only be created by an administrator. There is no way to sell access.
+
+The goal is a commercial layer where a **plan** is the configuration object: it
+names what it grants, how it is billed, what happens when it lapses, and how
+many tokens it permits. A subscription to a plan projects into the existing
+grant system, so nothing downstream of a grant has to learn what billing is.
+Stripe is the shipped merchant, but the merchant is a driver behind a contract —
+mirroring how `SourceProvider` + `RepositoryClient` + `StubClient` already make
+GitHub and GitLab interchangeable.
+
+Decisions taken (see the record at the end):
+
+| Decision | Choice |
+| --- | --- |
+| Unit of entitlement | Plans; a plan grants repositories and/or packages |
+| Customer of record | Polymorphic — a `User` or a `Team` |
+| Billing models | Recurring, one-time + updates window, trials, coupons |
+| Lapse behaviour | Configurable **per plan** |
+| Checkout & card management | Provider-hosted now, contract shaped for embedded later |
+| Pricing catalog | Local DB is truth, mirrored out to the merchant |
+| Tokens | Auto-issue one on activation, more up to the plan's seat cap |
+| Self-serve | Public pricing page, public signup + checkout, customer area outside `/admin` |
+| Subscription state | Merchant is truth, mirrored by webhook, repaired by a nightly reconcile |
+| Dunning | Merchant retries; access continues until it gives up |
+| Tax & invoices | Stripe Tax, invoices mirrored locally, VAT/business details collected |
+| Updates window | Pin a per-package **version ceiling** at lapse |
+| Metadata cache | Bucket by ceiling (fold the ceiling into the existing ETag) |
+| Immediate access loss | Dispute, full refund, admin suspension, and customer cancellation |
+| Merchants | Stripe (built) and Manual/offline (built) |
+
+---
+
+## The central design choice: entitlements project into the existing pivots
+
+A subscription does **not** get a new branch in `Package::scopeVisibleTo()`. The
+Composer metadata path is the hottest query in the app and its three-branch
+shape is deliberate. Instead:
+
+1. Add a `source` column (`manual` | `subscription`, default `manual`) to the
+   four grant pivots, and widen each composite unique index to include it. The
+   docblock on `User::packageGrants()` ([User.php:126](app/Models/User.php#L126))
+   already states that duplicate ids in the union are harmless — the caller only
+   asks whether an id is in the list — so a package granted both manually and by
+   subscription needs no special handling.
+2. An **entitlement projector** owns every `source = 'subscription'` row and
+   never touches a `manual` one. Administrators keep full control of manual
+   grants; the projector cannot clobber them and they cannot silently revoke a
+   paid one.
+3. `scopeVisibleTo`, `scopeVisibleToUser`, `packageGrants()`,
+   `repositoryGrants()`, the Effective access screen and `LogsGrantChanges`
+   audit logging all keep working **unchanged**. Zero hot-path cost.
+
+A separate `entitlements` ledger records what each subscription granted and the
+version ceiling pinned on it. The pivots answer *who can see what*; the ledger
+answers *which subscription granted it and up to which version*. Only the
+metadata and dist paths consult the ledger, and only for a package reached
+through a subscription.
+
+---
+
+## Schema
+
+New migrations in `database/migrations/`, following the house style (prose
+comment per table explaining why it is shaped that way).
+
+**`billing_customers`** — `morphs('billable')` (`User` or `Team`), `name`,
+`email`, `company_name`, `tax_id`, `address` (json), `merchant`,
+`merchant_customer_id` (nullable — a Manual customer has none), timestamps,
+soft deletes. Unique on `(merchant, merchant_customer_id)`.
+
+**`plans`** — `name`, `slug` (unique), `description`, `active`, `listed`
+(shown on the public pricing page), `billing_model`
+(`recurring` | `one_time_with_updates`), `trial_days`, `token_limit` (nullable =
+unlimited), `seat_limit`, `updates_window_months`, `lapse_behaviour`
+(`withdraw_entitlement` | `revoke_tokens` | `freeze_at_version` | `none`),
+`grace_days` (nullable = follow the merchant), `cancellation`
+(`immediate` | `end_of_period`), `auto_issue_token`, `sort`, timestamps,
+soft deletes.
+
+**`plan_prices`** — `plan_id`, `currency` (ISO 4217), `amount` (integer minor
+units — never a float), `interval` (`month` | `year` | `one_time`),
+`interval_count`, `active`, `default`, timestamps.
+
+**`plan_entitlements`** — `plan_id`, `morphs('grantable')` (`Repository` or
+`Package`), unique on `(plan_id, grantable_type, grantable_id)`. Deliberately
+the same shape as the existing grant pivots.
+
+**`merchant_references`** — `morphs('referenceable')` (`Plan`, `PlanPrice`,
+`BillingCustomer`, `Subscription`, `Invoice`), `merchant`, `external_id`,
+`synced_at`. Unique on `(referenceable_type, referenceable_id, merchant)` and on
+`(merchant, external_id)`. This is what makes the local catalog portable — a
+second merchant is a second row, not a second schema.
+
+**`subscriptions`** — `billing_customer_id`, `plan_id`, `plan_price_id`,
+`merchant`, `status`, `quantity`, `trial_ends_at`, `current_period_start`,
+`current_period_end`, `grace_ends_at`, `cancel_at`, `canceled_at`, `ends_at`,
+`suspended_at`, `suspension_reason`, `coupon_code`, timestamps, soft deletes.
+Indexed on `(status, current_period_end)` for the reconciler.
+
+**`entitlements`** — `subscription_id`, `billing_customer_id`,
+`morphs('grantable')`, `version_ceiling` (nullable, normalised), `active`,
+`starts_at`, `ends_at`. The projector's ledger.
+
+**`invoices`** — `billing_customer_id`, nullable `subscription_id`, `merchant`,
+`number`, `currency`, `subtotal`, `tax`, `total`, `amount_refunded`, `status`,
+`hosted_url`, `pdf_url`, `issued_at`, `paid_at`, `refunded_at`.
+
+**`merchant_events`** — `merchant`, `external_id` (**unique** — the idempotency
+key), `type`, `payload` (json), `received_at`, `processed_at`, `failed_at`,
+`error`. Prunable via `model:prune`, added to the existing 03:30 schedule entry.
+
+**Alterations**
+- `access_tokens`: nullable `subscription_id` (`nullOnDelete`), so the
+  `revoke_tokens` lapse behaviour knows exactly which credentials it issued.
+- `package_user`, `repository_user`, `package_team`, `repository_team`: add
+  `source` string default `'manual'`, drop and recreate the composite unique to
+  include it.
+
+---
+
+## Enums (`app/Enums/`)
+
+All backed string enums implementing Filament's `HasLabel`/`HasDescription`,
+with behaviour on the enum via `match ($this)` — the established convention.
+
+- `MerchantProvider` — `Stripe`, `Manual`. Carries `getLabel()`,
+  `supportsHostedCheckout()`, `supportsPortal()`, `supportsTax()`, and the
+  `client()` factory.
+- `SubscriptionStatus` — `Incomplete`, `Trialing`, `Active`, `PastDue`,
+  `Paused`, `Canceled`, `Unpaid`, `Suspended`, `Expired`. The single method that
+  matters is `grantsAccess(): bool` (true for `Trialing`, `Active`, `PastDue`).
+  Every driver normalises its own vocabulary into this.
+- `BillingModel`, `LapseBehaviour`, `BillingInterval`, `CancellationTiming`.
+
+---
+
+## The merchant driver contract (`app/Merchants/`)
+
+Modelled directly on `app/Sources/` — an interface, `final readonly` value
+objects, per-driver implementations, and a throwing stub. **Not** Laravel
+Cashier: Cashier owns the `users` table shape, its own subscription models and
+its own routes, all of which would fight a provider-neutral contract. Use
+`stripe/stripe-php` directly.
+
+```
+app/Merchants/
+  MerchantClient.php              interface
+  UnsupportedMerchantException.php
+  StubClient.php                  throws from every method
+  Stripe/StripeClient.php
+  Manual/ManualClient.php
+  Values/{CheckoutRequest,CheckoutSession,RemoteSubscription,RemoteInvoice,NormalisedEvent}.php
+```
+
+`MerchantClient` methods:
+
+| Method | Purpose |
+| --- | --- |
+| `syncProduct(Plan): string` / `syncPrice(PlanPrice): string` | Push the local catalog out, return the external id for `merchant_references` |
+| `ensureCustomer(BillingCustomer): string` | Create or update the remote customer, incl. tax id and address |
+| `startCheckout(CheckoutRequest): CheckoutSession` | Returns a redirect URL today; the request/response pair is where an embedded flow will later add a client secret without reshaping the contract |
+| `portalUrl(BillingCustomer, string $returnUrl): string` | Card management, cancellation, invoice history |
+| `changePrice(Subscription, PlanPrice): void` | Upgrade/downgrade |
+| `cancel(Subscription, bool $immediately): void` | |
+| `fetchSubscription(string $externalId): RemoteSubscription` | Used by the reconciler |
+| `fetchInvoices(BillingCustomer): iterable<RemoteInvoice>` | Backfill |
+| `verifySignature(Request): NormalisedEvent` | Signature check + normalise into the canonical vocabulary |
+
+`ManualClient` implements the whole interface without any network: `startCheckout`
+returns a URL into the admin panel, `portalUrl` throws a soft "not available",
+`verifySignature` is never reached. Building it alongside Stripe is what proves
+the abstraction is real rather than aspirational.
+
+Factory, mirroring `Package::client()` at [Package.php:611](app/Models/Package.php#L611):
+
+```php
+public function client(): MerchantClient
+{
+    return match ($this) {
+        self::Stripe => new StripeClient(config('services.stripe')),
+        self::Manual => new ManualClient,
+    };
+}
+```
+
+Credentials go in `config/services.php` (`stripe.secret`, `stripe.publishable`,
+`stripe.webhook_secret`, `stripe.tax_enabled`), keeping secrets where the other
+integrations put theirs.
+
+---
+
+## Services (`app/Services/Billing/`)
+
+Flat single-purpose classes, matching how `app/Services` is already organised.
+
+- **`EntitlementProjector`** — the heart. `project(Subscription)` computes the
+  desired `source = 'subscription'` pivot rows and ledger entries from the
+  subscription's status, plan and lapse behaviour, then syncs them
+  transactionally. Idempotent by construction: it is safe to run on every event
+  and on every reconcile. Handles all four `LapseBehaviour` cases, including
+  pinning ceilings for `freeze_at_version`.
+- **`SubscriptionProjector`** — applies a `NormalisedEvent` (or a
+  `RemoteSubscription` from the reconciler) to the local `Subscription` row, then
+  calls `EntitlementProjector`. Guards against out-of-order events by ignoring
+  any payload older than the row's last applied event.
+- **`CatalogSync`** — pushes plans/prices to a merchant and records
+  `merchant_references`. Exposed as `billing:sync-catalog` and a Filament action.
+- **`CheckoutBuilder`** — turns a plan + price + customer + optional coupon into
+  a `CheckoutRequest`, resolving success/cancel URLs.
+- **`VersionCeiling`** — computes the highest normalised version of a package at
+  an instant, and answers `permits(PlanVersion, ?string $ceiling)`. Uses
+  `composer/semver` (already a dependency) and the existing
+  `app/Support/VersionNormalizer.php`.
+- **`SubscriptionTokens`** — issues the activation token via the existing
+  `Token::issue()`, enforces the plan's `token_limit`, and revokes
+  subscription-issued tokens on lapse when the plan says so.
+
+---
+
+## Enforcing the updates window
+
+Three touch points, all in
+[ComposerRepositoryController.php](app/Http/Controllers/ComposerRepositoryController.php):
+
+1. **`etag()` (~line 813)** — fold the requesting credential's ceiling for this
+   package into the fingerprint. Because `payload()` (~line 697) already keys its
+   cache as `composer:metadata:{id}:{dev}:{etag}`, bucketing falls out for free:
+   every customer without a ceiling shares today's single cached body, and each
+   distinct ceiling gets its own entry. No new cache mechanism.
+2. **`payload()`** — drop versions above the ceiling when one is present.
+3. **`dist()` (~line 917)** — reject a reference above the ceiling with a 403
+   that names the reason, so a stale lock file gets a comprehensible error rather
+   than a bare denial.
+
+`lastModified()` already refuses to go backwards, which is what keeps a ceiling
+from producing a `Last-Modified` that confuses caches.
+
+The ceiling lookup is one indexed query against `entitlements`, executed only
+when the package was reached through a subscription. Resolve it once per request
+and stash it on the request attributes alongside `composerToken`, the way
+`ResolveComposerRepository` already stashes `composerRepository`.
+
+---
+
+## Webhooks & reconciliation
+
+- Route `POST /billing/{merchant}/webhook`, registered in `routes/web.php`
+  outside the `web` group (no session, no CSRF), under a new
+  `throttle:merchant-webhooks` limiter defined beside the others in
+  `AppServiceProvider::defineRateLimiters()`.
+- `MerchantWebhookController` verifies the signature against the **raw body**
+  with `hash_equals`, exactly as
+  [GitHubWebhookController](app/Http/Controllers/GitHubWebhookController.php)
+  does, writes a `merchant_events` row (unique `external_id` swallows replays),
+  returns 2xx immediately, and dispatches `ProcessMerchantEvent`.
+- `app/Jobs/ProcessMerchantEvent.php` — follows the `DeliverWebhook`
+  conventions: explicit `$tries`, `$timeout`, `$deleteWhenMissingModels`,
+  `backoff()`, and a `failed()` hook that marks the row and notifies admins.
+- `app/Console/Commands/ReconcileBilling.php` (`billing:reconcile`) re-pulls every
+  subscription that is active, in grace, or changed in the last 48h, and repairs
+  drift. Added to `routes/console.php` at ~04:00 with `->onOneServer()
+  ->withoutOverlapping()`, matching every other entry there.
+
+---
+
+## Public surface
+
+Everything anonymous uses the existing non-Filament Blade front end
+(`resources/views/components/page-layout.blade.php`), so it inherits the
+canonical/OG/JSON-LD handling and the Tailwind build already in place.
+
+- `app/Http/Controllers/Pages/PricingController.php` — `/pricing` and
+  `/pricing/{plan:slug}`, under `throttle:pages`. Listed plans only, with the
+  packages each unlocks linked to their existing public package pages.
+- **Registration** — `/register`, gated by `config('registry.billing.public_signup')`,
+  creating a `User` with **no role**. `User::canAccessPanel()` returns
+  `$this->roles()->exists()` ([User.php:50](app/Models/User.php#L50)), so a
+  customer is structurally incapable of reaching `/admin`. Email verification,
+  a honeypot, and `throttle` on the POST.
+- **Customer area** — `/billing/*` behind `auth`, in
+  `app/Http/Controllers/Billing/`: subscription status and next charge, plan
+  change, redirect to the merchant portal for card management, locally-mirrored
+  invoice list, and token management capped at the plan's `token_limit`.
+- Checkout return lands on `/billing/welcome`, which shows the auto-issued token
+  **once** with the two `composer config` lines already used elsewhere in the app.
+
+---
+
+## Filament (`app/Filament/Resources/`)
+
+Auto-discovered; each follows the `Resource + Schemas/ + Tables/ + Pages/`
+layout, in a new `'Billing'` navigation group.
+
+- `Plans/` — plan settings, a repeater for prices, and the entitlement pickers.
+  The two pickers must be scoped with `visibleToUser(auth()->user())`, the same
+  way [TeamForm.php:85](app/Filament/Resources/Teams/Schemas/TeamForm.php#L85)
+  scopes its grant pickers.
+- `BillingCustomers/`, `Subscriptions/`, `Invoices/`.
+- Actions: comp a subscription (Manual driver), suspend/unsuspend, cancel,
+  resync catalog, replay a failed merchant event.
+- `app/Filament/Widgets/BillingTotals.php` — MRR, active subscriptions, trials
+  ending, failed payments. Dropping the file in registers it.
+- Policies in Shield's shape in `app/Policies/`, then `php artisan shield:generate`.
+- New `WebhookEvent` cases so the existing outgoing-webhook system fires on
+  subscription lifecycle changes.
+
+---
+
+## Notifications
+
+Extending the existing `AnnouncedByMail` + `RoutedByAdminNotifier` concerns:
+`SubscriptionActivated` (carries the token), `TrialEnding`, `PaymentFailed`,
+`SubscriptionLapsed`, `SubscriptionCanceled`, `InvoicePaid`. Admin-side alerts
+(dispute opened, reconcile drift, webhook processing failure) go through
+`app/Services/AdminNotifier.php`.
+
+---
+
+## Config
+
+A `billing` block in `config/registry.php`, env-driven with an explicit cast and
+a prose rationale per key — the file's established style:
+`BILLING_ENABLED`, `BILLING_MERCHANT`, `BILLING_PUBLIC_SIGNUP`,
+`BILLING_CURRENCY`, `BILLING_GRACE_DAYS`, `BILLING_TERMS_URL`,
+`BILLING_RECONCILE_LOOKBACK_HOURS`. Secrets stay in `config/services.php`.
+
+---
+
+## Build order
+
+Each step leaves the app working and testable; all of them ship together.
+
+1. Schema, enums, models, factories, `source` column on the four pivots.
+2. `EntitlementProjector` + `ManualClient` — full lifecycle end to end with no
+   network calls at all. This is the step that must be watertight.
+3. Filament resources, policies, widget, admin actions.
+4. `StripeClient`, `CatalogSync`, hosted checkout + portal, webhook ingestion,
+   `ProcessMerchantEvent`, invoice mirroring, `billing:reconcile`.
+5. Public pricing page, registration, customer area, token issuance and caps.
+6. Version ceilings: `VersionCeiling` service, the three controller touch points,
+   the `freeze_at_version` lapse path.
+7. `docs/billing.md` and `docs/merchant-drivers.md`, in the style of the existing
+   docs; README section; `.env.example` keys.
+
+---
+
+## Verification
+
+- `composer test` — new Feature tests alongside the existing ones (PHPUnit,
+  `RefreshDatabase`, `$seed = true`, `Http::preventStrayRequests()`):
+  - `BillingEntitlementScopingTest` — a subscription makes packages visible over
+    `/p2` and `/dist`; lapse withdraws them; a manual grant on the same package
+    survives the lapse.
+  - `SubscriptionLifecycleTest` — every status transition, all four lapse
+    behaviours, the four immediate-withdrawal events.
+  - `MerchantWebhookTest` — signature rejection, replayed `external_id` is a
+    no-op, out-of-order events do not regress state.
+  - `VersionCeilingMetadataTest` — a ceilinged client sees a truncated version
+    list and a distinct ETag; an unceilinged client's response and cache entry
+    are byte-identical to today's.
+  - `CheckoutFlowTest`, `PublicSignupTest`, `CustomerAreaTest`,
+    `SubscriptionTokenLimitTest`.
+  - A `FakeMerchantClient` bound in the container for anything that would
+    otherwise call Stripe.
+- `composer lint` and `composer analyse` must both pass.
+- Manual: `composer run dev`, seed a plan, comp a Manual subscription to a test
+  user, confirm `composer require` against the registry succeeds with the
+  auto-issued token and 403s after suspending the subscription.
+- Stripe: test-mode keys, `stripe listen --forward-to localhost:8000/billing/stripe/webhook`,
+  walk a full purchase → renewal → failed payment → cancellation.
+
+---
+
+## Flagged for your call, not assumed
+
+- **Immediate loss of access on customer cancellation** is unusual — the norm is
+  that a cancelled subscription runs to the end of the period already paid for,
+  and doing otherwise tends to produce refund requests. It is implemented as the
+  per-plan `cancellation` setting, defaulting to `immediate` as you chose, so it
+  can be changed per plan without a deploy.
+- **Upgrade/downgrade timing** was not asked about; the plan assumes the
+  industry default — upgrades apply immediately with proration, downgrades at
+  period end. Say if you want otherwise.
+- **Team subscriptions need a billing contact.** `Team` today has no owner and no
+  per-team roles ([docs/teams.md](docs/teams.md) is explicit that this is
+  deliberate). A `Team` billing customer therefore needs one nominated user; this
+  plan adds that as a nullable `billing_contact_user_id`, which is the smallest
+  change that does not import a team-roles concept.
+- **Usage-based billing is out of scope.** `downloads` carries only
+  `token_prefix` as credential attribution, and the two non-Composer archive
+  paths write `null`. Metering per subscriber would need a schema change and a
+  revisit of the 400-day `downloads:prune` retention.
+- **Stripe Tax is the most merchant-specific part of the design.** It sits behind
+  `MerchantClient::supportsTax()`; a merchant without it would need the tax
+  columns filled some other way.

--- a/docs/plans/over-engineering-audit.md
+++ b/docs/plans/over-engineering-audit.md
@@ -1,0 +1,171 @@
+# Over-engineering audit — cut list
+
+## Context
+
+A repo-wide audit (2026-08-22, branch `feat/enhance`) hunting only for
+over-engineering: dead code, unreachable branches, speculative flexibility,
+duplication, and hand-rolled stdlib. Correctness, security and performance were
+explicitly out of scope. Every finding below was verified by grepping usage
+across `app/ tests/ routes/ config/ database/ resources/` (vendor excluded);
+the evidence column records what the grep proved.
+
+Estimated total: **~1,250 lines and 1 composer dependency** removable.
+
+Nothing here is a behaviour change for a user. The riskiest items are the two
+interface-method deletions (batch 2) and the notification/controller dedups
+(batch 5), which touch money paths — those have test coverage
+(`MerchantWebhookTest`, `SubscriptionLifecycleTest`, the archive-serving
+feature tests) that must stay green.
+
+### How to work this plan
+
+Each batch is independently shippable. Within a batch, items are ranked
+biggest cut first. After each batch:
+
+```sh
+composer lint && composer analyse && composer test
+```
+
+PHPStan is the real tripwire here — most of these are "no references" deletes,
+and level-max Larastan will flag anything a delete orphans.
+
+---
+
+## Batch 1 — pure deletes, zero call sites
+
+Nothing references these. Delete and run the suite.
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 1.1 | `App\Merchants\StubClient` (whole file) | `app/Merchants/StubClient.php` | Zero references repo-wide. `MerchantProvider::client()` is an exhaustive match on `Stripe\|Manual` with no default arm. Only mentions are prose in `docs/merchant-drivers.md` and `docs/plans/ecommerce-subscriptions.md` — update both (see batch 7). | 97 |
+| 1.2 | `HidesBreadcrumbs` trait + its 13 `use` lines and imports | `app/Filament/Concerns/HidesBreadcrumbs.php` | `AdminPanelProvider` already calls `->breadcrumbs(false)`; the vendor blade checks `filament()->hasBreadcrumbs()` *before* calling `getBreadcrumbs()`, so every override is a no-op. | 35 |
+| 1.3 | `use HandlesAuthorization;` in all 15 policies | `app/Policies/*.php` | `allow(`/`deny(` — zero hits; every policy method returns a bare bool. | 30 |
+| 1.4 | `BillingCustomer::beneficiaries()` | `app/Models/BillingCustomer.php:621` | Zero call sites. Its own docblock names `EntitlementProjector` as the caller, but `syncPivots()` reads `$customer->billable` and branches on `User\|Team` itself. | 22 |
+| 1.5 | Dead enum helpers: `LapseBehaviour::keepsGrants()`, `GrantSource::editableByHand()`, `MerchantProvider::supportsHostedCheckout()`, `BillingModel::renews()`, `BillingModel::hasUpdatesWindow()` | `app/Enums/` | Zero call sites each. All the code that could use them matches on the enum cases directly (`EntitlementProjector::syncLedger`, `ReconcileBilling:112`, `CheckoutController` via `purchasable()`). | 54 |
+| 1.6 | `LicenseUsage::label()` | `app/Support/LicenseUsage.php` | No prod caller (one test-only use). Both display sites (`Licenses.php:84`, `licenses.blade.php:52`) hardcode `?? 'Not declared'`. Delete the test assertion with it. | 6 |
+| 1.7 | `inspire` Artisan closure | `routes/console.php:10` | Untouched Laravel skeleton stub; no schedule entry, no docs. | 5 |
+| 1.8 | Empty JS entrypoint + its vite input | `resources/js/app.js`, `vite.config.js` | File body is literally `//`. The only `@vite` call in the repo is `@vite('resources/css/app.css')` in `page-layout.blade.php`. | 2 |
+| 1.9 | Explicit `->pages([Dashboard::class])` + import | `app/Providers/Filament/AdminPanelProvider.php` | `discoverPages(in: app_path('Filament/Pages'))` on the next line already registers it; Filament de-dupes but the line is noise. | 4 |
+| 1.10 | Unused `use App\Sources\StubClient;` import | `app/Enums/MerchantProvider.php:8` | Imported only for a `@see` docblock line. (Moot once batch 3 lands.) | 1 |
+
+**Batch total: ~256 lines**
+
+## Batch 2 — dead merchant-contract surface
+
+The `MerchantClient` interface carries methods nothing calls. Shrink the
+contract, then the implementations. Money path — run `MerchantWebhookTest`,
+`SubscriptionLifecycleTest`, `SignupTest` after.
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 2.1 | `changePrice()` from the interface and all implementations | `app/Merchants/MerchantClient.php:69`, `Stripe/StripeClient.php:212`, `Manual/ManualClient.php:66` | Zero call sites. Upgrades/downgrades happen in Stripe's hosted Billing Portal (`BillingController::portal`) — the only price-change path that exists. | 45 |
+| 2.2 | `fetchInvoices()` from the interface and all implementations (incl. the Stripe `autoPagingIterator` generator) | `app/Merchants/MerchantClient.php:88`, `StripeClient.php:249`, `ManualClient.php:81` | Zero call sites. Invoices are mirrored only by webhook via `invoiceFromPayload()`. The docblock claims "for backfill", but `ReconcileBilling` has no invoice sweep. | 40 |
+| 2.3 | Six structurally unreachable `ManualClient` methods: `ensureCustomer`, `cancel`, `fetchSubscription`, `invoiceFromPayload`, `customerExternalId`, `verifySignature` | `app/Merchants/Manual/ManualClient.php` | Every caller guards Manual out first: `CheckoutBuilder:76` skips `ensureCustomer`; `CancelSubscriptionAction:43` skips `cancel`; `Subscription::scopeReconcilable` excludes Manual from `fetchSubscription`; `MerchantWebhookController:35` 404s (Manual `receivesWebhooks()` is false) before the webhook-only trio. Decide with 2.1/2.2 whether these leave the interface too, or Manual keeps thin `throw` stubs. Note: `cancel()`'s comment names `SubscriptionProjector` as the local canceller — it's actually `CancelSubscriptionAction`. Fix or delete with it. | 45 |
+| 2.4 | `customerExternalId(NormalisedEvent $event)` → `customerExternalId(array $payload)`; drop the VO reconstruction in the caller | `app/Jobs/ProcessMerchantEvent.php:245`, `MerchantClient.php:100`, `StripeClient.php:311` | `disputeOpened()` is the sole caller and rebuilds a `NormalisedEvent` from a stored row just so the callee can read two fields (`payload`, `kind`). The `kind === DISPUTE_OPENED` guard inside `StripeClient` is then always-true. | 12 |
+
+**Batch total: ~142 lines**
+
+## Batch 3 — providers that don't exist (Gitea/Bitbucket)
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 3.1 | `App\Sources\StubClient` (whole class — 9 methods, all `throw $this->unsupported()`) | `app/Sources/StubClient.php` | Two prod call sites, both `default =>` match arms (`Package.php:1054`, `Source.php:96`). Replace with `default => throw new UnsupportedProviderException(...)` inline. | 70 |
+| 3.2 | `SourceProvider::Gitea` and `::Bitbucket` cases + their 8 match arms across `getLabel/defaultApiUrl/host/browseUrl/forHost` | `app/Enums/SourceProvider.php` | No client implements either; every arm routes to the stub. No Gitea/Bitbucket row exists in seeders, factories or tests. One test (`GitLabProviderTest:213`) asserts `forHost()` guesses Gitea from a hostname — delete that assertion with the case. | 25 |
+
+**Caveat:** if a `sources.provider` column value of `gitea`/`bitbucket` could
+exist in a deployed database, enum-backed casting would throw on read. Check
+before shipping: no seeder or migration writes one, but a cautious deploy adds
+a one-line data assertion or leaves the case with a `throw` arm for one
+release.
+
+**Batch total: ~95 lines**
+
+## Batch 4 — Shield policy surface
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 4.1 | The 68 generated `restore/restoreAny/forceDelete/forceDeleteAny/replicate/reorder` methods across all 14 Shield policies + trim `policies.methods` in config | `app/Policies/*.php`, `config/filament-shield.php:159` | Zero hits for `RestoreAction\|ForceDeleteAction\|TrashedFilter\|ReplicateAction\|reorderable(true)` in app/ + resources/. The 4 SoftDeletes models (Plan, Subscription, BillingCustomer, Token) expose no trashed filter or restore action in any resource. Also removes ~84 dead permission checkboxes from the Roles screen. Re-run `ShieldPermissionSeeder` / prune the orphaned `permissions` rows, and trim `tests/Feature/PolicyPermissionTest.php:44-55`. | 280 |
+| 4.2 | `InvoicePolicy::create/update/delete/deleteAny` | `app/Policies/InvoicePolicy.php` | Resource is list-only by design: `canCreate(): false`, only `index` in `getPages()`, no Edit/Delete actions in `InvoicesTable`. | 24 |
+| 4.3 | `PackageAdvisoryPolicy::deleteAny` | `app/Policies/PackageAdvisoryPolicy.php:64` | `AdvisoriesRelationManager` has no bulk actions — imports Create/Delete/Edit actions only. | 5 |
+
+**Batch total: ~309 lines**
+
+## Batch 5 — duplication (shrink, careful diffs)
+
+Same logic, fewer copies. These change shared code on live paths — lean on the
+existing feature tests.
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 5.1 | Five copies of the same `toDatabase()` FilamentNotification builder + five near-identical `toSlack()` bodies | `app/Notifications/PackageAbandoned.php`, `PackageVersionsPublished.php`, `PackageSyncFailed.php`, `UnserveablePackageNames.php`, `Billing/BillingAlert.php` | All five end in `->title($this->title())->body($this->body())->actions([...markAsRead()])->getDatabaseMessage()`, differing only in warning/success tone and heroicon name. `title()`/`body()` are already the abstract pair `AnnouncedByMail` declares — add a sibling trait taking abstract `icon()`/`tone()` (and an optional context block for Slack). | 85 |
+| 5.2 | Triplicated "serve the zip" tail: exists-guard, `PackageDownloaded::dispatch` on GET, `temporaryUrl` redirect with Cache-Control, `download` fallback | `app/Http/Controllers/VersionArchiveController.php:66`, `Pages/PackageArchiveController.php:70`, `ComposerRepositoryController.php:980` | Three copies differ only in the Cache-Control string (`no-store` vs `public, max-age=3600`) and the 404 message. `ArchiveStore` already owns `disk()`, `temporaryUrl()` and `downloadFilename()` — give it `serve(string $path, string $filename, string $cacheControl)`. | 45 |
+| 5.3 | `RebuildPackage` service — both methods are one-line delegations | `app/Services/RebuildPackage.php` | `rebuild()` → `PackageSynchronizer::sync(force: true)`; `queue()` → `SyncPackageJob::dispatchUnlessPending(force: true)`. Inline at the 3 call sites (`RebuildPackageAction:33`, `QueueSyncsBulkAction:67`, `RebuildPackages:52`). | 43 |
+| 5.4 | `RegistryMetrics` generic `metric($name,$type,$help,$samples[])` + `labels()` escaping machinery | `app/Services/RegistryMetrics.php:284` | 16 of 17 call sites pass `'labels' => []`; every family carries exactly one sample. Replace with direct `gauge()`/`counter()` emitters; the single labelled series (`up`) formats its one label inline. | 35 |
+| 5.5 | Identical `package()` resolver in the two export **commands** | `app/Console/Commands/ExportDownloads.php:107`, `ExportSbom.php:98` | Bodies identical apart from a hoisted local; same query, same two `throw_if` messages verbatim. Share via `App\Console\Concerns`. | 30 |
+| 5.6 | `CatalogSync` — fold into its callers | `app/Services/Billing/CatalogSync.php` | `syncAll()` is a 6-line foreach with exactly one caller (`SyncBillingCatalog:29`); the docblock's "panel action" caller does not exist. `syncPlan()` keeps 2 call sites — inline or move onto `Plan`. | 30 |
+| 5.7 | `MailDelivery` class → 2-line helper or inline | `app/Support/MailDelivery.php` | 8 lines of code, 33 of comment, 2 consuming files (`UserForm`, `SendWelcomeEmailAction`). Keep the *why* comment at whichever site survives — the log/array-drivers-lie insight is worth its lines. | 25 |
+| 5.8 | Byte-identical `package()` resolver in the two export **controllers** | `app/Http/Controllers/DownloadExportController.php:83`, `SbomExportController.php:76` | Same signature, same body, same abort message shape; both also repeat the identical `streamDownload` + `fopen('php://output')` closure. | 20 |
+| 5.9 | Duplicated console helpers: `settled()` (2 prune commands), `emailError()` (2 user commands) | `CleanArchives.php:124` / `PruneMirror.php:138`; `AddUser.php:122` / `CreateAdmin.php:145` | Byte-for-byte identical. Both user commands already `use IssuesPasswordResetLinks` — move `emailError()` there. | 15 |
+| 5.10 | `latestStableVersion()` + `isVersionLikeTag()` hand-rolled version ordering | `app/Services/PackageSynchronizer.php:646` | Second implementation of "highest stable version" — `VersionCeiling::currentCeiling` already sorts on the indexed `order` column in SQL. Reuse `VersionNormalizer::order()` or the column. | 15 |
+
+**Batch total: ~343 lines**
+
+## Batch 6 — speculative flexibility in billing values
+
+Write-only fields and parameters that only ever receive one value.
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 6.1 | `CheckoutSession` value object → return the redirect URL string | `app/Merchants/Values/CheckoutSession.php` | Constructed once (`StripeClient:203`, 2 of 3 args), consumed once (`CheckoutController:37` reads only `->redirectUrl`). `$externalId` and `$clientSecret` have zero readers; "embedded flow later adds a client secret" is the speculation. | 19 |
+| 6.2 | `CheckoutBuilder` `?User $contact` param + `instanceof Team` branches | `app/Services/Billing/CheckoutBuilder.php:74` | Sole caller is `CheckoutController:35` passing `$request->user()`; Team billing customers are created in Filament, never through checkout. `start(User $user, PlanPrice $price)`. | 12 |
+| 6.3 | `CheckoutRequest` constant fields: `quantity` (always 1), `couponCode` (always null — Stripe owns coupons via `allow_promotion_codes`), `collectBusinessDetails` (always true) | `app/Merchants/Values/CheckoutRequest.php` | `new CheckoutRequest(` appears exactly once in the repo; all three are literals there. Hardcode in `StripeClient`. | 6 |
+| 6.4 | Write-only VO fields: `RemoteSubscription::$priceExternalId`, `RemoteInvoice::$refundedAt` | `app/Merchants/Values/` | `priceExternalId` written at `StripeClient:371`, read by nobody (`SubscriptionProjector::apply` forceFills 10 fields, not this one). `refundedAt` is hardcoded `null` by its only producer; the real value is written by `invoiceRefunded` independently. | 4 |
+| 6.5 | Fake DI: constructor-default collaborators nobody ever injects | `EntitlementProjector.php:175`, `SubscriptionProjector.php:526`, `VersionCeiling.php:697` | No call site passes an argument, no container binding exists. Plain `new` where used. | 9 |
+| 6.6 | `SubscriptionTokens::withinLimit()` public → private | `app/Services/Billing/SubscriptionTokens.php:648` | Only caller is `issueFor()` in the same class. | 1 |
+| 6.7 | `Plan::activePrices()` → inline into `purchasable()` | `app/Models/Plan.php:128` | One caller (`purchasable()`), which itself has one caller (`CheckoutController:26`). Zero blade/Filament use. | 5 |
+| 6.8 | `VersionCeiling` pre-`order`-column backfill fallback (second query + map + max) | `app/Services/Billing/VersionCeiling.php:59` | The `order` column ships in the *initial* `create_package_versions_table` migration and is written on every insert — no deployed row can be null. `return $ceiling ?? self::NOTHING;`. | 14 |
+
+**Batch total: ~70 lines**
+
+## Batch 7 — config and dependency trim
+
+| # | Cut | Path | Evidence | ~Lines |
+|---|-----|------|----------|-------:|
+| 7.1 | Postmark mailer block + services key | `config/mail.php:59`, `config/services.php:42` | `symfony/postmark-mailer` is not installed — selecting `MAIL_MAILER=postmark` fatals at boot. Dead and a trap. | 10 |
+| 7.2 | `resend/resend-php` hard require → drop (or `suggest`) | `composer.json`, `config/mail.php:64`, `config/services.php:46` | Zero app code touches it; only stock config scaffolding, zero `services.resend` reads. SMTP covers self-hosted. **−1 dependency.** | 5 |
+| 7.3 | `public` disk + `links` array | `config/filesystems.php:55,90` | `Storage::disk(config('filesystems.dists'))` in `ArchiveStore` is the only `Storage::` call in app/; `dists` resolves to `local\|s3` only. No `storage:link` anywhere. | 20 |
+| 7.4 | `STRIPE_PUBLISHABLE` env + services key | `config/services.php:65`, `.env.example:229` | Hosted-checkout only — no Stripe.js, no `loadStripe`, zero readers. | 2 |
+| 7.5 | Doc updates for the cuts above | `docs/merchant-drivers.md`, `docs/plans/ecommerce-subscriptions.md` | Both describe the merchant `StubClient` pattern and the full 12-method contract; rewrite those passages once batches 1–2 land. | — |
+
+**Batch total: ~37 lines, −1 dep**
+
+---
+
+## Explicitly kept (audited, not bloat)
+
+So nobody re-litigates these next audit:
+
+- **`EgressPolicy` / `BoundedSink` / `BoundedSinkWrapper`** — SSRF/zip-bomb guards; every method reachable, wrapper shape is dictated by PHP's stream-wrapper API.
+- **`PageMarkdown`** — not replaceable by `Str::markdown()`: escapes raw HTML from untrusted READMEs served on the admin origin, refuses `javascript:`/`data:` URLs, resolves relative links against the source repo.
+- **`VersionNormalizer` / `HttpTimeouts`** — real logic, every constant used (the `LOGIN == CONNECT` coincidence is semantic, not duplication).
+- **`HostResolver` interface** — one prod implementation but a real test seam (`FakeHostResolver` backs the whole egress test suite).
+- **`MerchantClient` interface itself** — two live implementations behind `MerchantProvider::client()`; keep, but it shrinks to ~5 methods after batch 2.
+- **`SubscriptionProjector`** — one public method but two genuinely different callers (webhook + reconciler); the `last_event_at` out-of-order guard is its reason to exist.
+- **`concurrently` npm dep** — *looks* unused, but the framework's `artisan dev` shells `npx concurrently` (vendor `DevCommand:199`). An earlier pass flagged it; overturned.
+- **`CancellationTiming::EndOfPeriod`** — no code reference, but it's a stored value selectable in Filament: data, not dead code.
+- All API Resources (explicit field lists keep encrypted casts off the wire), all middleware (custom token tables, dual-mount resolution), all 18 blade views, every `registry.php` config key, all Filament widgets/actions/relation managers, migrations (can't squash — v1.0.0–v1.3.9 are tagged), `composer/semver` + `composer/metadata-minifier` (spec behaviour, worse hand-rolled), `PruneCache` (Laravel ships no database-store sweeper).
+- **Empty `Controller` base class** — technically deletable, but touching 23 files to save 7 lines is churn, not laziness. Skip.
+
+## Tally
+
+| Batch | Theme | ~Lines |
+|-------|-------|-------:|
+| 1 | Pure deletes | 256 |
+| 2 | Dead merchant contract | 142 |
+| 3 | Gitea/Bitbucket stubs | 95 |
+| 4 | Shield policy surface | 309 |
+| 5 | Duplication | 343 |
+| 6 | Speculative billing values | 70 |
+| 7 | Config + deps | 37 |
+
+**net: ~-1,250 lines, -1 dep.**

--- a/resources/views/billing/index.blade.php
+++ b/resources/views/billing/index.blade.php
@@ -1,0 +1,132 @@
+<x-page-layout
+    :repository="$repository"
+    :title="'Billing — '.config('app.name')"
+    :summary="'Your subscriptions, invoices and access tokens.'"
+    :canonical="route('billing.index')"
+>
+    <header class="mb-10">
+        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">Billing</h1>
+        <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">Signed in as {{ $user->email }}</p>
+    </header>
+
+    @if (session('status'))
+        <div class="mb-8 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200">
+            {{ session('status') }}
+        </div>
+    @endif
+
+    @if (session('plainToken'))
+        <div class="mb-8 rounded-lg border border-emerald-300 bg-emerald-50 px-4 py-3 dark:border-emerald-700 dark:bg-emerald-950">
+            <p class="text-sm font-medium text-emerald-900 dark:text-emerald-100">Your new token — copy it now, it is shown once:</p>
+            <pre class="mt-2 overflow-x-auto rounded bg-zinc-900 px-3 py-2 text-sm text-zinc-100"><code>{{ session('plainToken') }}</code></pre>
+        </div>
+    @endif
+
+    @if ($user->email_verified_at === null)
+        <div class="mb-8 rounded-lg border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
+            Your email address is not verified yet — buying needs a verified address.
+            <form method="POST" action="{{ route('billing.verify.resend') }}" class="mt-2">
+                @csrf
+                <button type="submit" class="underline underline-offset-2">Resend the verification email</button>
+            </form>
+        </div>
+    @endif
+
+    <section class="mb-10">
+        <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">Subscriptions</h2>
+
+        @if ($customer === null || $customer->subscriptions->isEmpty())
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+                No subscriptions yet — <a href="{{ route('pages.pricing') }}" class="underline underline-offset-2">see what is available</a>.
+            </p>
+        @else
+            <ul class="divide-y divide-zinc-100 rounded-xl border border-zinc-200 dark:divide-zinc-900 dark:border-zinc-800">
+                @foreach ($customer->subscriptions as $subscription)
+                    <li class="px-5 py-4">
+                        <div class="flex items-center justify-between gap-4">
+                            <div>
+                                <span class="font-medium text-zinc-900 dark:text-white">{{ $subscription->plan->name }}</span>
+                                <span class="ml-2 rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-900 dark:text-zinc-400">{{ $subscription->status->getLabel() }}</span>
+                            </div>
+                            @if ($subscription->price)
+                                <span class="text-sm text-zinc-500 dark:text-zinc-400">{{ $subscription->price->display() }}</span>
+                            @endif
+                        </div>
+
+                        @if ($subscription->current_period_end)
+                            <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                                {{ $subscription->cancel_at ? 'Ends' : 'Renews' }} {{ $subscription->current_period_end->toFormattedDateString() }}
+                            </p>
+                        @endif
+
+                        @if ($subscription->grantsAccess())
+                            <form method="POST" action="{{ route('billing.tokens.store', $subscription) }}" class="mt-3 flex items-center gap-2">
+                                @csrf
+                                <input type="text" name="name" required placeholder="Token name (e.g. CI)"
+                                    class="rounded-lg border border-zinc-300 bg-white px-3 py-1.5 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white">
+                                <button type="submit" class="rounded-lg border border-zinc-300 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-900">
+                                    New token
+                                </button>
+                                @if ($subscription->plan->token_limit !== null)
+                                    <span class="text-xs text-zinc-500 dark:text-zinc-400">{{ $subscription->tokens()->count() }}/{{ $subscription->plan->token_limit }} used</span>
+                                @endif
+                            </form>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        @endif
+    </section>
+
+    @if ($tokens->isNotEmpty())
+        <section class="mb-10">
+            <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">Access tokens</h2>
+            <ul class="divide-y divide-zinc-100 rounded-xl border border-zinc-200 dark:divide-zinc-900 dark:border-zinc-800">
+                @foreach ($tokens as $token)
+                    <li class="flex items-center justify-between gap-4 px-5 py-3">
+                        <div>
+                            <span class="text-sm font-medium text-zinc-900 dark:text-white">{{ $token->name }}</span>
+                            <span class="ml-2 font-mono text-xs text-zinc-500 dark:text-zinc-400">{{ $token->token_prefix }}…</span>
+                            @if ($token->last_used_at)
+                                <span class="ml-2 text-xs text-zinc-500 dark:text-zinc-400">last used {{ $token->last_used_at->diffForHumans() }}</span>
+                            @endif
+                        </div>
+                        <form method="POST" action="{{ route('billing.tokens.destroy', $token) }}">
+                            @csrf
+                            @method('DELETE')
+                            <button type="submit" class="text-sm text-red-600 underline-offset-2 hover:underline dark:text-red-400">Revoke</button>
+                        </form>
+                    </li>
+                @endforeach
+            </ul>
+        </section>
+    @endif
+
+    @if ($customer !== null && $customer->merchant->supportsPortal())
+        <section class="mb-10">
+            <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">Payment</h2>
+            <p class="text-sm text-zinc-600 dark:text-zinc-400">
+                <a href="{{ route('billing.portal') }}" class="underline underline-offset-2">Manage your card, cancel, or download invoices</a> — handled securely by the payment provider.
+            </p>
+        </section>
+    @endif
+
+    @if ($customer !== null && $customer->invoices->isNotEmpty())
+        <section>
+            <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">Invoices</h2>
+            <ul class="divide-y divide-zinc-100 rounded-xl border border-zinc-200 dark:divide-zinc-900 dark:border-zinc-800">
+                @foreach ($customer->invoices as $invoice)
+                    <li class="flex items-center justify-between gap-4 px-5 py-3 text-sm">
+                        <span class="text-zinc-900 dark:text-white">{{ $invoice->number ?? 'Invoice' }}</span>
+                        <span class="text-zinc-500 dark:text-zinc-400">{{ $invoice->issued_at?->toFormattedDateString() }}</span>
+                        <span class="text-zinc-900 dark:text-white">{{ strtoupper($invoice->currency) }} {{ number_format($invoice->total / 100, 2) }}</span>
+                        <span class="text-zinc-500 dark:text-zinc-400">{{ $invoice->status }}</span>
+                        @if ($invoice->hosted_url)
+                            <a href="{{ $invoice->hosted_url }}" target="_blank" rel="noopener" class="underline underline-offset-2">View</a>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        </section>
+    @endif
+</x-page-layout>

--- a/resources/views/billing/register.blade.php
+++ b/resources/views/billing/register.blade.php
@@ -1,0 +1,63 @@
+<x-page-layout
+    :repository="$repository"
+    :title="'Create an account — '.config('app.name')"
+    :summary="'Create an account to subscribe to packages on '.config('app.name')"
+    :canonical="route('billing.register')"
+>
+    <header class="mb-10">
+        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
+            Create an account
+        </h1>
+        <p class="mt-4 text-zinc-600 dark:text-zinc-400">
+            An account holds your subscriptions, invoices and access tokens.
+            Already have one? <a href="{{ route('filament.admin.auth.login') }}" class="underline underline-offset-2">Sign in</a>.
+        </p>
+    </header>
+
+    <form method="POST" action="{{ route('billing.register.store') }}" class="max-w-md space-y-5">
+        @csrf
+
+        {{-- The honeypot: hidden from people, filled by bots. --}}
+        <div class="hidden" aria-hidden="true">
+            <label>Website<input type="text" name="website" tabindex="-1" autocomplete="off"></label>
+        </div>
+
+        <div>
+            <label for="name" class="block text-sm font-medium text-zinc-900 dark:text-white">Name</label>
+            <input id="name" name="name" type="text" required value="{{ old('name') }}"
+                class="mt-1 w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white">
+            @error('name')<p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <label for="email" class="block text-sm font-medium text-zinc-900 dark:text-white">Email</label>
+            <input id="email" name="email" type="email" required value="{{ old('email') }}"
+                class="mt-1 w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white">
+            @error('email')<p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <label for="password" class="block text-sm font-medium text-zinc-900 dark:text-white">Password</label>
+            <input id="password" name="password" type="password" required autocomplete="new-password"
+                class="mt-1 w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white">
+            <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">At least 12 characters.</p>
+            @error('password')<p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</p>@enderror
+        </div>
+
+        <div>
+            <label for="password_confirmation" class="block text-sm font-medium text-zinc-900 dark:text-white">Confirm password</label>
+            <input id="password_confirmation" name="password_confirmation" type="password" required autocomplete="new-password"
+                class="mt-1 w-full rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white">
+        </div>
+
+        @if (config('registry.billing.terms_url'))
+            <p class="text-xs text-zinc-500 dark:text-zinc-400">
+                By creating an account you agree to the <a href="{{ config('registry.billing.terms_url') }}" class="underline underline-offset-2">terms of service</a>.
+            </p>
+        @endif
+
+        <button type="submit" class="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200">
+            Create account
+        </button>
+    </form>
+</x-page-layout>

--- a/resources/views/billing/welcome.blade.php
+++ b/resources/views/billing/welcome.blade.php
@@ -1,0 +1,46 @@
+<x-page-layout
+    :repository="$repository"
+    :title="'Welcome — '.config('app.name')"
+    :summary="'Your purchase is complete.'"
+    :canonical="route('billing.welcome')"
+>
+    @if ($subscription === null)
+        {{-- The completion webhook is racing this redirect and has not landed
+             yet; the page refreshes itself until it does. --}}
+        <meta http-equiv="refresh" content="3">
+
+        <header class="mb-10">
+            <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">Finalizing your purchase…</h1>
+            <p class="mt-4 text-zinc-600 dark:text-zinc-400">
+                The payment went through and your subscription is being set up. This page refreshes itself — it usually takes a few seconds.
+            </p>
+        </header>
+    @else
+        <header class="mb-10">
+            <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
+                You're in
+            </h1>
+            <p class="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+                Your {{ $subscription->plan->name }} subscription is active.
+            </p>
+        </header>
+
+        @if ($plainToken !== null)
+            <section class="mb-10 rounded-xl border border-emerald-300 dark:border-emerald-700">
+                <h2 class="border-b border-emerald-200 px-5 py-3 text-sm font-semibold text-zinc-900 dark:border-emerald-800 dark:text-white">
+                    Your access token — shown once, copy it now
+                </h2>
+                <div class="space-y-3 px-5 py-4">
+                    <pre class="overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>{{ $plainToken }}</code></pre>
+                    <p class="text-sm text-zinc-600 dark:text-zinc-400">Tell Composer about it, then require your packages as usual:</p>
+                    <pre class="overflow-x-auto rounded-lg bg-zinc-900 px-4 py-3 text-sm text-zinc-100"><code>composer config --global http-basic.{{ parse_url($registryUrl, PHP_URL_HOST) }} token {{ $plainToken }}
+composer config repositories.{{ \Illuminate\Support\Str::slug(config('app.name')) }} composer {{ $registryUrl }}</code></pre>
+                </div>
+            </section>
+        @endif
+
+        <p class="text-sm text-zinc-600 dark:text-zinc-400">
+            Tokens, invoices and your card live in <a href="{{ route('billing.index') }}" class="underline underline-offset-2">your billing area</a>.
+        </p>
+    @endif
+</x-page-layout>

--- a/resources/views/pages/plan.blade.php
+++ b/resources/views/pages/plan.blade.php
@@ -1,0 +1,80 @@
+<x-page-layout
+    :repository="$repository"
+    :title="$plan->name.' — '.config('app.name')"
+    :summary="$plan->description ?: 'A plan on '.config('app.name')"
+    :canonical="$canonical"
+    og-type="product"
+>
+    <header class="mb-10">
+        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
+            {{ $plan->name }}
+        </h1>
+
+        @if (filled($plan->description))
+            <p class="mt-4 text-lg text-zinc-600 dark:text-zinc-400">{{ $plan->description }}</p>
+        @endif
+    </header>
+
+    <section class="mb-10 rounded-xl border border-zinc-200 dark:border-zinc-800">
+        <h2 class="border-b border-zinc-200 px-5 py-3 text-sm font-semibold text-zinc-900 dark:border-zinc-800 dark:text-white">
+            Buy
+        </h2>
+        <div class="divide-y divide-zinc-100 dark:divide-zinc-900">
+            @forelse ($plan->prices as $price)
+                <div class="flex items-center justify-between gap-4 px-5 py-4">
+                    <div>
+                        <p class="font-medium text-zinc-900 dark:text-white">{{ $price->display() }}</p>
+                        @if ($plan->trial_days > 0 && $price->interval->recurring())
+                            <p class="text-xs text-zinc-500 dark:text-zinc-400">Starts with a {{ $plan->trial_days }}-day free trial</p>
+                        @endif
+                        @if ($plan->billing_model === \App\Enums\BillingModel::OneTimeWithUpdates)
+                            <p class="text-xs text-zinc-500 dark:text-zinc-400">Includes {{ $plan->updates_window_months }} months of updates; what you have then is yours forever.</p>
+                        @endif
+                    </div>
+
+                    @auth
+                        <form method="POST" action="{{ route('billing.checkout', $price) }}">
+                            @csrf
+                            <button type="submit" class="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200">
+                                Subscribe
+                            </button>
+                        </form>
+                    @else
+                        <a href="{{ config('registry.billing.public_signup') ? route('billing.register') : route('filament.admin.auth.login') }}" class="rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-200">
+                            Sign {{ config('registry.billing.public_signup') ? 'up' : 'in' }} to buy
+                        </a>
+                    @endauth
+                </div>
+            @empty
+                <p class="px-5 py-4 text-sm text-zinc-500 dark:text-zinc-400">Not on sale right now.</p>
+            @endforelse
+        </div>
+    </section>
+
+    @if ($plan->packages->isNotEmpty() || $plan->repositories->isNotEmpty())
+        <section>
+            <h2 class="mb-3 text-sm font-semibold text-zinc-900 dark:text-white">What it grants</h2>
+
+            <ul class="divide-y divide-zinc-100 rounded-xl border border-zinc-200 dark:divide-zinc-900 dark:border-zinc-800">
+                @foreach ($plan->repositories as $granted)
+                    <li class="px-5 py-4">
+                        <span class="font-medium text-zinc-900 dark:text-white">{{ $granted->name }}</span>
+                        <span class="ml-2 text-xs text-zinc-500 dark:text-zinc-400">every package in the repository, present and future</span>
+                    </li>
+                @endforeach
+                @foreach ($plan->packages as $granted)
+                    <li class="px-5 py-4">
+                        @if ($granted->page_enabled)
+                            <a href="{{ $granted->pageUrl() }}" class="font-medium text-zinc-900 underline-offset-2 hover:underline dark:text-white">{{ $granted->name }}</a>
+                        @else
+                            <span class="font-medium text-zinc-900 dark:text-white">{{ $granted->name }}</span>
+                        @endif
+                        @if (filled($granted->description))
+                            <p class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">{{ $granted->description }}</p>
+                        @endif
+                    </li>
+                @endforeach
+            </ul>
+        </section>
+    @endif
+</x-page-layout>

--- a/resources/views/pages/pricing.blade.php
+++ b/resources/views/pages/pricing.blade.php
@@ -1,0 +1,39 @@
+<x-page-layout
+    :repository="$repository"
+    :title="'Pricing — '.config('app.name')"
+    :summary="'Plans and pricing for the packages this registry publishes.'"
+    :canonical="$canonical"
+>
+    <header class="mb-10">
+        <h1 class="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
+            Pricing
+        </h1>
+        <p class="mt-4 text-lg text-zinc-600 dark:text-zinc-400">
+            A subscription grants access to the packages its plan includes, installable with Composer the moment checkout completes.
+        </p>
+    </header>
+
+    @if ($plans->isEmpty())
+        <p class="text-sm text-zinc-500 dark:text-zinc-400">Nothing is on sale right now.</p>
+    @else
+        <div class="grid gap-6 sm:grid-cols-2">
+            @foreach ($plans as $plan)
+                <a href="{{ route('pages.pricing.plan', $plan) }}" class="block rounded-xl border border-zinc-200 p-6 hover:border-zinc-400 dark:border-zinc-800 dark:hover:border-zinc-600">
+                    <h2 class="text-lg font-semibold text-zinc-900 dark:text-white">{{ $plan->name }}</h2>
+
+                    @if (filled($plan->description))
+                        <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{{ $plan->description }}</p>
+                    @endif
+
+                    <p class="mt-4 text-sm font-medium text-zinc-900 dark:text-white">
+                        {{ $plan->prices->map->display()->join(' · ') ?: 'Contact us' }}
+                    </p>
+
+                    @if ($plan->trial_days > 0)
+                        <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{{ $plan->trial_days }}-day free trial</p>
+                    @endif
+                </a>
+            @endforeach
+        </div>
+    @endif
+</x-page-layout>

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Activity;
+use App\Models\MerchantEvent;
 use App\Models\Notification;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -95,8 +96,18 @@ Schedule::command('mirror:prune')
 // The audit log is append-only by design — nothing in the app updates or
 // deletes an entry — so it needs the same treatment, with a much longer
 // retention: the questions it answers are asked months after the change.
-Schedule::command('model:prune', ['--model' => [Notification::class, Activity::class]])
+Schedule::command('model:prune', ['--model' => [Notification::class, Activity::class, MerchantEvent::class]])
     ->dailyAt('03:30')
+    ->onOneServer();
+
+// The safety net under the billing webhooks, and the clock for everything
+// local: re-pulls merchant-billed subscriptions, crosses the boundaries
+// nobody webhooks about (grace running out, a Manual period ending, an
+// updates window closing), and sends the trial-ending warnings. A no-op in
+// one query while billing is disabled.
+Schedule::command('billing:reconcile')
+    ->dailyAt('04:00')
+    ->withoutOverlapping(60)
     ->onOneServer();
 
 // The fastest-growing table in the schema, and the last one to get a bound:

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,18 +1,18 @@
 <?php
 
-use App\Http\Controllers\DownloadExportController;
-use App\Http\Controllers\GitHubWebhookController;
-use App\Http\Controllers\GitLabWebhookController;
 use App\Http\Controllers\Billing\BillingController;
 use App\Http\Controllers\Billing\CheckoutController;
 use App\Http\Controllers\Billing\RegisterController;
 use App\Http\Controllers\Billing\SubscriptionTokenController;
 use App\Http\Controllers\Billing\WelcomeController;
+use App\Http\Controllers\DownloadExportController;
+use App\Http\Controllers\GitHubWebhookController;
+use App\Http\Controllers\GitLabWebhookController;
 use App\Http\Controllers\MerchantWebhookController;
-use App\Http\Controllers\Pages\PricingController;
 use App\Http\Controllers\Pages\PackageArchiveController;
 use App\Http\Controllers\Pages\PackageAssetController;
 use App\Http\Controllers\Pages\PackagePageController;
+use App\Http\Controllers\Pages\PricingController;
 use App\Http\Controllers\Pages\RepositoryPageController;
 use App\Http\Controllers\Pages\SitemapController;
 use App\Http\Controllers\PasswordSetupController;

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,13 @@
 use App\Http\Controllers\DownloadExportController;
 use App\Http\Controllers\GitHubWebhookController;
 use App\Http\Controllers\GitLabWebhookController;
+use App\Http\Controllers\Billing\BillingController;
+use App\Http\Controllers\Billing\CheckoutController;
+use App\Http\Controllers\Billing\RegisterController;
+use App\Http\Controllers\Billing\SubscriptionTokenController;
+use App\Http\Controllers\Billing\WelcomeController;
+use App\Http\Controllers\MerchantWebhookController;
+use App\Http\Controllers\Pages\PricingController;
 use App\Http\Controllers\Pages\PackageArchiveController;
 use App\Http\Controllers\Pages\PackageAssetController;
 use App\Http\Controllers\Pages\PackagePageController;
@@ -111,6 +118,44 @@ Route::middleware('throttle:webhooks')->group(function (): void {
     // header rather than signing the body.
     Route::post('/incoming/gitlab/{package}', [GitLabWebhookController::class, 'repository'])
         ->name('webhooks.gitlab.package');
+});
+
+// The payment merchant's webhook — Stripe's, or a future driver's, resolved
+// by the path segment. Signature verification is the whole of the
+// authentication here too, so it shares the webhook throttle's reasoning
+// with its own limiter: these deliveries are rarer and each one costs a
+// signature check plus a row.
+Route::post('/billing/{merchant}/webhook', MerchantWebhookController::class)
+    ->middleware('throttle:merchant-webhooks')
+    ->name('webhooks.merchant');
+
+// The commercial surface. Pricing is public like the package pages and on
+// their throttle; registration exists only while public signup is switched
+// on; and everything under /billing is the customer area — a signed-in
+// surface deliberately outside /admin, because buying access must never
+// grant a seat in the ops tooling.
+Route::middleware('throttle:pages')->group(function (): void {
+    Route::get('/pricing', [PricingController::class, 'index'])->name('pages.pricing');
+    Route::get('/pricing/{plan:slug}', [PricingController::class, 'show'])->name('pages.pricing.plan');
+    Route::get('/register', [RegisterController::class, 'show'])->name('billing.register');
+});
+
+Route::post('/register', [RegisterController::class, 'store'])
+    ->middleware('throttle:registration')
+    ->name('billing.register.store');
+
+Route::get('/billing/verify/{user}', [RegisterController::class, 'verify'])
+    ->middleware('throttle:pages')
+    ->name('billing.verify');
+
+Route::middleware('auth')->prefix('billing')->name('billing.')->group(function (): void {
+    Route::get('/', [BillingController::class, 'index'])->name('index');
+    Route::get('/portal', [BillingController::class, 'portal'])->name('portal');
+    Route::get('/welcome', WelcomeController::class)->name('welcome');
+    Route::post('/verify/resend', [RegisterController::class, 'resend'])->name('verify.resend');
+    Route::post('/checkout/{price}', [CheckoutController::class, 'store'])->name('checkout');
+    Route::post('/subscriptions/{subscription}/tokens', [SubscriptionTokenController::class, 'store'])->name('tokens.store');
+    Route::delete('/tokens/{token}', [SubscriptionTokenController::class, 'destroy'])->name('tokens.destroy');
 });
 
 // The SSO round trip for runtime-configured login providers. The login page

--- a/tests/Feature/AuditLogTest.php
+++ b/tests/Feature/AuditLogTest.php
@@ -493,7 +493,7 @@ class AuditLogTest extends TestCase
 
         $this->get('/admin/activities')
             ->assertOk()
-            ->assertSee('including records you cannot reach elsewhere', escape: false);
+            ->assertSee('A complete history of every change in the registry', escape: false);
     }
 
     /**

--- a/tests/Feature/BillingEntitlementScopingTest.php
+++ b/tests/Feature/BillingEntitlementScopingTest.php
@@ -33,7 +33,7 @@ use Tests\TestCase;
  * never disturbed in either direction; and running the projector twice is
  * running it once.
  *
- * @see \App\Services\Billing\EntitlementProjector
+ * @see EntitlementProjector
  * @see docs/plans/ecommerce-subscriptions.md
  */
 class BillingEntitlementScopingTest extends TestCase
@@ -68,6 +68,9 @@ class BillingEntitlementScopingTest extends TestCase
         ]);
     }
 
+    /**
+     * @param  list<string>  $versions
+     */
     private function makePackage(string $name, Repository $repository, array $versions): Package
     {
         $package = Package::factory()->create(['name' => $name, 'repository_id' => $repository->id]);

--- a/tests/Feature/BillingEntitlementScopingTest.php
+++ b/tests/Feature/BillingEntitlementScopingTest.php
@@ -1,0 +1,493 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\GrantSource;
+use App\Enums\LapseBehaviour;
+use App\Enums\SubscriptionStatus;
+use App\Enums\TokenAbility;
+use App\Models\BillingCustomer;
+use App\Models\Package;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Repository;
+use App\Models\Subscription;
+use App\Models\Team;
+use App\Models\Token;
+use App\Models\User;
+use App\Services\Billing\EntitlementProjector;
+use App\Services\Billing\SubscriptionTokens;
+use App\Services\Billing\VersionCeiling;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Subscriptions grant access by projection into the grant pivots, and the
+ * projector is the one writer of every row whose source says 'subscription'.
+ *
+ * These are the promises the whole commercial layer stands on: an active
+ * subscription makes its plan's packages visible through the same chokepoint
+ * every read already uses; lapsing withdraws exactly what the plan's lapse
+ * behaviour says and nothing else; a manual grant on the same package is
+ * never disturbed in either direction; and running the projector twice is
+ * running it once.
+ *
+ * @see \App\Services\Billing\EntitlementProjector
+ * @see docs/plans/ecommerce-subscriptions.md
+ */
+class BillingEntitlementScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $paid;
+
+    private Package $widgets;
+
+    private Package $gadgets;
+
+    private Package $unrelated;
+
+    private Plan $plan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paid = Repository::factory()->create(['path' => 'paid', 'public' => false]);
+        $other = Repository::factory()->create(['path' => 'other', 'public' => false]);
+
+        $this->widgets = $this->makePackage('acme/widgets', $this->paid, ['1.0.0', '1.1.0']);
+        $this->gadgets = $this->makePackage('acme/gadgets', $this->paid, ['2.0.0']);
+        $this->unrelated = $this->makePackage('acme/unrelated', $other, ['1.0.0']);
+
+        $this->plan = Plan::factory()->create();
+        $this->plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+    }
+
+    private function makePackage(string $name, Repository $repository, array $versions): Package
+    {
+        $package = Package::factory()->create(['name' => $name, 'repository_id' => $repository->id]);
+
+        foreach ($versions as $version) {
+            $package->versions()->create([
+                'version' => $version,
+                'reference' => sha1($name.$version),
+                'is_dev' => false,
+                'metadata' => ['name' => $name, 'version' => $version],
+            ]);
+        }
+
+        return $package;
+    }
+
+    private function subscribe(User|Team $billable, ?Plan $plan = null, SubscriptionStatus $status = SubscriptionStatus::Active): Subscription
+    {
+        $plan ??= $this->plan;
+
+        $customer = BillingCustomer::factory()->create([
+            'billable_type' => $billable->getMorphClass(),
+            'billable_id' => $billable->getKey(),
+        ]);
+
+        return Subscription::factory()
+            ->status($status)
+            ->create([
+                'billing_customer_id' => $customer->getKey(),
+                'plan_id' => $plan->getKey(),
+                'plan_price_id' => PlanPrice::factory()->create(['plan_id' => $plan->getKey()])->getKey(),
+            ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reach(User $user): array
+    {
+        return Package::query()->visibleToUser($user)->orderBy('name')->pluck('name')->all();
+    }
+
+    public function test_an_active_subscription_grants_the_plans_packages(): void
+    {
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user);
+
+        (new EntitlementProjector)->project($subscription);
+
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+        $this->assertDatabaseHas('package_user', [
+            'package_id' => $this->widgets->getKey(),
+            'user_id' => $user->getKey(),
+            'source' => GrantSource::Subscription->value,
+        ]);
+    }
+
+    public function test_a_repository_entitlement_grants_the_whole_repository(): void
+    {
+        $plan = Plan::factory()->create();
+        $plan->entitlements()->create([
+            'grantable_type' => Repository::class,
+            'grantable_id' => $this->paid->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        (new EntitlementProjector)->project($this->subscribe($user, $plan));
+
+        $this->assertSame(['acme/gadgets', 'acme/widgets'], $this->reach($user));
+    }
+
+    public function test_lapsing_withdraws_the_entitlement_and_only_the_entitlement(): void
+    {
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Canceled])->save();
+        $projector->project($subscription);
+
+        $this->assertSame([], $this->reach($user));
+    }
+
+    public function test_a_manual_grant_on_the_same_package_survives_the_lapse(): void
+    {
+        $user = User::factory()->create();
+        $user->packages()->attach($this->widgets);
+
+        $subscription = $this->subscribe($user);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+
+        // Granted twice — by hand and by subscription — and visible once.
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+        $this->assertSame(2, DB::table('package_user')->where('user_id', $user->getKey())->count());
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Canceled])->save();
+        $projector->project($subscription);
+
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+        $this->assertDatabaseHas('package_user', [
+            'package_id' => $this->widgets->getKey(),
+            'user_id' => $user->getKey(),
+            'source' => GrantSource::Manual->value,
+        ]);
+    }
+
+    public function test_the_projector_never_touches_manual_grants_going_the_other_way(): void
+    {
+        $user = User::factory()->create();
+        $user->packages()->attach($this->unrelated);
+
+        (new EntitlementProjector)->project($this->subscribe($user));
+
+        $this->assertSame(['acme/unrelated', 'acme/widgets'], $this->reach($user));
+    }
+
+    public function test_a_team_subscription_grants_to_every_member_through_the_team(): void
+    {
+        $team = Team::factory()->create();
+        $member = User::factory()->create();
+        $outsider = User::factory()->create();
+        $team->users()->attach($member);
+
+        (new EntitlementProjector)->project($this->subscribe($team));
+
+        $this->assertSame(['acme/widgets'], $this->reach($member));
+        $this->assertSame([], $this->reach($outsider));
+
+        // Membership churn behaves exactly as manual team grants do.
+        $team->users()->detach($member);
+        $this->assertSame([], $this->reach($member->fresh()));
+    }
+
+    public function test_suspension_withdraws_access_even_when_lapse_would_keep_it(): void
+    {
+        $plan = Plan::factory()->create(['lapse_behaviour' => LapseBehaviour::None]);
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+
+        $subscription->forceFill(['suspended_at' => now(), 'suspension_reason' => 'dispute'])->save();
+        $projector->project($subscription);
+
+        $this->assertSame([], $this->reach($user));
+
+        // Unsuspending restores everything.
+        $subscription->forceFill(['suspended_at' => null, 'suspension_reason' => null])->save();
+        $projector->project($subscription);
+
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+    }
+
+    public function test_lapse_behaviour_none_keeps_the_grants(): void
+    {
+        $plan = Plan::factory()->create(['lapse_behaviour' => LapseBehaviour::None]);
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+        $subscription->forceFill(['status' => SubscriptionStatus::Canceled])->save();
+        $projector->project($subscription);
+
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+    }
+
+    public function test_revoke_tokens_revokes_the_subscriptions_tokens_and_no_others(): void
+    {
+        $plan = Plan::factory()->create(['lapse_behaviour' => LapseBehaviour::RevokeTokens]);
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $projector = new EntitlementProjector;
+        $projector->project($subscription);
+
+        $subscriptionToken = (new SubscriptionTokens)->issueActivationToken($subscription);
+        $personal = Token::issue($user, 'laptop', [TokenAbility::RepositoryRead]);
+
+        $this->assertNotNull($subscriptionToken);
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Unpaid])->save();
+        $projector->project($subscription);
+
+        $this->assertNull(Token::findByPlainText($subscriptionToken->plainText));
+        $this->assertNotNull(Token::findByPlainText($personal->plainText));
+        $this->assertSame([], $this->reach($user));
+    }
+
+    public function test_freeze_at_version_pins_a_ceiling_and_keeps_the_grant(): void
+    {
+        $plan = Plan::factory()->perpetual()->create();
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+        $subscription->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        $projector->project($subscription);
+
+        // Still granted — the licence is perpetual — but pinned.
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+
+        $entitlement = $subscription->entitlements()
+            ->where('grantable_type', Package::class)
+            ->where('grantable_id', $this->widgets->getKey())
+            ->sole();
+
+        $this->assertTrue((bool) $entitlement->active);
+        $this->assertNotNull($entitlement->version_ceiling);
+
+        // The pin is the highest version that existed at the freeze: 1.1.0
+        // is inside it, and a release cut afterwards is not.
+        $ceilings = new VersionCeiling;
+        $onePointOne = $this->widgets->versions()->where('version', '1.1.0')->sole();
+        $this->assertTrue($ceilings->permits($onePointOne, $entitlement->version_ceiling));
+
+        $newer = $this->widgets->versions()->create([
+            'version' => '2.0.0',
+            'reference' => sha1('acme/widgets2.0.0'),
+            'is_dev' => false,
+            'metadata' => ['name' => 'acme/widgets', 'version' => '2.0.0'],
+        ]);
+        $this->assertFalse($ceilings->permits($newer, $entitlement->version_ceiling));
+
+        // A second projection must not move the pin.
+        $before = $entitlement->version_ceiling;
+        $projector->project($subscription);
+        $this->assertSame($before, $entitlement->fresh()->version_ceiling);
+    }
+
+    public function test_a_frozen_repository_grant_expands_to_the_packages_it_held(): void
+    {
+        $plan = Plan::factory()->perpetual()->create();
+        $plan->entitlements()->create([
+            'grantable_type' => Repository::class,
+            'grantable_id' => $this->paid->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+        $this->assertSame(['acme/gadgets', 'acme/widgets'], $this->reach($user));
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        $projector->project($subscription);
+
+        // Both packages stay reachable, each behind its own ceiling; the
+        // repository-wide grant is gone, so a package added to the
+        // repository after the freeze is never granted.
+        $this->assertSame(['acme/gadgets', 'acme/widgets'], $this->reach($user));
+
+        $latecomer = $this->makePackage('acme/latecomer', $this->paid, ['1.0.0']);
+        $projector->project($subscription);
+
+        $this->assertSame(['acme/gadgets', 'acme/widgets'], $this->reach($user));
+        $this->assertNotContains($latecomer->name, $this->reach($user));
+
+        // Renewal restores the repository grant and retires the expansion.
+        $subscription->forceFill(['status' => SubscriptionStatus::Active])->save();
+        $projector->project($subscription);
+
+        $this->assertSame(['acme/gadgets', 'acme/latecomer', 'acme/widgets'], $this->reach($user));
+        $this->assertNull(
+            $subscription->entitlements()
+                ->where('grantable_type', Repository::class)
+                ->sole()
+                ->version_ceiling,
+        );
+    }
+
+    public function test_grace_keeps_access_until_it_runs_out(): void
+    {
+        $plan = Plan::factory()->create(['grace_days' => 14]);
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $projector = new EntitlementProjector;
+        $projector->project($subscription);
+
+        // The merchant gave up, but the plan's grace clock is still running.
+        $subscription->forceFill([
+            'status' => SubscriptionStatus::Unpaid,
+            'grace_ends_at' => now()->addDays(14),
+        ])->save();
+        $projector->project($subscription);
+
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+
+        // The clock ran out.
+        $subscription->forceFill(['grace_ends_at' => now()->subMinute()])->save();
+        $projector->project($subscription);
+
+        $this->assertSame([], $this->reach($user));
+    }
+
+    public function test_two_subscriptions_granting_one_package_withdraw_independently(): void
+    {
+        $user = User::factory()->create();
+
+        $first = $this->subscribe($user);
+
+        $secondPlan = Plan::factory()->create();
+        $secondPlan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+        $customer = $first->customer;
+        $second = Subscription::factory()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'plan_id' => $secondPlan->getKey(),
+            'plan_price_id' => PlanPrice::factory()->create(['plan_id' => $secondPlan->getKey()])->getKey(),
+        ]);
+
+        $projector = new EntitlementProjector;
+        $projector->projectCustomer($customer);
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+
+        // One lapses; the other still holds the grant.
+        $first->forceFill(['status' => SubscriptionStatus::Canceled])->save();
+        $projector->projectCustomer($customer->fresh());
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+
+        // Both lapsed; the grant goes.
+        $second->forceFill(['status' => SubscriptionStatus::Canceled])->save();
+        $projector->projectCustomer($customer->fresh());
+        $this->assertSame([], $this->reach($user));
+    }
+
+    public function test_editing_the_plan_reprojects_onto_active_subscriptions(): void
+    {
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user);
+        $projector = new EntitlementProjector;
+        $projector->project($subscription);
+
+        $this->plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->gadgets->getKey(),
+        ]);
+        $projector->project($subscription->fresh());
+
+        $this->assertSame(['acme/gadgets', 'acme/widgets'], $this->reach($user));
+
+        $this->plan->entitlements()->where('grantable_id', $this->gadgets->getKey())->delete();
+        $projector->project($subscription->fresh());
+
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+    }
+
+    public function test_projection_is_idempotent(): void
+    {
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user);
+        $projector = new EntitlementProjector;
+
+        $projector->project($subscription);
+        $rows = DB::table('package_user')->where('user_id', $user->getKey())->count();
+
+        $projector->project($subscription);
+        $projector->project($subscription);
+
+        $this->assertSame($rows, DB::table('package_user')->where('user_id', $user->getKey())->count());
+        $this->assertSame(['acme/widgets'], $this->reach($user));
+    }
+
+    public function test_the_token_limit_caps_issuance_and_revocation_frees_a_seat(): void
+    {
+        $plan = Plan::factory()->create(['token_limit' => 2]);
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $subscription = $this->subscribe($user, $plan);
+        $tokens = new SubscriptionTokens;
+
+        $first = $tokens->issueActivationToken($subscription);
+        $second = $tokens->issueFor($subscription, 'ci');
+        $third = $tokens->issueFor($subscription, 'one too many');
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertNull($third);
+
+        // Revoking one frees its seat.
+        $first->token->delete();
+        $this->assertNotNull($tokens->issueFor($subscription, 'replacement'));
+    }
+}

--- a/tests/Feature/CustomerAreaTest.php
+++ b/tests/Feature/CustomerAreaTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\SubscriptionStatus;
+use App\Models\BillingCustomer;
+use App\Models\Invoice;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Subscription;
+use App\Models\Token;
+use App\Models\User;
+use App\Services\Billing\SubscriptionTokens;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * The /billing customer area: each customer sees their own commercial
+ * records and nobody else's, and token management respects the plan's cap
+ * and the subscription's state.
+ */
+class CustomerAreaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['registry.billing.enabled' => true]);
+    }
+
+    /**
+     * @return array{0: User, 1: BillingCustomer, 2: Subscription}
+     */
+    private function customer(?Plan $plan = null): array
+    {
+        $plan ??= Plan::factory()->create(['token_limit' => 2]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $customer = BillingCustomer::factory()->create([
+            'billable_type' => $user->getMorphClass(),
+            'billable_id' => $user->getKey(),
+        ]);
+
+        $subscription = Subscription::factory()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'plan_id' => $plan->getKey(),
+            'plan_price_id' => PlanPrice::factory()->create(['plan_id' => $plan->getKey()])->getKey(),
+        ]);
+
+        return [$user, $customer, $subscription];
+    }
+
+    public function test_the_area_shows_own_subscriptions_and_invoices_only(): void
+    {
+        [$user, $customer, $subscription] = $this->customer(Plan::factory()->create(['name' => 'Mine']));
+        Invoice::factory()->create(['billing_customer_id' => $customer->getKey(), 'number' => 'INV-MINE']);
+
+        [, $otherCustomer] = $this->customer(Plan::factory()->create(['name' => 'Theirs']));
+        Invoice::factory()->create(['billing_customer_id' => $otherCustomer->getKey(), 'number' => 'INV-THEIRS']);
+
+        $this->actingAs($user)->get('/billing')
+            ->assertOk()
+            ->assertSee('Mine')
+            ->assertSee('INV-MINE')
+            ->assertDontSee('Theirs')
+            ->assertDontSee('INV-THEIRS');
+    }
+
+    public function test_tokens_are_minted_inside_the_cap_and_shown_once(): void
+    {
+        [$user, , $subscription] = $this->customer();
+
+        $first = $this->actingAs($user)->post("/billing/subscriptions/{$subscription->getKey()}/tokens", ['name' => 'CI']);
+        $first->assertRedirect()->assertSessionHas('plainToken');
+
+        $second = $this->actingAs($user)->post("/billing/subscriptions/{$subscription->getKey()}/tokens", ['name' => 'Laptop']);
+        $second->assertSessionHas('plainToken');
+
+        // The cap is two; the third is refused with an explanation.
+        $third = $this->actingAs($user)->post("/billing/subscriptions/{$subscription->getKey()}/tokens", ['name' => 'One too many']);
+        $third->assertSessionMissing('plainToken')->assertSessionHas('status');
+
+        $this->assertSame(2, $subscription->tokens()->count());
+    }
+
+    public function test_nobody_can_mint_or_revoke_on_somebody_elses_subscription(): void
+    {
+        [, , $subscription] = $this->customer();
+        $token = app(SubscriptionTokens::class)->issueFor($subscription, 'theirs');
+
+        $stranger = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($stranger)
+            ->post("/billing/subscriptions/{$subscription->getKey()}/tokens", ['name' => 'sneaky'])
+            ->assertForbidden();
+
+        $this->actingAs($stranger)
+            ->delete("/billing/tokens/{$token->token->getKey()}")
+            ->assertForbidden();
+
+        $this->assertNotNull(Token::findByPlainText($token->plainText));
+    }
+
+    public function test_a_lapsed_subscription_stops_minting(): void
+    {
+        [$user, , $subscription] = $this->customer();
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Canceled])->save();
+
+        $this->actingAs($user)
+            ->post("/billing/subscriptions/{$subscription->getKey()}/tokens", ['name' => 'CI'])
+            ->assertForbidden();
+    }
+
+    public function test_revoking_ones_own_token_works_and_frees_the_seat(): void
+    {
+        [$user, , $subscription] = $this->customer();
+        $token = app(SubscriptionTokens::class)->issueFor($subscription, 'CI');
+
+        $this->actingAs($user)
+            ->delete("/billing/tokens/{$token->token->getKey()}")
+            ->assertRedirect();
+
+        $this->assertNull(Token::findByPlainText($token->plainText));
+        $this->assertSame(0, $subscription->tokens()->count());
+    }
+
+    public function test_a_manual_customer_is_told_there_is_no_portal(): void
+    {
+        [$user] = $this->customer();
+
+        $this->actingAs($user)->get('/billing/portal')
+            ->assertRedirect(route('billing.index'))
+            ->assertSessionHas('status');
+    }
+}

--- a/tests/Feature/MerchantWebhookTest.php
+++ b/tests/Feature/MerchantWebhookTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\BillingModel;
+use App\Enums\LapseBehaviour;
+use App\Enums\SubscriptionStatus;
+use App\Jobs\ProcessMerchantEvent;
+use App\Models\BillingCustomer;
+use App\Models\Invoice;
+use App\Models\MerchantEvent;
+use App\Models\MerchantReference;
+use App\Models\Package;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Repository;
+use App\Models\Subscription;
+use App\Models\User;
+use App\Services\Billing\EntitlementProjector;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Testing\TestResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+/**
+ * The merchant webhook inbox: verify against the raw body, record before
+ * acknowledging, act from the queue, and treat every redelivery as a no-op.
+ *
+ * Stripe's signature scheme is an HMAC this test can compute for itself, so
+ * the verification path exercised here is the real driver's — nothing is
+ * faked between the HTTP request and the row in merchant_events.
+ */
+class MerchantWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SECRET = 'whsec_test_secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'registry.billing.enabled' => true,
+            'services.stripe.secret' => 'sk_test_fake',
+            'services.stripe.webhook_secret' => self::SECRET,
+        ]);
+    }
+
+    /**
+     * A delivery signed the way Stripe signs: v1 = HMAC-SHA256("{t}.{body}").
+     *
+     * @param  array<string, mixed>  $event
+     * @return TestResponse<Response>
+     */
+    private function deliver(array $event, ?string $secret = null): TestResponse
+    {
+        $body = (string) json_encode($event);
+        $timestamp = time();
+        $signature = hash_hmac('sha256', "{$timestamp}.{$body}", $secret ?? self::SECRET);
+
+        return $this->call(
+            'POST',
+            '/billing/stripe/webhook',
+            server: [
+                'HTTP_STRIPE_SIGNATURE' => "t={$timestamp},v1={$signature}",
+                'CONTENT_TYPE' => 'application/json',
+            ],
+            content: $body,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $object
+     * @return array<string, mixed>
+     */
+    private function event(string $id, string $type, array $object): array
+    {
+        return [
+            'id' => $id,
+            'object' => 'event',
+            'type' => $type,
+            'created' => time(),
+            'data' => ['object' => $object],
+        ];
+    }
+
+    public function test_an_unsigned_delivery_is_refused_and_records_nothing(): void
+    {
+        $this->post('/billing/stripe/webhook', [], ['Content-Type' => 'application/json'])
+            ->assertStatus(400);
+
+        $this->assertDatabaseCount('merchant_events', 0);
+    }
+
+    public function test_a_delivery_signed_with_the_wrong_secret_is_refused(): void
+    {
+        $this->deliver(
+            $this->event('evt_1', 'invoice.paid', ['id' => 'in_1']),
+            secret: 'whsec_not_ours',
+        )->assertStatus(400);
+
+        $this->assertDatabaseCount('merchant_events', 0);
+    }
+
+    public function test_a_verified_delivery_is_recorded_and_queued(): void
+    {
+        Queue::fake();
+
+        $this->deliver($this->event('evt_1', 'invoice.paid', ['id' => 'in_1', 'customer' => 'cus_x']))
+            ->assertNoContent();
+
+        $this->assertDatabaseHas('merchant_events', [
+            'external_id' => 'evt_1',
+            'type' => 'invoice.paid',
+        ]);
+
+        Queue::assertPushed(ProcessMerchantEvent::class, 1);
+    }
+
+    public function test_a_redelivery_is_acknowledged_without_being_processed_twice(): void
+    {
+        Queue::fake();
+
+        $event = $this->event('evt_dup', 'invoice.paid', ['id' => 'in_1', 'customer' => 'cus_x']);
+
+        $this->deliver($event)->assertNoContent();
+        $this->deliver($event)->assertNoContent();
+
+        $this->assertSame(1, MerchantEvent::query()->where('external_id', 'evt_dup')->count());
+        Queue::assertPushed(ProcessMerchantEvent::class, 1);
+    }
+
+    public function test_an_event_nobody_acts_on_is_verified_and_not_recorded(): void
+    {
+        Queue::fake();
+
+        $this->deliver($this->event('evt_noise', 'customer.updated', ['id' => 'cus_x']))
+            ->assertNoContent();
+
+        $this->assertDatabaseCount('merchant_events', 0);
+        Queue::assertNothingPushed();
+    }
+
+    public function test_webhooks_disabled_while_billing_is_off(): void
+    {
+        config(['registry.billing.enabled' => false]);
+
+        $this->deliver($this->event('evt_1', 'invoice.paid', ['id' => 'in_1']))
+            ->assertNotFound();
+    }
+
+    public function test_a_one_time_checkout_completes_into_a_frozen_style_subscription(): void
+    {
+        // Queue runs inline (sync) in tests, so the completion webhook does
+        // the whole job: subscription row, projection, session reference.
+        $repository = Repository::factory()->create(['path' => 'paid', 'public' => false]);
+        $package = Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $repository->id]);
+
+        $plan = Plan::factory()->perpetual()->create();
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $package->getKey(),
+        ]);
+        $price = PlanPrice::factory()->oneTime()->create(['plan_id' => $plan->getKey()]);
+
+        $user = User::factory()->create();
+        $customer = BillingCustomer::factory()->stripe()->create([
+            'billable_type' => $user->getMorphClass(),
+            'billable_id' => $user->getKey(),
+        ]);
+
+        $this->deliver($this->event('evt_checkout', 'checkout.session.completed', [
+            'id' => 'cs_test_1',
+            'customer' => $customer->merchant_customer_id,
+            'subscription' => null,
+            'metadata' => [
+                'billing_customer_id' => (string) $customer->getKey(),
+                'plan_id' => (string) $plan->getKey(),
+                'plan_price_id' => (string) $price->getKey(),
+            ],
+        ]))->assertNoContent();
+
+        $subscription = Subscription::query()->sole();
+
+        $this->assertSame(SubscriptionStatus::Active, $subscription->status);
+        $this->assertNotNull($subscription->current_period_end);
+
+        // The purchase granted the package.
+        $this->assertTrue(
+            Package::query()->visibleToUser($user->fresh())->whereKey($package->getKey())->exists(),
+        );
+
+        // The session id is remembered, which is all the welcome page holds.
+        $this->assertTrue(
+            MerchantReference::resolve($subscription->merchant, 'cs_test_1')?->is($subscription) ?? false,
+        );
+
+        // The welcome page mints and shows the activation token, exactly once.
+        $first = $this->actingAs($user)->get('/billing/welcome?session=cs_test_1');
+        $first->assertOk()->assertSee('pp_');
+
+        $this->actingAs($user)->get('/billing/welcome?session=cs_test_1')
+            ->assertOk()->assertDontSee('pp_');
+    }
+
+    public function test_a_full_refund_withdraws_access_immediately(): void
+    {
+        [$user, $package, $subscription, $customer] = $this->activeSubscription();
+
+        $invoice = Invoice::factory()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'subscription_id' => $subscription->getKey(),
+            'subtotal' => 1000,
+            'total' => 1000,
+        ]);
+        MerchantReference::remember($invoice, $invoice->merchant, 'in_refund');
+
+        $this->deliver($this->event('evt_refund', 'charge.refunded', [
+            'id' => 'ch_1',
+            'invoice' => 'in_refund',
+            'customer' => $customer->merchant_customer_id,
+            'amount_refunded' => 1000,
+        ]))->assertNoContent();
+
+        $this->assertSame(SubscriptionStatus::Canceled, $subscription->fresh()->status);
+        $this->assertFalse(
+            Package::query()->visibleToUser($user->fresh())->whereKey($package->getKey())->exists(),
+        );
+    }
+
+    public function test_a_dispute_suspends_every_subscription_of_the_customer(): void
+    {
+        [$user, $package, $subscription, $customer] = $this->activeSubscription();
+
+        $this->deliver($this->event('evt_dispute', 'charge.dispute.created', [
+            'id' => 'dp_1',
+            'charge' => 'ch_1',
+            'customer' => $customer->merchant_customer_id,
+        ]))->assertNoContent();
+
+        $this->assertNotNull($subscription->fresh()->suspended_at);
+        $this->assertFalse(
+            Package::query()->visibleToUser($user->fresh())->whereKey($package->getKey())->exists(),
+        );
+    }
+
+    /**
+     * @return array{0: User, 1: Package, 2: Subscription, 3: BillingCustomer}
+     */
+    private function activeSubscription(): array
+    {
+        $repository = Repository::factory()->create(['path' => 'paid', 'public' => false]);
+        $package = Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $repository->id]);
+
+        $plan = Plan::factory()->create(['lapse_behaviour' => LapseBehaviour::WithdrawEntitlement, 'billing_model' => BillingModel::Recurring]);
+        $plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $package->getKey(),
+        ]);
+
+        $user = User::factory()->create();
+        $customer = BillingCustomer::factory()->stripe()->create([
+            'billable_type' => $user->getMorphClass(),
+            'billable_id' => $user->getKey(),
+        ]);
+
+        $subscription = Subscription::factory()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'plan_id' => $plan->getKey(),
+            'plan_price_id' => PlanPrice::factory()->create(['plan_id' => $plan->getKey()])->getKey(),
+        ]);
+
+        (new EntitlementProjector)->project($subscription);
+
+        $this->assertTrue(
+            Package::query()->visibleToUser($user->fresh())->whereKey($package->getKey())->exists(),
+        );
+
+        return [$user, $package, $subscription, $customer];
+    }
+}

--- a/tests/Feature/MerchantWebhookTest.php
+++ b/tests/Feature/MerchantWebhookTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Enums\BillingModel;
 use App\Enums\LapseBehaviour;
+use App\Enums\MerchantProvider;
 use App\Enums\SubscriptionStatus;
 use App\Jobs\ProcessMerchantEvent;
 use App\Models\BillingCustomer;
@@ -203,6 +204,29 @@ class MerchantWebhookTest extends TestCase
 
         $this->actingAs($user)->get('/billing/welcome?session=cs_test_1')
             ->assertOk()->assertDontSee('pp_');
+    }
+
+    public function test_the_welcome_page_finds_a_subscription_checkout_through_the_recorded_event(): void
+    {
+        [$user, , $subscription] = $this->activeSubscription();
+
+        // What checkoutCompleted leaves behind for a subscription checkout:
+        // the one reference slot holds the subscription id every webhook
+        // resolves by, and the session id lives only in the recorded event.
+        $subscription->forceFill(['merchant' => MerchantProvider::Stripe])->save();
+        MerchantReference::remember($subscription, MerchantProvider::Stripe, 'sub_welcome');
+
+        MerchantEvent::create([
+            'merchant' => MerchantProvider::Stripe,
+            'external_id' => 'evt_welcome',
+            'type' => 'checkout.session.completed',
+            'payload' => ['id' => 'cs_welcome', 'subscription' => 'sub_welcome'],
+            'received_at' => now(),
+        ]);
+
+        $this->actingAs($user)->get('/billing/welcome?session=cs_welcome')
+            ->assertOk()
+            ->assertSee('pp_');
     }
 
     public function test_a_full_refund_withdraws_access_immediately(): void

--- a/tests/Feature/PublicSignupTest.php
+++ b/tests/Feature/PublicSignupTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Plan;
+use App\Models\User;
+use App\Notifications\Billing\VerifyBillingEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+/**
+ * Self-serve signup: exists only while switched on, creates accounts that
+ * cannot reach /admin, and requires a verified address before checkout.
+ */
+class PublicSignupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'registry.billing.enabled' => true,
+            'registry.billing.public_signup' => true,
+        ]);
+    }
+
+    public function test_signup_is_a_404_until_switched_on(): void
+    {
+        config(['registry.billing.public_signup' => false]);
+
+        $this->get('/register')->assertNotFound();
+        $this->post('/register', [])->assertNotFound();
+    }
+
+    public function test_registration_creates_a_roleless_account_that_cannot_reach_the_panel(): void
+    {
+        Notification::fake();
+
+        $this->post('/register', [
+            'name' => 'Buyer',
+            'email' => 'buyer@example.com',
+            'password' => 'a-long-enough-password',
+            'password_confirmation' => 'a-long-enough-password',
+        ])->assertRedirect(route('billing.index'));
+
+        $user = User::query()->where('email', 'buyer@example.com')->sole();
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertFalse($user->canAccessPanel(filament()->getDefaultPanel()));
+        Notification::assertSentTo($user, VerifyBillingEmail::class);
+
+        // Signed in, but the panel's front door stays shut.
+        $this->get('/admin')->assertForbidden();
+    }
+
+    public function test_the_honeypot_swallows_bots_without_creating_anything(): void
+    {
+        $this->post('/register', [
+            'name' => 'Bot',
+            'email' => 'bot@example.com',
+            'password' => 'a-long-enough-password',
+            'password_confirmation' => 'a-long-enough-password',
+            'website' => 'https://spam.example',
+        ])->assertRedirect(route('billing.index'));
+
+        $this->assertDatabaseMissing('users', ['email' => 'bot@example.com']);
+    }
+
+    public function test_the_signed_link_verifies_the_address(): void
+    {
+        Notification::fake();
+
+        $this->post('/register', [
+            'name' => 'Buyer',
+            'email' => 'buyer@example.com',
+            'password' => 'a-long-enough-password',
+            'password_confirmation' => 'a-long-enough-password',
+        ]);
+
+        $user = User::query()->where('email', 'buyer@example.com')->sole();
+        $this->assertNull($user->email_verified_at);
+
+        $url = URL::temporarySignedRoute('billing.verify', now()->addDay(), ['user' => $user->getKey()]);
+
+        $this->get($url)->assertRedirect(route('billing.index'));
+        $this->assertNotNull($user->fresh()->email_verified_at);
+
+        // A tampered link verifies nothing.
+        $other = User::factory()->create(['email_verified_at' => null]);
+        $this->get(str_replace("/billing/verify/{$user->getKey()}", "/billing/verify/{$other->getKey()}", $url))->assertForbidden();
+        $this->assertNull($other->fresh()->email_verified_at);
+    }
+
+    public function test_the_customer_area_requires_signing_in(): void
+    {
+        $this->get('/billing')->assertRedirect();
+    }
+
+    public function test_the_pricing_page_lists_only_listed_plans(): void
+    {
+        Plan::factory()->listed()->create(['name' => 'Advertised']);
+        $unlisted = Plan::factory()->create(['name' => 'Negotiated']);
+
+        $this->get('/pricing')
+            ->assertOk()
+            ->assertSee('Advertised')
+            ->assertDontSee('Negotiated');
+
+        // Unlisted is still reachable by direct link, 404 only when inactive.
+        $this->get("/pricing/{$unlisted->slug}")->assertOk();
+
+        $unlisted->forceFill(['active' => false])->save();
+        $this->get("/pricing/{$unlisted->slug}")->assertNotFound();
+    }
+
+    public function test_the_whole_public_surface_is_a_404_while_billing_is_off(): void
+    {
+        config(['registry.billing.enabled' => false]);
+
+        $plan = Plan::factory()->listed()->create();
+
+        $this->get('/pricing')->assertNotFound();
+        $this->get("/pricing/{$plan->slug}")->assertNotFound();
+        $this->actingAs(User::factory()->create())->get('/billing')->assertNotFound();
+    }
+}

--- a/tests/Feature/SubscriptionLifecycleTest.php
+++ b/tests/Feature/SubscriptionLifecycleTest.php
@@ -11,9 +11,11 @@ use App\Models\PlanPrice;
 use App\Models\Repository;
 use App\Models\Subscription;
 use App\Models\User;
+use App\Notifications\Billing\SubscriptionLapsed;
 use App\Services\Billing\SubscriptionProjector;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 /**
@@ -158,5 +160,23 @@ class SubscriptionLifecycleTest extends TestCase
 
         $this->assertNull($subscription->fresh()->grace_ends_at);
         $this->assertFalse($this->reach($user));
+    }
+
+    public function test_the_grace_end_sweep_sends_the_lapse_notice_exactly_once(): void
+    {
+        config(['registry.billing.enabled' => true]);
+        Notification::fake();
+
+        [$subscription] = $this->subscription();
+        $subscription->forceFill([
+            'status' => SubscriptionStatus::PastDue,
+            'grace_ends_at' => now()->subHour(),
+        ])->save();
+
+        $this->artisan('billing:reconcile')->assertSuccessful();
+        $this->artisan('billing:reconcile')->assertSuccessful();
+
+        Notification::assertSentTimes(SubscriptionLapsed::class, 1);
+        $this->assertNotNull($subscription->fresh()->grace_notified_at);
     }
 }

--- a/tests/Feature/SubscriptionLifecycleTest.php
+++ b/tests/Feature/SubscriptionLifecycleTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\SubscriptionStatus;
+use App\Merchants\Values\RemoteSubscription;
+use App\Models\BillingCustomer;
+use App\Models\Package;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Repository;
+use App\Models\Subscription;
+use App\Models\User;
+use App\Services\Billing\SubscriptionProjector;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * SubscriptionProjector: the one translation of merchant truth into the
+ * local row, and the guards that make webhook disorder harmless.
+ *
+ * @see SubscriptionProjector
+ */
+class SubscriptionLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Package $package;
+
+    private Plan $plan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $repository = Repository::factory()->create(['path' => 'paid', 'public' => false]);
+        $this->package = Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $repository->id]);
+
+        $this->plan = Plan::factory()->create();
+        $this->plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->package->getKey(),
+        ]);
+    }
+
+    /**
+     * @return array{0: Subscription, 1: User}
+     */
+    private function subscription(): array
+    {
+        $user = User::factory()->create();
+        $customer = BillingCustomer::factory()->create([
+            'billable_type' => $user->getMorphClass(),
+            'billable_id' => $user->getKey(),
+        ]);
+
+        $subscription = Subscription::factory()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'plan_id' => $this->plan->getKey(),
+            'plan_price_id' => PlanPrice::factory()->create(['plan_id' => $this->plan->getKey()])->getKey(),
+            'status' => SubscriptionStatus::Incomplete,
+        ]);
+
+        return [$subscription, $user];
+    }
+
+    private function remote(SubscriptionStatus $status, CarbonImmutable $asOf): RemoteSubscription
+    {
+        return new RemoteSubscription(
+            externalId: 'sub_x',
+            customerExternalId: 'cus_x',
+            status: $status,
+            priceExternalId: 'price_x',
+            quantity: 1,
+            trialEndsAt: null,
+            currentPeriodStart: $asOf,
+            currentPeriodEnd: $asOf->addMonth(),
+            cancelAt: null,
+            canceledAt: null,
+            endedAt: null,
+            couponCode: null,
+            asOf: $asOf,
+        );
+    }
+
+    private function reach(User $user): bool
+    {
+        return Package::query()->visibleToUser($user->fresh())->whereKey($this->package->getKey())->exists();
+    }
+
+    public function test_applying_merchant_truth_moves_the_row_and_the_grants(): void
+    {
+        [$subscription, $user] = $this->subscription();
+        $projector = app(SubscriptionProjector::class);
+
+        $projector->apply($subscription, $this->remote(SubscriptionStatus::Active, CarbonImmutable::now()));
+
+        $this->assertSame(SubscriptionStatus::Active, $subscription->fresh()->status);
+        $this->assertTrue($this->reach($user));
+    }
+
+    public function test_a_stale_event_cannot_roll_a_newer_truth_back(): void
+    {
+        [$subscription, $user] = $this->subscription();
+        $projector = app(SubscriptionProjector::class);
+
+        $now = CarbonImmutable::now();
+
+        // The cancellation arrives first (it was sent second)...
+        $projector->apply($subscription, $this->remote(SubscriptionStatus::Canceled, $now));
+        $this->assertFalse($this->reach($user));
+
+        // ...and the delayed "it became active" from a minute earlier must
+        // not resurrect access.
+        $projector->apply($subscription->fresh(), $this->remote(SubscriptionStatus::Active, $now->subMinute()));
+
+        $this->assertSame(SubscriptionStatus::Canceled, $subscription->fresh()->status);
+        $this->assertFalse($this->reach($user));
+    }
+
+    public function test_a_money_lapse_starts_the_plans_grace_clock_exactly_once(): void
+    {
+        $this->plan->forceFill(['grace_days' => 14])->save();
+
+        [$subscription, $user] = $this->subscription();
+        $projector = app(SubscriptionProjector::class);
+
+        $now = CarbonImmutable::now();
+        $projector->apply($subscription, $this->remote(SubscriptionStatus::Active, $now));
+
+        // The merchant gives up collecting: grace begins, access continues.
+        $projector->apply($subscription->fresh(), $this->remote(SubscriptionStatus::Unpaid, $now->addMinute()));
+
+        $subscription->refresh();
+        $this->assertNotNull($subscription->grace_ends_at);
+        $firstDeadline = $subscription->grace_ends_at;
+        $this->assertTrue($this->reach($user));
+
+        // A second Unpaid event must not push the deadline out.
+        $this->travel(1)->hours();
+        $projector->apply($subscription->fresh(), $this->remote(SubscriptionStatus::Unpaid, $now->addHours(2)));
+        $this->assertTrue($firstDeadline->equalTo($subscription->fresh()->grace_ends_at));
+
+        // Renewal clears the clock.
+        $projector->apply($subscription->fresh(), $this->remote(SubscriptionStatus::Active, $now->addHours(3)));
+        $this->assertNull($subscription->fresh()->grace_ends_at);
+    }
+
+    public function test_an_incomplete_checkout_earns_no_grace(): void
+    {
+        $this->plan->forceFill(['grace_days' => 14])->save();
+
+        [$subscription, $user] = $this->subscription();
+        $projector = app(SubscriptionProjector::class);
+
+        $projector->apply($subscription, $this->remote(SubscriptionStatus::Incomplete, CarbonImmutable::now()));
+
+        $this->assertNull($subscription->fresh()->grace_ends_at);
+        $this->assertFalse($this->reach($user));
+    }
+}

--- a/tests/Feature/VersionCeilingMetadataTest.php
+++ b/tests/Feature/VersionCeilingMetadataTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\SubscriptionStatus;
+use App\Enums\TokenAbility;
+use App\Models\BillingCustomer;
+use App\Models\Package;
+use App\Models\Plan;
+use App\Models\PlanPrice;
+use App\Models\Repository;
+use App\Models\Subscription;
+use App\Models\Token;
+use App\Models\User;
+use App\Services\Billing\EntitlementProjector;
+use App\Support\VersionNormalizer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * A frozen entitlement's version ceiling, enforced where Composer reads.
+ *
+ * Two promises, and the second matters as much as the first: a ceilinged
+ * client sees only the versions released while their licence was live (and a
+ * distinct validator, so caches cannot cross the streams), and everybody
+ * else's response — body, ETag, cache entry — is byte-identical to what it
+ * was before billing existed.
+ *
+ * @see \App\Services\Billing\VersionCeiling
+ */
+class VersionCeilingMetadataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Repository $paid;
+
+    private Package $widgets;
+
+    private Plan $plan;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paid = Repository::factory()->create(['path' => 'paid', 'public' => false]);
+        $this->widgets = Package::factory()->create(['name' => 'acme/widgets', 'repository_id' => $this->paid->id]);
+
+        foreach (['1.0.0', '1.1.0'] as $version) {
+            $this->makeVersion($version);
+        }
+
+        $this->widgets->versions()->create([
+            'version' => 'dev-main',
+            'reference' => sha1('dev-main'),
+            'is_dev' => true,
+            'metadata' => ['name' => 'acme/widgets', 'version' => 'dev-main'],
+        ]);
+
+        $this->plan = Plan::factory()->perpetual()->create();
+        $this->plan->entitlements()->create([
+            'grantable_type' => Package::class,
+            'grantable_id' => $this->widgets->getKey(),
+        ]);
+    }
+
+    private function makeVersion(string $version): void
+    {
+        // `order` the way the sync path writes it — the metadata filter
+        // reads it, and a row without one sorts outside every ceiling.
+        $this->widgets->versions()->create([
+            'version' => $version,
+            'order' => (new VersionNormalizer)->order($version),
+            'reference' => sha1($version),
+            'is_dev' => false,
+            'metadata' => ['name' => 'acme/widgets', 'version' => $version],
+        ]);
+    }
+
+    /**
+     * @return array{0: Subscription, 1: string} the subscription and a plain token
+     */
+    private function subscribe(User $user): array
+    {
+        $customer = BillingCustomer::factory()->create([
+            'billable_type' => $user->getMorphClass(),
+            'billable_id' => $user->getKey(),
+        ]);
+
+        $subscription = Subscription::factory()->create([
+            'billing_customer_id' => $customer->getKey(),
+            'plan_id' => $this->plan->getKey(),
+            'plan_price_id' => PlanPrice::factory()->create(['plan_id' => $this->plan->getKey()])->getKey(),
+        ]);
+
+        (new EntitlementProjector)->project($subscription);
+
+        $token = Token::issue($user, 'test', [TokenAbility::RepositoryRead]);
+
+        return [$subscription, $token->plainText];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function versionsSeen(string $plainToken): array
+    {
+        $packages = $this->withBasicAuth('token', $plainToken)
+            ->getJson('/r/paid/p2/acme/widgets.json')
+            ->assertOk()
+            ->json('packages.acme/widgets');
+
+        return array_column($packages, 'version');
+    }
+
+    public function test_a_live_subscription_sees_every_version(): void
+    {
+        [, $plain] = $this->subscribe(User::factory()->create());
+
+        $this->assertSame(['1.1.0', '1.0.0'], $this->versionsSeen($plain));
+    }
+
+    public function test_a_frozen_licence_sees_only_what_existed_at_the_freeze(): void
+    {
+        [$subscription, $plain] = $this->subscribe(User::factory()->create());
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        (new EntitlementProjector)->project($subscription);
+
+        // Released after the freeze: outside the ceiling.
+        $this->makeVersion('2.0.0');
+
+        $this->assertSame(['1.1.0', '1.0.0'], $this->versionsSeen($plain));
+
+        // The dev flavour empties out entirely — branches track the ongoing
+        // work the licence stopped paying for.
+        $dev = $this->withBasicAuth('token', $plain)
+            ->getJson('/r/paid/p2/acme/widgets~dev.json')
+            ->assertOk()
+            ->json('packages.acme/widgets');
+
+        $this->assertSame([], $dev);
+    }
+
+    public function test_the_ceiling_guards_the_dist_download_too(): void
+    {
+        [$subscription, $plain] = $this->subscribe(User::factory()->create());
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        (new EntitlementProjector)->project($subscription);
+
+        $this->makeVersion('2.0.0');
+
+        $this->withBasicAuth('token', $plain)
+            ->get('/r/paid/dist/acme/widgets/'.sha1('2.0.0').'.zip')
+            ->assertForbidden();
+    }
+
+    public function test_ceilinged_and_uncapped_clients_get_distinct_validators(): void
+    {
+        [$frozen, $frozenPlain] = $this->subscribe(User::factory()->create());
+        [, $livePlain] = $this->subscribe(User::factory()->create());
+
+        $frozen->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        (new EntitlementProjector)->project($frozen);
+
+        $this->makeVersion('2.0.0');
+
+        $frozenEtag = $this->withBasicAuth('token', $frozenPlain)
+            ->getJson('/r/paid/p2/acme/widgets.json')->assertOk()->headers->get('ETag');
+        $liveEtag = $this->withBasicAuth('token', $livePlain)
+            ->getJson('/r/paid/p2/acme/widgets.json')->assertOk()->headers->get('ETag');
+
+        $this->assertNotSame($frozenEtag, $liveEtag);
+    }
+
+    public function test_a_manual_grant_on_the_same_package_lifts_the_ceiling(): void
+    {
+        $user = User::factory()->create();
+        [$subscription, $plain] = $this->subscribe($user);
+
+        $subscription->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        (new EntitlementProjector)->project($subscription);
+
+        $this->makeVersion('2.0.0');
+        $this->assertSame(['1.1.0', '1.0.0'], $this->versionsSeen($plain));
+
+        // An administrator grants the package by hand: the wider path wins.
+        $user->packages()->attach($this->widgets);
+        $this->assertSame(['2.0.0', '1.1.0', '1.0.0'], $this->versionsSeen($plain));
+    }
+
+    public function test_an_uncapped_readers_response_is_untouched_by_billing_existing(): void
+    {
+        // The manually-granted reader everyone was before billing.
+        $reader = User::factory()->create();
+        $reader->packages()->attach($this->widgets);
+        $readerToken = Token::issue($reader, 'reader', [TokenAbility::RepositoryRead]);
+
+        $before = $this->withBasicAuth('token', $readerToken->plainText)
+            ->getJson('/r/paid/p2/acme/widgets.json')->assertOk();
+
+        // A frozen licence appears in the world; the reader's document and
+        // validator must not move.
+        [$frozen] = $this->subscribe(User::factory()->create());
+        $frozen->forceFill(['status' => SubscriptionStatus::Expired])->save();
+        (new EntitlementProjector)->project($frozen);
+
+        $after = $this->withBasicAuth('token', $readerToken->plainText)
+            ->getJson('/r/paid/p2/acme/widgets.json')->assertOk();
+
+        $this->assertSame($before->headers->get('ETag'), $after->headers->get('ETag'));
+        $this->assertSame($before->getContent(), $after->getContent());
+    }
+}

--- a/tests/Feature/VersionCeilingMetadataTest.php
+++ b/tests/Feature/VersionCeilingMetadataTest.php
@@ -13,6 +13,7 @@ use App\Models\Subscription;
 use App\Models\Token;
 use App\Models\User;
 use App\Services\Billing\EntitlementProjector;
+use App\Services\Billing\VersionCeiling;
 use App\Support\VersionNormalizer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -26,7 +27,7 @@ use Tests\TestCase;
  * else's response — body, ETag, cache entry — is byte-identical to what it
  * was before billing existed.
  *
- * @see \App\Services\Billing\VersionCeiling
+ * @see VersionCeiling
  */
 class VersionCeilingMetadataTest extends TestCase
 {


### PR DESCRIPTION
This pull request introduces the foundation for a comprehensive billing and subscription system, including support for multiple merchant providers (such as Stripe), subscription reconciliation, and fine-grained control over access grants and plan behaviors. It adds new enums to model billing concepts, console commands to manage billing state and plan synchronization, and documentation updates to guide usage and extension.

**Billing and Subscription System Foundation**

* New billing configuration options are added to `.env.example`, supporting merchant selection (e.g., Stripe), currency, terms URL, and Stripe-specific secrets and tax settings.
* Two new console commands are introduced:
  * [`ReconcileBilling`](diffhunk://#diff-9e0816e90c93d992ed1bd75d79369a88de7a17cb4d8710ab656f99f66b33601bR1-R181): Ensures subscription state is consistent by re-pulling merchant-billed subscriptions, crossing local billing boundaries, and sending trial ending warnings.
  * [`SyncBillingCatalog`](diffhunk://#diff-7e870b75f5260c49540a413cb065dd1d31b1b9dc1149535579b9f97ecd02b565R1-R35): Pushes the local plan catalog to the configured merchant, keeping external pricing in sync.

**Billing Domain Modeling**

* Several new enums are added to model core billing concepts:
  * [`BillingModel`](diffhunk://#diff-81d05fe003711f1c7bb2553c86db07a552440318f43d3ea1023be871fe299719R1-R68): Distinguishes between recurring subscriptions and one-time purchases with updates windows.
  * [`BillingInterval`](diffhunk://#diff-4ab371d95a375b45457f5e6748d5cb650c6e4738e901bfe5d47be47682440a60R1-R36): Represents how often a price charges (monthly, yearly, one-time).
  * [`LapseBehaviour`](diffhunk://#diff-02fc3b8fab094cb166743887485b048a9aa112bc834cb2df214ad4e43d677c4eR1-R89): Defines what happens to access when a subscription lapses (withdraw, revoke tokens, freeze at version, or do nothing).
  * [`CancellationTiming`](diffhunk://#diff-97d48bca1decfb481d5b36c3e59e4e29753ec9a61053455816bc6337624f6a7bR1-R39): Controls whether cancellation is immediate or at period end.
  * [`GrantSource`](diffhunk://#diff-1f003d974503bfbf69f6a17eea4a18c2392aa87ed8ef685478d6014ca116f24cR1-R60): Tracks whether an access grant was given manually or by a subscription, ensuring they do not overwrite each other.

**Documentation Updates**

* New documentation links are added to `README.md` for billing, merchant drivers, and related topics, helping users and developers understand and extend the billing system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches payments (Stripe webhooks, checkout, refunds/disputes), access grants, token issuance, and Composer metadata/dist filtering. Bugs here can leak paid packages, cut off paying customers, or mishandle money.
> 
> **Overview**
> Adds an **opt-in commercial billing layer** (`BILLING_ENABLED`, off by default) so a registry can sell package access. Stripe hosted checkout/portal is the public merchant; administrators can always create **Manual** subscriptions (comps, POs, wire).
> 
> Plans define what is sold: prices, recurring vs one-time-with-updates, lapse behaviour (withdraw, revoke tokens, freeze at version, keep access), grace, cancellation timing, and token limits. Paid access is projected onto the existing grant pivots with a `GrantSource` so subscription grants never overwrite hand grants. Composer `/p2` and dist now apply a **version ceiling** only for frozen entitlements; uncapped callers keep the same cached payload.
> 
> Webhooks verify, persist, then process on the queue; `billing:reconcile` re-pulls merchant state and crosses local clocks (period end, grace, trials). Public pricing, optional `/register`, a customer billing area, and a Filament Commercial group (plans, customers, subscriptions, invoices) land behind the same flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3259eeceddda6b1f67aed97f1d8039440dfa76d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->