### PR TITLE
Fix pivot source migration index ordering

### DIFF
--- a/database/migrations/2026_08_19_000060_add_source_to_grant_pivots.php
+++ b/database/migrations/2026_08_19_000060_add_source_to_grant_pivots.php
@@ -39,29 +39,19 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('package_user', function (Blueprint $table) {
-            $table->string('source', 32)->default('manual');
-            $table->dropUnique(['package_id', 'user_id']);
-            $table->unique(['package_id', 'user_id', 'source']);
-        });
-
-        Schema::table('repository_user', function (Blueprint $table) {
-            $table->string('source', 32)->default('manual');
-            $table->dropUnique(['repository_id', 'user_id']);
-            $table->unique(['repository_id', 'user_id', 'source']);
-        });
-
-        Schema::table('package_team', function (Blueprint $table) {
-            $table->string('source', 32)->default('manual');
-            $table->dropUnique(['package_id', 'team_id']);
-            $table->unique(['package_id', 'team_id', 'source']);
-        });
-
-        Schema::table('repository_team', function (Blueprint $table) {
-            $table->string('source', 32)->default('manual');
-            $table->dropUnique(['repository_id', 'team_id']);
-            $table->unique(['repository_id', 'team_id', 'source']);
-        });
+        // The new unique must exist before the old one is dropped: MySQL backs
+        // the leftmost-column FK with the old index and errors (1553) if no
+        // replacement index covers it. The hasColumn guard makes the migration
+        // rerunnable after a partial failure, since each ALTER auto-commits.
+        foreach ($this->pivots() as $pivot => $cols) {
+            Schema::table($pivot, function (Blueprint $table) use ($pivot, $cols) {
+                if (! Schema::hasColumn($pivot, 'source')) {
+                    $table->string('source', 32)->default('manual');
+                }
+                $table->unique([...$cols, 'source']);
+                $table->dropUnique($cols);
+            });
+        }
     }
 
     /**
@@ -72,32 +62,29 @@ return new class extends Migration
         // Narrowing the unique back would fail on a table where a grant
         // exists under both sources; drop the projector's rows first, which
         // is also the honest meaning of rolling this feature back.
-        foreach (['package_user', 'repository_user', 'package_team', 'repository_team'] as $pivot) {
+        foreach ($this->pivots() as $pivot => $cols) {
             DB::table($pivot)->where('source', 'subscription')->delete();
+
+            // Same FK-backing rule as up(): recreate the narrow unique before
+            // dropping the wide one.
+            Schema::table($pivot, function (Blueprint $table) use ($cols) {
+                $table->unique($cols);
+                $table->dropUnique([...$cols, 'source']);
+                $table->dropColumn('source');
+            });
         }
+    }
 
-        Schema::table('package_user', function (Blueprint $table) {
-            $table->dropUnique(['package_id', 'user_id', 'source']);
-            $table->unique(['package_id', 'user_id']);
-            $table->dropColumn('source');
-        });
-
-        Schema::table('repository_user', function (Blueprint $table) {
-            $table->dropUnique(['repository_id', 'user_id', 'source']);
-            $table->unique(['repository_id', 'user_id']);
-            $table->dropColumn('source');
-        });
-
-        Schema::table('package_team', function (Blueprint $table) {
-            $table->dropUnique(['package_id', 'team_id', 'source']);
-            $table->unique(['package_id', 'team_id']);
-            $table->dropColumn('source');
-        });
-
-        Schema::table('repository_team', function (Blueprint $table) {
-            $table->dropUnique(['repository_id', 'team_id', 'source']);
-            $table->unique(['repository_id', 'team_id']);
-            $table->dropColumn('source');
-        });
+    /**
+     * @return array<string, list<string>>
+     */
+    private function pivots(): array
+    {
+        return [
+            'package_user' => ['package_id', 'user_id'],
+            'repository_user' => ['repository_id', 'user_id'],
+            'package_team' => ['package_id', 'team_id'],
+            'repository_team' => ['repository_id', 'team_id'],
+        ];
     }
 };


### PR DESCRIPTION
Refactors the grant pivot migration to iterate shared pivot metadata instead of duplicating four table blocks, and changes unique-index operations to create replacement indexes before dropping old ones to avoid MySQL FK/index error 1553. It also adds a column-existence guard so `up()` can recover from partial runs, and updates `down()` to mirror the safe index order while removing subscription rows before narrowing uniques.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches unique indexes on access-grant pivot tables and can fail or leave partial schema if still mishandled; `down()` still deletes subscription grant rows. Schema-only, no application grant logic change.
> 
> **Overview**
> Fixes the grant-pivot `source` migration so MySQL no longer hits error 1553 when unique indexes that back FKs are replaced.
> 
> `up()` now creates the widened unique (`…, source`) **before** dropping the old pair unique, and skips adding `source` if the column already exists so a mid-ALTER retry can finish. `down()` uses the same create-then-drop order after deleting `subscription` rows.
> 
> The four pivot tables are driven from a shared `pivots()` map instead of duplicated schema blocks. Grant semantics are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b805526adc11672f6055ca245c4bdb03fc16fa87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->